### PR TITLE
Modbus Board Management CLI

### DIFF
--- a/utils/modbus-cli/.dockerignore
+++ b/utils/modbus-cli/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore node_modules
+node_modules/
+
+# Ignore build output
+dist/
+
+# Ignore logs
+npm-debug.log*
+*.log
+
+# Ignore environment files
+.env
+.env.local
+
+# Ignore IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Ignore OS files
+.DS_Store
+Thumbs.db

--- a/utils/modbus-cli/.gitignore
+++ b/utils/modbus-cli/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db

--- a/utils/modbus-cli/Dockerfile
+++ b/utils/modbus-cli/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:20-alpine
+
+# Install build dependencies
+RUN apk add --no-cache \
+    python3 \
+    make \
+    g++ \
+    linux-headers
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY tsconfig.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY src ./src
+
+# Build TypeScript
+RUN npm run build
+
+# Create a symbolic link for easy execution
+RUN ln -s /app/dist/index.js /usr/local/bin/modbus-cli && \
+    chmod +x /app/dist/index.js
+
+# Default command shows help
+ENTRYPOINT ["node", "/app/dist/index.js"]
+CMD ["--help"]

--- a/utils/modbus-cli/README.md
+++ b/utils/modbus-cli/README.md
@@ -1,0 +1,219 @@
+# Modbus CLI - Waveshare Modbus RTU Relay Configuration Tool
+
+A Docker-based CLI tool for configuring Waveshare Modbus RTU Relay (D) modules via USB.
+
+## ⚠️ Important
+
+**Only connect ONE Modbus relay board to the host at a time when using this tool.**
+
+## Features
+
+- Read current device configuration (slave ID, baudrate, parity, operation modes)
+- Set slave ID (device address)
+- Configure operation mode per channel (Normal, Linkage, Toggle, Edge Trigger)
+- Containerized for consistent environment across different hosts
+- USB passthrough support for direct hardware access
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Waveshare Modbus RTU Relay (D) board connected via USB
+- USB to RS485 adapter (if needed)
+
+## Quick Start
+
+### 1. Build the Docker Image
+
+```bash
+cd utils/modbus-cli
+docker-compose build
+```
+
+### 2. Identify Your USB Device
+
+Find your USB serial device:
+
+```bash
+ls -l /dev/ttyUSB*
+# or
+dmesg | grep tty
+```
+
+If your device is not `/dev/ttyACM0`, update the `docker-compose.yml` file accordingly.
+
+### 3. Usage Examples
+
+#### Read Current Configuration
+
+```bash
+docker-compose run --rm modbus-cli config
+```
+
+With custom port:
+
+```bash
+docker-compose run --rm modbus-cli config -p /dev/ttyUSB1
+```
+
+#### Set Slave ID
+
+Set the device address to 5:
+
+```bash
+docker-compose run --rm modbus-cli set-slave-id 5
+```
+
+**Note:** You must power cycle the device after changing the slave ID.
+
+#### Set Channel Operation Mode
+
+Set channel 1 to Linkage mode:
+
+```bash
+docker-compose run --rm modbus-cli set-mode 1 linkage
+```
+
+Set channel 3 to Toggle mode (with custom slave ID):
+
+```bash
+docker-compose run --rm modbus-cli set-mode 3 toggle -s 5
+```
+
+Available modes:
+- `normal` - Relay controlled by commands only
+- `linkage` - Relay status matches input channel status
+- `toggle` - Relay toggles on input pulse
+- `edge` - Relay changes on input level change
+
+## Commands Reference
+
+### `config`
+
+Read and display the current device configuration.
+
+**Options:**
+- `-p, --port <port>` - Serial port (default: `/dev/ttyACM0`)
+- `-b, --baudrate <baudrate>` - Baudrate (default: `9600`)
+
+**Example:**
+```bash
+docker-compose run --rm modbus-cli config
+```
+
+### `set-slave-id <id>`
+
+Set the slave ID (device address).
+
+**Arguments:**
+- `<id>` - New slave ID (1-255)
+
+**Options:**
+- `-p, --port <port>` - Serial port (default: `/dev/ttyACM0`)
+- `-b, --baudrate <baudrate>` - Baudrate (default: `9600`)
+
+**Example:**
+```bash
+docker-compose run --rm modbus-cli set-slave-id 10
+```
+
+### `set-mode <channel> <mode>`
+
+Set the operation mode for a specific channel.
+
+**Arguments:**
+- `<channel>` - Channel number (1-8)
+- `<mode>` - Operation mode: `normal`, `linkage`, `toggle`, `edge`
+
+**Options:**
+- `-p, --port <port>` - Serial port (default: `/dev/ttyACM0`)
+- `-b, --baudrate <baudrate>` - Baudrate (default: `9600`)
+- `-s, --slave-id <id>` - Slave ID of the device (default: `1`)
+
+**Example:**
+```bash
+docker-compose run --rm modbus-cli set-mode 2 toggle -s 1
+```
+
+## Operation Modes Explained
+
+| Mode | Description |
+|------|-------------|
+| **Normal** | Relay is directly controlled by Modbus commands only |
+| **Linkage** | Relay status automatically matches the corresponding input channel status |
+| **Toggle** | Relay toggles once when the input channel receives a pulse |
+| **Edge Trigger** | Relay status changes once when the input channel level changes |
+
+## Troubleshooting
+
+### Permission Denied Error
+
+If you get a permission error accessing the serial device:
+
+```bash
+# Add your user to the dialout group
+sudo usermod -a -G dialout $USER
+
+# Or run with sudo (less secure)
+sudo docker-compose run --rm modbus-cli config
+```
+
+### Device Not Found
+
+Ensure your USB device is properly connected:
+
+```bash
+ls -l /dev/ttyUSB*
+```
+
+Update `docker-compose.yml` if your device has a different name.
+
+### No Response from Device
+
+- Verify the device is powered
+- Check that only ONE device is connected
+- Verify the baudrate matches your device (default: 9600)
+- Try the broadcast address by setting slave-id to 0
+
+## Hardware Documentation
+
+For detailed hardware specifications and Modbus protocol information, see:
+- [Waveshare Modbus RTU Relay (D) Wiki](https://www.waveshare.com/wiki/Modbus_RTU_Relay_(D))
+
+## Technical Details
+
+- **Communication:** Modbus RTU over RS485
+- **Default Settings:** 9600 baud, 8 data bits, no parity, 1 stop bit
+- **Slave Address Range:** 1-255
+- **Channels:** 8 relay channels with individual mode control
+
+## Development
+
+### Running Without Docker
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Build:
+
+```bash
+npm run build
+```
+
+Run:
+
+```bash
+node dist/index.js config
+```
+
+### Development Mode
+
+```bash
+npm run dev -- config
+```
+
+## License
+
+MIT

--- a/utils/modbus-cli/docker-compose.yml
+++ b/utils/modbus-cli/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  modbus-cli:
+    build: .
+    image: modbus-cli:latest
+    container_name: modbus-cli
+    devices:
+      # Pass through USB serial devices
+      # Note: You may need to adjust this based on your actual device
+      - /dev/ttyACM0:/dev/ttyACM0
+    privileged: true  # Required for device access
+    stdin_open: true
+    tty: true
+    # Override default CMD to run interactive shell
+    # Use: docker-compose run --rm modbus-cli config
+    # Or:  docker-compose run --rm modbus-cli set-slave-id 5

--- a/utils/modbus-cli/package.json
+++ b/utils/modbus-cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "modbus-cli",
+  "version": "1.0.0",
+  "description": "CLI tool to configure Waveshare Modbus RTU Relay boards",
+  "main": "dist/index.js",
+  "bin": {
+    "modbus-cli": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "keywords": ["modbus", "cli", "waveshare", "relay"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^11.1.0",
+    "modbus-serial": "^8.0.15",
+    "chalk": "^4.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.6",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/utils/modbus-cli/src/index.ts
+++ b/utils/modbus-cli/src/index.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { ModbusClient } from './modbus-client';
+import chalk from 'chalk';
+
+const program = new Command();
+
+program
+  .name('modbus-cli')
+  .description('CLI tool to configure Waveshare Modbus RTU Relay boards')
+  .version('1.0.0');
+
+program
+  .command('config')
+  .description('Read current configuration from the board')
+  .option('-p, --port <port>', 'Serial port (e.g., /dev/ttyACM0)', '/dev/ttyACM0')
+  .option('-b, --baudrate <baudrate>', 'Baudrate', '9600')
+  .action(async (options) => {
+    console.log(chalk.yellow('⚠️  Please ensure only ONE board is connected to the host!'));
+    console.log('');
+    
+    const client = new ModbusClient(options.port, parseInt(options.baudrate));
+    
+    try {
+      await client.connect();
+      console.log(chalk.green('✓ Connected to device'));
+      
+      const config = await client.readConfiguration();
+      
+      console.log('');
+      console.log(chalk.bold.cyan('=== Current Configuration ==='));
+      console.log('');
+      console.log(`${chalk.bold('Slave ID:')}          ${config.slaveId} (0x${config.slaveId.toString(16).padStart(2, '0').toUpperCase()})`);
+      console.log(`${chalk.bold('Baudrate:')}          ${config.baudrate}`);
+      console.log(`${chalk.bold('Parity:')}            ${config.parity}`);
+      console.log(`${chalk.bold('Software Version:')}  ${config.version}`);
+      console.log('');
+      console.log(chalk.bold.cyan('=== Operation Modes (by channel) ==='));
+      console.log('');
+      
+      const modeNames = ['Normal', 'Linkage', 'Toggle', 'Edge Trigger'];
+      config.controlModes.forEach((mode, index) => {
+        console.log(`  Channel ${index + 1}: ${modeNames[mode] || 'Unknown'}`);
+      });
+      console.log('');
+      
+      await client.disconnect();
+      console.log(chalk.green('✓ Disconnected'));
+      
+    } catch (error) {
+      console.error(chalk.red(`Error: ${(error as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+program
+  .command('set-slave-id')
+  .description('Set the slave ID (device address)')
+  .argument('<id>', 'New slave ID (1-255)')
+  .option('-p, --port <port>', 'Serial port (e.g., /dev/ttyACM0)', '/dev/ttyACM0')
+  .option('-b, --baudrate <baudrate>', 'Baudrate', '9600')
+  .action(async (id, options) => {
+    console.log(chalk.yellow('⚠️  Please ensure only ONE board is connected to the host!'));
+    console.log('');
+    
+    const slaveId = parseInt(id);
+    
+    if (slaveId < 1 || slaveId > 255) {
+      console.error(chalk.red('Error: Slave ID must be between 1 and 255'));
+      process.exit(1);
+    }
+    
+    const client = new ModbusClient(options.port, parseInt(options.baudrate));
+    
+    try {
+      await client.connect();
+      console.log(chalk.green('✓ Connected to device'));
+      
+      await client.setSlaveId(slaveId);
+      console.log(chalk.green(`✓ Slave ID set to ${slaveId} (0x${slaveId.toString(16).padStart(2, '0').toUpperCase()})`));
+      console.log(chalk.yellow('⚠️  Please power cycle the device for changes to take effect'));
+      
+      await client.disconnect();
+      
+    } catch (error) {
+      console.error(chalk.red(`Error: ${(error as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+program
+  .command('set-mode')
+  .description('Set operation mode for a channel')
+  .argument('<channel>', 'Channel number (1-8)')
+  .argument('<mode>', 'Operation mode: normal, linkage, toggle, edge')
+  .option('-p, --port <port>', 'Serial port (e.g., /dev/ttyACM0)', '/dev/ttyACM0')
+  .option('-b, --baudrate <baudrate>', 'Baudrate', '9600')
+  .option('-s, --slave-id <id>', 'Slave ID of the device', '1')
+  .action(async (channel, mode, options) => {
+    console.log(chalk.yellow('⚠️  Please ensure only ONE board is connected to the host!'));
+    console.log('');
+    
+    const channelNum = parseInt(channel);
+    
+    if (channelNum < 1 || channelNum > 8) {
+      console.error(chalk.red('Error: Channel must be between 1 and 8'));
+      process.exit(1);
+    }
+    
+    const modeMap: { [key: string]: number } = {
+      'normal': 0,
+      'linkage': 1,
+      'toggle': 2,
+      'edge': 3
+    };
+    
+    const modeLower = mode.toLowerCase();
+    if (!(modeLower in modeMap)) {
+      console.error(chalk.red('Error: Mode must be one of: normal, linkage, toggle, edge'));
+      process.exit(1);
+    }
+    
+    const modeValue = modeMap[modeLower];
+    const client = new ModbusClient(options.port, parseInt(options.baudrate), parseInt(options.slaveId));
+    
+    try {
+      await client.connect();
+      console.log(chalk.green('✓ Connected to device'));
+      
+      await client.setChannelMode(channelNum, modeValue);
+      console.log(chalk.green(`✓ Channel ${channelNum} set to ${modeLower} mode`));
+      
+      await client.disconnect();
+      
+    } catch (error) {
+      console.error(chalk.red(`Error: ${(error as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+program.parse(process.argv);

--- a/utils/modbus-cli/src/modbus-client.ts
+++ b/utils/modbus-cli/src/modbus-client.ts
@@ -1,0 +1,150 @@
+import ModbusRTU from 'modbus-serial';
+
+export interface DeviceConfig {
+  slaveId: number;
+  baudrate: number;
+  parity: string;
+  version: string;
+  controlModes: number[];
+}
+
+export class ModbusClient {
+  private client: ModbusRTU;
+  private port: string;
+  private baudrate: number;
+  private slaveId: number;
+
+  constructor(port: string, baudrate: number = 9600, slaveId: number = 1) {
+    this.client = new ModbusRTU();
+    this.port = port;
+    this.baudrate = baudrate;
+    this.slaveId = slaveId;
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connectRTUBuffered(this.port, {
+      baudRate: this.baudrate,
+      dataBits: 8,
+      parity: 'none',
+      stopBits: 1,
+    });
+
+    this.client.setID(this.slaveId);
+    this.client.setTimeout(1000);
+  }
+
+  async disconnect(): Promise<void> {
+    this.client.close(() => {});
+  }
+
+  /**
+   * Read current configuration from the device
+   */
+  async readConfiguration(): Promise<DeviceConfig> {
+    // Use broadcast address to read device address
+    this.client.setID(0);
+    
+    // Read device address (register 0x4000)
+    const addressData = await this.client.readHoldingRegisters(0x4000, 1);
+    const slaveId = addressData.data[0];
+    
+    // Switch to actual device address
+    this.client.setID(slaveId);
+    
+    // Read UART parameters (register 0x2000)
+    const uartData = await this.client.readHoldingRegisters(0x2000, 1);
+    const uartParams = uartData.data[0];
+    const parityMode = (uartParams >> 8) & 0xFF;
+    const baudrateMode = uartParams & 0xFF;
+    
+    const parityMap = ['None', 'Even', 'Odd'];
+    const baudrateMap = [4800, 9600, 19200, 38400, 57600, 115200, 128000, 256000];
+    
+    // Read software version (register 0x8000)
+    this.client.setID(0);
+    const versionData = await this.client.readHoldingRegisters(0x8000, 1);
+    const versionValue = versionData.data[0];
+    const version = `V${(versionValue / 100).toFixed(2)}`;
+    
+    // Read control modes for all 8 channels (registers 0x1000-0x1007)
+    this.client.setID(slaveId);
+    const modesData = await this.client.readHoldingRegisters(0x1000, 8);
+    const controlModes = Array.from(modesData.data);
+    
+    return {
+      slaveId,
+      baudrate: baudrateMap[baudrateMode] || 9600,
+      parity: parityMap[parityMode] || 'None',
+      version,
+      controlModes,
+    };
+  }
+
+  /**
+   * Set the slave ID (device address)
+   * @param newSlaveId New slave ID (1-255)
+   */
+  async setSlaveId(newSlaveId: number): Promise<void> {
+    if (newSlaveId < 1 || newSlaveId > 255) {
+      throw new Error('Slave ID must be between 1 and 255');
+    }
+
+    // Use broadcast address to set device address
+    this.client.setID(0);
+    
+    // Write to register 0x4000
+    await this.client.writeRegister(0x4000, newSlaveId);
+  }
+
+  /**
+   * Set the operation mode for a specific channel
+   * @param channel Channel number (1-8)
+   * @param mode Mode value (0=Normal, 1=Linkage, 2=Toggle, 3=Edge Trigger)
+   */
+  async setChannelMode(channel: number, mode: number): Promise<void> {
+    if (channel < 1 || channel > 8) {
+      throw new Error('Channel must be between 1 and 8');
+    }
+
+    if (mode < 0 || mode > 3) {
+      throw new Error('Mode must be between 0 and 3');
+    }
+
+    // Register address: 0x1000 + (channel - 1)
+    const registerAddress = 0x1000 + (channel - 1);
+    
+    await this.client.writeRegister(registerAddress, mode);
+  }
+
+  /**
+   * Set baudrate for the device
+   * @param baudrate Baudrate value (4800, 9600, 19200, 38400, 57600, 115200, 128000, 256000)
+   * @param parity Parity mode (0=None, 1=Even, 2=Odd)
+   */
+  async setBaudrate(baudrate: number, parity: number = 0): Promise<void> {
+    const baudrateMap: { [key: number]: number } = {
+      4800: 0,
+      9600: 1,
+      19200: 2,
+      38400: 3,
+      57600: 4,
+      115200: 5,
+      128000: 6,
+      256000: 7,
+    };
+
+    if (!(baudrate in baudrateMap)) {
+      throw new Error('Invalid baudrate. Valid values: 4800, 9600, 19200, 38400, 57600, 115200, 128000, 256000');
+    }
+
+    if (parity < 0 || parity > 2) {
+      throw new Error('Parity must be 0 (None), 1 (Even), or 2 (Odd)');
+    }
+
+    // Use broadcast address
+    this.client.setID(0);
+    
+    const value = (parity << 8) | baudrateMap[baudrate];
+    await this.client.writeRegister(0x2000, value);
+  }
+}

--- a/utils/modbus-cli/tsconfig.json
+++ b/utils/modbus-cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Wir hatten da bisher keine richtige Lösung für.
Es ist jetzt ein Tool zum Auslesen der Modbus Config von Waveshare Boards und zum Setzen von slaveID der Boards.

Wir könnten drüber nachdenken, dass mit in das Justfile aufzunehmen.