### PR TITLE
Draft integrated carrier PCB hardware concept

### DIFF
--- a/docs/Bill-of-Materials.md
+++ b/docs/Bill-of-Materials.md
@@ -90,6 +90,11 @@ Recommended variant:
 This is the 3.5 mm terminal variant. It is easier to wire and service than
 direct point-to-point wiring.
 
+For the next hardware simplification step, see the integrated carrier PCB draft:
+
+- [`docs/Hardware-Integration-Concept.md`](Hardware-Integration-Concept.md)
+- [`docs/adr/0018-integrated-carrier-pcb-first.md`](adr/0018-integrated-carrier-pcb-first.md)
+
 Per Modbus board / connection board, this design typically uses:
 
 - 10x 2-pin PCB screw terminal connectors

--- a/docs/Hardware-Integration-Concept.md
+++ b/docs/Hardware-Integration-Concept.md
@@ -1,0 +1,367 @@
+# Open-Locker Hardware Integration Concept
+
+This document explains the current Open-Locker cabinet electronics and drafts a
+practical path toward a simpler PCB-based build.
+
+It is written for builders who do not already know PCB design or electronics.
+Exact connector pinouts must still be verified against the KiCad schematic,
+PCB layout, and the specific lock hardware before manufacturing or wiring a
+cabinet.
+
+## Short Answer
+
+Yes, Open-Locker could eventually use one PCB that contains almost everything.
+For the current project stage, the better next step is an integrated carrier
+PCB: a larger Open-Locker board that holds or connects the proven controller,
+relay/input board, lock connectors, power distribution, protection parts, and
+RS485 wiring in one clearly labeled place.
+
+Recommended path:
+
+1. Keep active controller and relay electronics on proven off-the-shelf boards.
+2. Improve the Open-Locker PCB into a carrier/distribution board around those
+   modules.
+3. Validate one eight-compartment cabinet.
+4. Only consider a fully custom controller PCB after the carrier design is
+   stable and repeated builds show that the extra engineering is worth it.
+
+This recommendation is recorded in
+[`docs/adr/0018-integrated-carrier-pcb-first.md`](adr/0018-integrated-carrier-pcb-first.md).
+
+## What Exists Today
+
+The validated cabinet-side architecture is:
+
+```mermaid
+flowchart LR
+    Backend["Laravel Backend"] -->|MQTT| Client["locker-client"]
+    Client -->|USB / serial| Adapter["USB-RS485 Adapter"]
+    Adapter -->|RS485 / Modbus RTU| Relay["Waveshare Modbus RTU Relay (D)"]
+    Relay -->|relay outputs| Locks["12 V cabinet locks"]
+    Locks -->|feedback switches| Relay
+    Power["12 V PSU"] --> Relay
+    Power --> Buck["12 V to 5 V converter"]
+    Buck --> Client
+```
+
+The repository already contains connection-board KiCad projects under
+[`hardware/`](../hardware/). These boards are not full controllers. They are
+wiring/distribution boards that make the cabinet easier to connect.
+
+The recommended existing board is:
+
+- [`hardware/connection-board-cut-out_3_5`](../hardware/connection-board-cut-out_3_5)
+
+## Beginner Vocabulary
+
+| Term | Meaning in Open-Locker |
+| --- | --- |
+| PCB | A printed circuit board. It replaces loose wires with copper tracks and labeled connectors. |
+| Carrier PCB | A PCB that organizes other modules instead of replacing all of their electronics. |
+| Controller | The computer or microcontroller running the locker client logic. Today this is usually a Raspberry Pi; an ESP board is planned. |
+| Relay | An electrically controlled switch. It briefly powers a lock so the door can open. |
+| Digital input | A signal read by the board. Open-Locker uses it for door or lock feedback. |
+| RS485 | The two-wire electrical bus used for Modbus RTU communication. |
+| Modbus RTU | The protocol used between the locker client and the relay/input board. |
+| Flyback diode | A protection diode across a lock coil. It absorbs the voltage spike when the lock turns off. |
+
+## Current Eight-Compartment Wiring Model
+
+For each compartment, the logical wiring is:
+
+```text
+12 V power
+  |
+  +--> relay channel contact
+          |
+          +--> lock release coil
+                  |
+                  +--> 0 V / GND return
+
+lock feedback switch
+  |
+  +--> digital input channel
+```
+
+Each compartment therefore needs:
+
+- one lock release output path
+- one feedback input path
+- one flyback diode across the lock coil
+- clear labels tying compartment number, relay channel, and digital input
+  channel together
+
+The software uses protocol-facing addresses `0..7`, while humans usually talk
+about compartments `1..8`. The documentation and PCB silkscreen should show
+both where useful, for example `Compartment 1 / Relay 0 / DI 0`.
+
+## Option A: Current Modular Build
+
+This is the safest and most validated option today.
+
+```mermaid
+flowchart TB
+    Pi["Raspberry Pi"] --> Usb["USB-RS485 Adapter"]
+    Usb --> Relay["Waveshare Modbus RTU Relay (D)"]
+    Relay --> Conn["Open-Locker Connection Board"]
+    Conn --> Lock1["Lock + feedback 1"]
+    Conn --> Lock2["Lock + feedback 2"]
+    Conn --> LockN["... up to 8"]
+    Psu["12 V PSU"] --> Relay
+    Psu --> Conn
+    Psu --> Buck["12 V to 5 V converter"]
+    Buck --> Pi
+```
+
+### Benefits
+
+- uses the hardware already supported by the locker-client
+- low custom electronics risk
+- easy to replace a failed module
+- relatively cheap at low quantities
+- easier to debug because each module has a clear job
+
+### Drawbacks
+
+- many separate parts
+- more hand wiring
+- more ways to connect something incorrectly
+- harder for a non-electronics builder to reproduce without a wiring guide
+
+## Option B: Integrated Carrier PCB
+
+This is the recommended next hardware design step.
+
+The carrier PCB does not replace the proven relay/input module. Instead, it
+turns the inside of the cabinet into a labeled, repeatable assembly.
+
+```text
++-------------------------------------------------------------------+
+| Open-Locker Integrated Carrier PCB                                |
+|                                                                   |
+|  [12 V IN] -> [Fuse] -> [Reverse polarity protection] -> 12 V BUS |
+|                                  |                                |
+|                                  +--> [12 V to 5 V module]        |
+|                                                                   |
+|  [Controller area]                                                |
+|    - Raspberry Pi + USB-RS485, or                                 |
+|    - ESP relay/input board profile                                |
+|                                                                   |
+|  [RS485 A/B/GND] ---- [Modbus relay/input board connector]        |
+|                                                                   |
+|  [Compartment 1] [Compartment 2] [Compartment 3] [Compartment 4]  |
+|  [Compartment 5] [Compartment 6] [Compartment 7] [Compartment 8]  |
+|                                                                   |
+|  Each compartment connector:                                      |
+|    - lock coil wiring                                             |
+|    - feedback switch wiring                                       |
+|    - flyback diode                                                |
+|    - clear relay/input labels                                     |
++-------------------------------------------------------------------+
+```
+
+### What the carrier PCB should include
+
+- 12 V input terminal
+- fuse or resettable fuse for cabinet power
+- reverse-polarity protection
+- 12 V distribution to lock channels
+- optional 12 V to 5 V DC-DC converter footprint
+- RS485 A/B/GND terminals and daisy-chain/uplink connector
+- labeled compartment connectors
+- one flyback diode per lock channel
+- test pads for 12 V, 5 V, GND, RS485 A, and RS485 B
+- mounting holes that match the cabinet and selected modules
+- silkscreen labels that explain every connector without needing the schematic
+
+### What should stay off the first carrier PCB
+
+- mains AC power
+- custom relay driver electronics
+- custom microcontroller circuitry
+- battery charging
+- undocumented expansion features
+
+Keeping those out makes the first version easier to review, cheaper to
+prototype, and safer to debug.
+
+## Option C: Fully Custom All-in-One Controller PCB
+
+A fully custom Open-Locker controller PCB could combine:
+
+- microcontroller or Linux compute module
+- Ethernet/Wi-Fi
+- RS485
+- relay drivers or relay modules
+- digital inputs
+- power conversion
+- protection circuitry
+- all lock connectors
+
+This can make sense later, but it is not the best first step.
+
+### Why it is risky now
+
+- Open-Locker would become responsible for more electrical safety decisions.
+- Relay and lock current paths require trace-width, heat, and protection
+  calculations.
+- Firmware, boot recovery, update strategy, and diagnostics become hardware
+  design requirements.
+- A mistake may require a new PCB revision instead of replacing a purchased
+  module.
+- Low-volume cost can be higher once engineering time, failed prototypes,
+  shipping, and rework are counted.
+
+### When it may become worth it
+
+Revisit a fully custom controller PCB when most of these are true:
+
+- the carrier PCB has been validated in multiple cabinets
+- the expected build volume is high enough that module cost matters
+- the electrical requirements are stable
+- a hardware engineer has reviewed relay, power, EMC, and protection design
+- Open-Locker has a manufacturing test plan for every board
+- replacement and field-debugging procedures are clear
+
+## Rough Cost Comparison
+
+Prices change quickly, so treat this as directionally useful rather than as a
+quote.
+
+| Item | Rough reference | Notes |
+| --- | ---: | --- |
+| Waveshare `Modbus RTU Relay (D)` | about USD 35 | Official Waveshare single-unit price seen 2026-06-01. |
+| Waveshare `ESP32-S3-ETH-8DI-8RO` | about USD 50 | Official Waveshare single-unit price seen 2026-06-01. |
+| Simple 2-layer prototype PCB | from about USD 2 / 5 pcs | JLCPCB public prototype headline price for standard small boards; shipping and options are extra. |
+| SMT assembly setup | from about USD 8 | JLCPCB public assembly headline price; components, stencil, loading fees, manual soldering, and shipping are extra. |
+| Screw terminals, fuses, DC-DC module, connectors | varies | Often more important than bare PCB cost for a wiring board. |
+
+Important interpretation:
+
+- Bare PCBs are cheap.
+- Connectors, power parts, assembly, shipping, and mistakes are not free.
+- A custom all-in-one board may reduce parts later, but only after design and
+  validation costs are spread over enough units.
+- For early Open-Locker builds, predefined modules plus a good carrier PCB are
+  usually the best cost/risk balance.
+
+## Step-by-Step Path for Open-Locker
+
+### Step 1: Document one known-good cabinet wiring path
+
+Goal: make the current build understandable without opening KiCad first.
+
+Checklist:
+
+- define wire colors for 12 V, GND, RS485 A, RS485 B, lock coil, and feedback
+- document each connector on the existing connection board
+- map `Compartment 1..8` to relay address `0..7` and digital input `0..7`
+- add photos or drawings after the physical build is stable
+
+### Step 2: Validate the existing connection board
+
+Goal: ensure the current board is the correct base for the next design.
+
+Checklist:
+
+- verify every schematic net against a continuity test
+- verify every connector label against the actual cabinet harness
+- test one lock channel with current-limited 12 V power
+- test all eight digital inputs
+- test RS485 communication through the board
+
+### Step 3: Design the carrier PCB schematic
+
+Goal: turn the wiring guide into a schematic.
+
+Checklist:
+
+- one repeated channel block per compartment
+- one shared power input and protection block
+- one controller power block
+- one RS485 block
+- one relay/input board connection block
+- connector labels matching the documentation
+
+### Step 4: Review before ordering
+
+Goal: catch mistakes before money is spent.
+
+Checklist:
+
+- electrical rules check passes in KiCad
+- PCB design rules check passes in KiCad
+- trace widths are checked for lock current
+- relay contacts are rated for the lock load
+- 12 V and 5 V rails are clearly separated
+- mounting holes and connector clearances match the cabinet
+- an electronics-capable reviewer signs off
+
+### Step 5: Order a small bare-PCB prototype
+
+Goal: test the physical design before paying for assembly.
+
+Recommended first order:
+
+- five bare PCBs
+- hand-solder through-hole connectors
+- populate only the parts needed for one or two channels first
+
+### Step 6: Bench-test safely
+
+Goal: prove the board without risking a full cabinet.
+
+Checklist:
+
+- use a current-limited bench supply if available
+- test 12 V polarity protection
+- test 5 V output before connecting a controller
+- test RS485 communication
+- test one relay and one lock
+- test one digital input
+- repeat for all channels
+
+### Step 7: Cabinet-test one full eight-compartment build
+
+Goal: prove the complete wiring path.
+
+Checklist:
+
+- open every compartment from the backend/mobile flow
+- verify each door feedback state
+- power-cycle the cabinet and verify relays are safe
+- test disconnect/reconnect behavior on RS485
+- document any confusing labels or wiring steps
+
+### Step 8: Decide whether a custom controller is justified
+
+Goal: avoid custom electronics until the benefit is clear.
+
+Ask:
+
+- Did the carrier PCB remove most wiring confusion?
+- Are failed modules easy to replace?
+- Is the module cost now the main cost problem?
+- Are there enough repeated builds to justify engineering effort?
+- Is there a hardware test plan for production boards?
+
+If the answers are mostly no, keep improving the carrier board and docs.
+
+## Recommended Documentation Map
+
+To make the hardware understandable, keep these docs separate:
+
+- `docs/Bill-of-Materials.md`: what to buy
+- `hardware/README.md`: what each PCB project is for
+- this document: how the pieces should evolve into a simpler build
+- future wiring guide: exact connector pinouts, wire colors, and photos
+- ADRs: hardware strategy decisions and why they were made
+
+## Current Recommendation
+
+For Open-Locker now, it is better to have a small, well-documented Open-Locker
+PCB plus predefined components that plug into it.
+
+Do not jump straight to a fully custom all-in-one board. The potential future
+benefit is real, but the risk and validation effort are too high before the
+existing wiring is documented and a carrier PCB has been proven in a cabinet.

