### PR TITLE
refactor(ci): rename backend workflow and verify locker-client on dev

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,4 @@
-# This workflow builds the Docker image and pushes it to GitHub Container Registry (ghcr.io)
+# Builds the backend Docker image and pushes it to GitHub Container Registry (ghcr.io)
 # Requires repository secrets: GHCR_USERNAME, GHCR_TOKEN
 
 name: Backend CI
@@ -10,7 +10,7 @@ on:
       - dev
     paths:
       - "locker-backend/**"
-      - ".github/workflows/docker-ghcr.yml"
+      - ".github/workflows/backend-ci.yml"
   push:
     branches:
       - main
@@ -19,7 +19,7 @@ on:
       - "v*"
     paths:
       - "locker-backend/**"
-      - ".github/workflows/docker-ghcr.yml"
+      - ".github/workflows/backend-ci.yml"
   workflow_dispatch:
 
 jobs:
@@ -60,6 +60,7 @@ jobs:
         run: pnpm audit --audit-level=high
 
       - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -121,5 +122,3 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-

--- a/.github/workflows/build-locker-client.yml
+++ b/.github/workflows/build-locker-client.yml
@@ -24,12 +24,13 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/locker-client-v')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -38,13 +39,13 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/locker-client-v')
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/locker-client
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'pull_request' }}
+            type=sha,prefix={{branch}}-
             type=match,pattern=locker-client-v(.*),group=1
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -54,13 +55,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image (multi-platform)
+      - name: Build Docker image (verify)
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev'
         uses: docker/build-push-action@v5
         with:
           context: ./locker-client
           file: ./locker-client/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Docker image (main)
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./locker-client
+          file: ./locker-client/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Docker image (release tag)
+        if: startsWith(github.ref, 'refs/tags/locker-client-v')
+        uses: docker/build-push-action@v5
+        with:
+          context: ./locker-client
+          file: ./locker-client/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- Rename `docker-ghcr.yml` → `backend-ci.yml` for consistency with other workflow filenames
- Build locker-client on `dev` and PRs without pushing to GHCR (verify-only), matching backend behavior
- Skip GHCR login on PR/dev verify runs for both backend and locker-client

## Test plan
- [ ] Backend CI green on PR (audit + verify build)
- [ ] Build Locker Client green on PR (verify build, no invalid tags / no push)
- [ ] MQTT + mobile-app CI unaffected


Made with [Cursor](https://cursor.com)