--- a/docs/adr/0018-integrated-carrier-pcb-first.md
+++ b/docs/adr/0018-integrated-carrier-pcb-first.md
@@ -1,0 +1,172 @@
+# ADR-0018: Prefer an integrated carrier PCB before a fully custom controller PCB
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-01
+
+## Context
+
+Open-Locker currently has a validated Raspberry Pi based locker controller that
+uses a USB-RS485 adapter and the Waveshare `Modbus RTU Relay (D)` board. The
+repository also contains Open-Locker connection-board KiCad projects that
+simplify field wiring between locks, relay channels, digital inputs, power, and
+RS485.
+
+The current setup works, but it still requires several separate modules and a
+fair amount of wiring knowledge. A fully custom Open-Locker PCB could combine
+these functions into one board, but that would also move Open-Locker into custom
+relay-drive electronics, power electronics, protection design, manufacturing
+test, and field safety responsibility.
+
+## Decision
+
+For the next hardware simplification step, Open-Locker should design and
+validate an integrated carrier PCB instead of a fully custom all-in-one
+controller PCB.
+
+The carrier PCB should keep the proven off-the-shelf controller and I/O boards
+as replaceable modules, while reducing field wiring and making the cabinet build
+repeatable. The recommended first target is:
+
+- 12 V cabinet power input with fuse and reverse-polarity protection
+- 12 V distribution for lock power
+- a 12 V to 5 V controller power module or footprint
+- RS485 A/B/GND distribution and daisy-chain terminals
+- labeled connectors for up to eight locks and eight feedback switches
+- flyback diode placement per lock channel
+- mounting and connector strategy for the supported relay/input board
+- clear silkscreen labels for every field connection
+- test pads or status points for power and RS485 diagnostics
+
+The carrier PCB must preserve the current software/hardware support boundary:
+the supported relay strategy still depends on verified hardware-timed relay
+flash behavior from the Waveshare `Modbus RTU Relay (D)` or a separately
+validated equivalent.
+
+A fully custom all-in-one controller PCB can be reconsidered after the carrier
+board has been validated in a real cabinet and the project has enough build
+volume to justify custom electronics engineering, manufacturing tests, and
+support obligations.
+
+## Rationale
+
+The carrier PCB removes the most visible pain for builders: unclear and
+repetitive field wiring. It does that without replacing the supported relay
+timing behavior, RS485 behavior, and digital-input behavior that Open-Locker has
+already validated in software and documentation.
+
+This keeps the first hardware iteration small enough to review and test. A
+fully custom controller may reduce part count later, but it should not be the
+first simplification step because it changes too many reliability and support
+variables at once.
+
+## Alternatives Considered
+
+### Alternative A: Keep only the existing connection board
+
+- Pros:
+  - lowest engineering risk
+  - already represented in the repository as KiCad projects
+  - keeps all active electronics on purchased modules
+- Cons:
+  - still requires many separate wires and modules
+  - less beginner-friendly during assembly
+  - more cabinet-specific interpretation is needed
+- Why not chosen:
+  - it does not fully address the goal of making hardware assembly easier for
+    non-electronics builders
+
+### Alternative B: Build a fully custom all-in-one Open-Locker controller PCB now
+
+- Pros:
+  - potentially cleanest physical installation
+  - fewer purchased boards and fewer internal cables
+  - could eventually reduce unit cost at higher volume
+- Cons:
+  - highest engineering and validation risk
+  - requires custom relay, input, RS485, power, protection, and firmware design
+  - moves more safety and reliability responsibility onto Open-Locker
+  - low-volume unit cost may be worse once engineering and rework are included
+- Why not chosen:
+  - the current project stage benefits more from repeatability and validation
+    than from maximum integration
+
+### Alternative C: Use the planned ESP relay/input board without a carrier PCB
+
+- Pros:
+  - fewer modules than the Raspberry Pi setup
+  - uses an off-the-shelf board with relays, digital inputs, Ethernet, and RS485
+  - aligns with ADR-0005
+- Cons:
+  - still leaves lock wiring, power distribution, cabinet connectors, and labels
+    to the installer
+  - does not solve the physical documentation gap by itself
+- Why not chosen:
+  - this is a good controller option, but it still needs a repeatable wiring
+    and mounting layer
+
+## Consequences
+
+### Positive
+
+- lowers the wiring and assembly burden without replacing proven electronics
+- keeps the relay/input module replaceable if a board fails or supply changes
+- reduces custom electronics risk for early Open-Locker builds
+- creates a clearer documentation target for pinouts, labels, and cabinet wiring
+- allows the same physical wiring concept to support Raspberry Pi and ESP based
+  controller profiles
+
+### Negative
+
+- still uses multiple boards instead of one fully integrated PCB
+- may not minimize unit cost at high production volume
+- requires another KiCad design iteration and hardware validation cycle
+
+### Risks
+
+- field builders may assume the carrier board makes wiring polarity and power
+  sizing automatic
+- connector labels could become misleading if they are not verified against the
+  schematic, PCB layout, and cabinet harness
+- the carrier PCB could be overdesigned before the current cabinet wiring is
+  fully documented
+
+Mitigations:
+
+- document logical connections first, then exact pinouts after schematic review
+- validate the first board on a bench with current-limited power before using
+  real locks
+- keep high-voltage mains power outside the Open-Locker PCB
+- require an electrical review before ordering assembled prototypes
+
+## Rollout / Migration
+
+- document the existing connection-board projects and their intended use
+- create a hardware integration concept for the carrier PCB
+- derive a schematic from the validated eight-compartment wiring path
+- order a small bare-PCB prototype batch first
+- bench-test power, RS485, relay channels, digital inputs, and one lock channel
+- test a full eight-compartment cabinet
+- update the BOM and ADR status after validation
+
+## Supersedes / Superseded By
+
+- Supersedes: none
+- Superseded by: none
+
+## References
+
+- Related docs:
+  - `docs/Hardware-Integration-Concept.md`
+  - `docs/Bill-of-Materials.md`
+  - `docs/adr/0004-waveshare-hardware-flash-and-supported-boards.md`
+  - `docs/adr/0005-esp-build-controller-board-selection.md`
+  - `hardware/README.md`
+  - `locker-client/docs/WAVESHARE_INTEGRATION.md`
+  - `https://www.waveshare.com/modbus-rtu-relay-d.htm`
+  - `https://www.waveshare.com/esp32-s3-eth-8di-8ro.htm`
+  - `https://jlcpcb.com/`

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,69 @@
+# Open-Locker Hardware Boards
+
+This directory contains Open-Locker PCB and mechanical design files.
+
+The current boards are connection/distribution boards. They simplify cabinet
+wiring, but they do not replace the controller or the supported Modbus
+relay/input board.
+
+For the recommended hardware direction, see:
+
+- [`docs/Hardware-Integration-Concept.md`](../docs/Hardware-Integration-Concept.md)
+- [`docs/adr/0018-integrated-carrier-pcb-first.md`](../docs/adr/0018-integrated-carrier-pcb-first.md)
+- [`docs/Bill-of-Materials.md`](../docs/Bill-of-Materials.md)
+
+## PCB Projects
+
+| Path | Purpose | Notes |
+| --- | --- | --- |
+| [`connection-board-cut-out_3_5`](connection-board-cut-out_3_5) | Recommended connection board for repeatable cabinet wiring. | Uses 3.5 mm screw terminals, which are easier to wire and service in the field. |
+| [`connection-board-cut-out_2_54`](connection-board-cut-out_2_54) | Alternate connection board layout. | Uses smaller connector footprints. Pick only if the cabinet harness and connector pitch match. |
+| [`mtu-connection-board`](mtu-connection-board) | MTU-specific connection board. | Cabinet/form-factor specific variant. |
+| [`mtu-connection-board-large`](mtu-connection-board-large) | Larger MTU-specific connection board. | Cabinet/form-factor specific variant. |
+| [`models`](models) | OpenSCAD mechanical helper parts. | Includes lock spacers and PCB mounting adapters. Export STL files from these sources when needed. |
+
+## What the Connection Board Does
+
+The connection board is intended to make the inside of a locker cabinet easier
+to assemble and debug.
+
+Logical responsibilities:
+
+- route lock wiring for up to eight compartments
+- route feedback switch wiring for up to eight compartments
+- place one flyback diode per lock channel
+- provide labeled connection points between the cabinet harness and the
+  supported relay/input board
+- provide power and RS485 connection points for the cabinet wiring path
+
+The board should be treated as a wiring aid. The active relay timing and digital
+input behavior still come from the supported relay/input hardware and the
+locker-client software.
+
+## Current Supported Relay/Input Board
+
+The validated Modbus relay/input board is:
+
+- Waveshare `Modbus RTU Relay (D)`
+
+Open-Locker currently depends on verified Waveshare hardware flash behavior for
+safe lock release pulses. See:
+
+- [`docs/adr/0004-waveshare-hardware-flash-and-supported-boards.md`](../docs/adr/0004-waveshare-hardware-flash-and-supported-boards.md)
+- [`locker-client/docs/WAVESHARE_INTEGRATION.md`](../locker-client/docs/WAVESHARE_INTEGRATION.md)
+
+## Before Manufacturing or Wiring
+
+Before ordering PCBs or wiring a cabinet:
+
+1. Open the KiCad project for the selected board.
+2. Verify the schematic against the intended lock, relay, power, and RS485
+   wiring.
+3. Verify connector pitch and orientation against the physical connectors.
+4. Confirm trace widths and connector ratings for the lock current.
+5. Label the cabinet harness to match compartment numbers, relay addresses, and
+   digital input addresses.
+6. Bench-test with current-limited 12 V power before connecting all locks.
+
+Exact connector pinouts should be documented in a future wiring guide after the
+selected board revision and cabinet harness are validated.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a beginner-friendly hardware integration concept for Open-Locker cabinet electronics
- Recommend an integrated carrier PCB before a fully custom controller PCB
- Add ADR-0018 to record the hardware strategy decision
- Add a `hardware/README.md` entry point for existing KiCad board projects
- Link the new concept from the BOM

## Verification
- Checked local Markdown links in touched docs with a Python link validation script
- Checked touched docs for newly introduced non-ASCII characters

## ADR
- `docs/adr/0018-integrated-carrier-pcb-first.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f8874e7-d1fc-42f4-b7e5-e3fde4b6ce8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f8874e7-d1fc-42f4-b7e5-e3fde4b6ce8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

