### PR TITLE
feat(backend): group-based compartment access (#46, ADR-0020)

### DIFF
--- a/docs/adr/0020-group-based-compartment-access.md
+++ b/docs/adr/0020-group-based-compartment-access.md
@@ -1,0 +1,133 @@
+I have# ADR-0020: Group-based compartment access (event-sourced) with a projected effective-access read model
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-04
+
+## Context
+
+Compartment access today is **per-user only**. `CompartmentAccessAggregate` records
+`CompartmentAccessGranted` / `CompartmentAccessRevoked` events; `CompartmentAccessProjector`
+builds rows in `compartment_accesses`; and both hot paths read only that table:
+
+- `CompartmentAccessService::hasActiveAccess()` — drives open authorization (`requestOpen()`).
+- `CompartmentController::accessible()` — the `GET /api/compartments/accessible` list.
+
+Operationally, access is usually shared by teams/initiatives, so granting each compartment to each
+user individually is high-overhead. We want **groups**: admins put users in groups, grant groups
+access to compartments, and a user's **effective access = direct ∪ group-derived**. The mobile
+API must expose this transparently (no client change).
+
+Constraints:
+- Domain state must stay **event-sourced** (events + projectors), with **actor/audit** parity to
+  the direct-access path.
+- The hot read paths must avoid expensive runtime joins.
+- Auditability (who granted/revoked membership and access, and when) must be preserved.
+
+## Decision
+
+Add groups as a **parallel event-sourced model** (not folded into `users` or `compartment_accesses`)
+and resolve effective access through a **projected read model**.
+
+**Data model (read models, all built by a projector):**
+- `groups` — the group.
+- `group_user` — membership (user ∈ group), with actor + optional `expires_at`.
+- `group_compartment_accesses` — group → compartment grant (parallel to `compartment_accesses`;
+  `compartment_id` is a `foreignUuid`).
+- `user_group_compartment_accesses` — **projected effective table**: the flattened (user ↔ compartment)
+  access derived from `membership × group grants`. Direct access stays in `compartment_accesses`;
+  **effective = the union of the two**, evaluated as one extra indexed lookup (no multi-join).
+
+**Event sourcing:** a single `GroupAggregate` per group (the consistency boundary) records
+`GroupCreated`, `UserAddedToGroup`, `UserRemovedFromGroup`, `GroupCompartmentAccessGranted`,
+`GroupCompartmentAccessRevoked`. A `GroupProjector` maintains all four tables and **recomputes**
+`user_group_compartment_accesses` whenever a membership or group-grant event fires.
+
+**Semantics — additive / union:** a user has access if **any** active source grants it. Revoking one
+source (a direct grant, a group grant, or a membership) removes only that source; other active
+sources still apply. Each source respects its own `revoked_at` / `expires_at` via the existing
+`active()` scope.
+
+**Integration (hot paths):**
+- `hasActiveAccess()` returns true if an active row exists in `compartment_accesses` **or**
+  `user_group_compartment_accesses`; `requestOpen()` records `authorizationType:'group_access'` when
+  the authorizing access is group-derived (keeps `'granted_access'` for direct) for audit clarity.
+- `CompartmentController::accessible()` includes compartments reachable directly **or** via a group;
+  the `AccessibleCompartmentsResource` shape is unchanged (mobile transparent).
+
+**Authorization:** management (create group, membership, group grants) stays **admin-only** for now,
+reusing `CompartmentAccessService::ensureCanManageAccess()`. Manager-role support (#95) is out of scope.
+
+## Rationale
+
+A projected effective table keeps the mobile `accessible` call and open-authorization to a single
+indexed lookup instead of a `user → group_user → group_compartment_accesses` join on every request.
+Additive/union is the least-surprising sharing model and the simplest to reason about and test.
+Mirroring the existing aggregate/projector/`active()`-scope pattern keeps the codebase consistent
+and the new access just as auditable as direct access.
+
+## Alternatives Considered
+
+### Alternative A: Resolve effective access with query-time joins (no projected table)
+
+- Pros: less code; no recompute logic; no derived table to keep consistent.
+- Cons: multi-join on every hot read (`accessible`, open-authorization); cost grows with
+  members/groups.
+- Why not chosen: the read paths are hot and latency-sensitive; the issue explicitly calls out
+  avoiding expensive runtime joins.
+
+### Alternative B: Direct-revoke-overrides (deny-override) semantics
+
+- Pros: supports an explicit "ban this user from compartment X" even if a group would grant it.
+- Cons: more complex precedence rules and edge cases; surprising ("I revoked them but they still
+  have access via a group" vs "their group grant silently does nothing").
+- Why not chosen: no current requirement for deny-override; additive/union is simpler and matches
+  how shared access is expected to work. Can be revisited in a future ADR if banning is needed.
+
+## Consequences
+
+### Positive
+
+- Effective-access reads stay a single indexed lookup; mobile API unchanged.
+- Group membership and group access are fully event-sourced and auditable, like direct access.
+- Clear, predictable union semantics; straightforward test matrix.
+
+### Negative
+
+- The projector must **recompute** `user_group_compartment_accesses` on membership and group-grant
+  changes — an O(members × granted-compartments) write-time cost per change.
+- A second access source means more authorization branches and a larger test surface.
+
+### Risks
+
+- Projection drift if recompute logic is incomplete (e.g. a removed member keeps derived rows).
+  Mitigation: cover the full add/remove × grant/revoke × expiry matrix with feature tests; the table
+  is rebuildable by replaying events.
+- Time-based expiry is enforced at read time via `active()` (not by an event), consistent with the
+  existing direct-access behavior.
+
+## Rollout / Migration
+
+Deliver in reviewable slices after this ADR is accepted:
+1. Domain core — migrations + models + `GroupAggregate` + events + `GroupProjector` + `GroupAccessService`.
+2. Effective-access wiring — `hasActiveAccess()` + `accessible()`; feature-test the union/expiry/revoke matrix.
+3. Filament UI — `GroupResource` + members and compartment-access relation managers (routed through
+   `GroupAccessService`, never direct model writes).
+
+No data migration of existing direct access is required; direct access keeps working unchanged.
+
+## Supersedes / Superseded By
+
+- Supersedes: none
+- Superseded by: none
+
+## References
+
+- Related issues: #46 (builds on the direct-access model; complements #48 navigation, relates to #55)
+- Related code: `app/Aggregates/CompartmentAccessAggregate.php`, `app/Projectors/CompartmentAccessProjector.php`,
+  `app/Services/CompartmentAccessService.php`, `app/Models/CompartmentAccess.php`,
+  `app/Http/Controllers/CompartmentController.php`

--- a/docs/adr/0020-group-based-compartment-access.md
+++ b/docs/adr/0020-group-based-compartment-access.md
@@ -1,8 +1,8 @@
-I have# ADR-0020: Group-based compartment access (event-sourced) with a projected effective-access read model
+# ADR-0020: Group-based compartment access (event-sourced) with a projected effective-access read model
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -41,11 +41,21 @@ and resolve effective access through a **projected read model**.
 - `user_group_compartment_accesses` — **projected effective table**: the flattened (user ↔ compartment)
   access derived from `membership × group grants`. Direct access stays in `compartment_accesses`;
   **effective = the union of the two**, evaluated as one extra indexed lookup (no multi-join).
+  Unique on `(user_id, compartment_id)`; index pattern mirrors `compartment_accesses`. Optional
+  `group_id` column for audit (which group contributed the derived row). Projected `expires_at` =
+  earliest non-null of membership `expires_at` and group grant `expires_at`; enforce expiry at read
+  time via the existing `active()` scope.
 
 **Event sourcing:** a single `GroupAggregate` per group (the consistency boundary) records
 `GroupCreated`, `UserAddedToGroup`, `UserRemovedFromGroup`, `GroupCompartmentAccessGranted`,
 `GroupCompartmentAccessRevoked`. A `GroupProjector` maintains all four tables and **recomputes**
-`user_group_compartment_accesses` whenever a membership or group-grant event fires.
+`user_group_compartment_accesses` whenever a membership or group-grant event fires — scoped to the
+affected group/members only (incremental recompute, not a full-table rebuild). Register
+`GroupProjector` in `config/event-sourcing.php` (Slice 1).
+
+**v1 lifecycle:** groups **cannot be deleted** — no Filament delete action, no `GroupDeleted` event.
+Archiving (event-sourced `GroupArchived`, read-model update, ending effective access) is tracked in
+#106.
 
 **Semantics — additive / union:** a user has access if **any** active source grants it. Revoking one
 source (a direct grant, a group grant, or a membership) removes only that source; other active
@@ -54,10 +64,13 @@ sources still apply. Each source respects its own `revoked_at` / `expires_at` vi
 
 **Integration (hot paths):**
 - `hasActiveAccess()` returns true if an active row exists in `compartment_accesses` **or**
-  `user_group_compartment_accesses`; `requestOpen()` records `authorizationType:'group_access'` when
-  the authorizing access is group-derived (keeps `'granted_access'` for direct) for audit clarity.
+  `user_group_compartment_accesses`.
+- `requestOpen()` sets `authorizationType` by checking direct access first (`'granted_access'`), then
+  group-derived access (`'group_access'`) for audit clarity.
 - `CompartmentController::accessible()` includes compartments reachable directly **or** via a group;
   the `AccessibleCompartmentsResource` shape is unchanged (mobile transparent).
+- `CompartmentStatusBroadcastService::recipientUserIdsForCompartment()` unions direct and
+  group-derived access (Slice 2).
 
 **Authorization:** management (create group, membership, group grants) stays **admin-only** for now,
 reusing `CompartmentAccessService::ensureCanManageAccess()`. Manager-role support (#95) is out of scope.
@@ -99,7 +112,8 @@ and the new access just as auditable as direct access.
 ### Negative
 
 - The projector must **recompute** `user_group_compartment_accesses` on membership and group-grant
-  changes — an O(members × granted-compartments) write-time cost per change.
+  changes — an O(members × granted-compartments) write-time cost per change (scoped per affected
+  group/members, not a full-table rebuild).
 - A second access source means more authorization branches and a larger test surface.
 
 ### Risks
@@ -113,10 +127,13 @@ and the new access just as auditable as direct access.
 ## Rollout / Migration
 
 Deliver in reviewable slices after this ADR is accepted:
-1. Domain core — migrations + models + `GroupAggregate` + events + `GroupProjector` + `GroupAccessService`.
-2. Effective-access wiring — `hasActiveAccess()` + `accessible()`; feature-test the union/expiry/revoke matrix.
+1. Domain core — migrations + models + `GroupAggregate` + events + `GroupProjector` (registered in
+   `config/event-sourcing.php`) + `GroupAccessService`.
+2. Effective-access wiring — `hasActiveAccess()` + `accessible()` +
+   `CompartmentStatusBroadcastService::recipientUserIdsForCompartment()`; feature-test the
+   union/expiry/revoke matrix.
 3. Filament UI — `GroupResource` + members and compartment-access relation managers (routed through
-   `GroupAccessService`, never direct model writes).
+   `GroupAccessService`, never direct model writes); no delete action in the admin UI (v1).
 
 No data migration of existing direct access is required; direct access keeps working unchanged.
 
@@ -127,7 +144,8 @@ No data migration of existing direct access is required; direct access keeps wor
 
 ## References
 
-- Related issues: #46 (builds on the direct-access model; complements #48 navigation, relates to #55)
+- Related issues: #46 (builds on the direct-access model; complements #48 navigation, relates to #55),
+  #106 (group archiving follow-up)
 - Related code: `app/Aggregates/CompartmentAccessAggregate.php`, `app/Projectors/CompartmentAccessProjector.php`,
   `app/Services/CompartmentAccessService.php`, `app/Models/CompartmentAccess.php`,
   `app/Http/Controllers/CompartmentController.php`

--- a/locker-backend/app/Aggregates/GroupAggregate.php
+++ b/locker-backend/app/Aggregates/GroupAggregate.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Aggregates;
+
+use App\StorableEvents\GroupCompartmentAccessGranted;
+use App\StorableEvents\GroupCompartmentAccessRevoked;
+use App\StorableEvents\GroupCreated;
+use App\StorableEvents\UserAddedToGroup;
+use App\StorableEvents\UserRemovedFromGroup;
+use Carbon\CarbonInterface;
+use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+
+/**
+ * One aggregate per group; the group's UUID is the aggregate UUID (the group is
+ * itself the consistency boundary, so no derived UUID is needed).
+ */
+class GroupAggregate extends AggregateRoot
+{
+    public function createGroup(
+        string $groupUuid,
+        string $name,
+        ?string $description,
+        int $actorUserId,
+        CarbonInterface $createdAt,
+    ): self {
+        $this->recordThat(new GroupCreated(
+            groupUuid: $groupUuid,
+            name: $name,
+            description: $description,
+            actorUserId: $actorUserId,
+            createdAt: $createdAt->toIso8601String(),
+        ));
+
+        return $this;
+    }
+
+    public function addUser(
+        string $groupUuid,
+        int $userId,
+        int $actorUserId,
+        CarbonInterface $addedAt,
+        ?CarbonInterface $expiresAt = null,
+    ): self {
+        $this->recordThat(new UserAddedToGroup(
+            groupUuid: $groupUuid,
+            userId: $userId,
+            actorUserId: $actorUserId,
+            addedAt: $addedAt->toIso8601String(),
+            expiresAt: $expiresAt?->toIso8601String(),
+        ));
+
+        return $this;
+    }
+
+    public function removeUser(
+        string $groupUuid,
+        int $userId,
+        int $actorUserId,
+        CarbonInterface $removedAt,
+    ): self {
+        $this->recordThat(new UserRemovedFromGroup(
+            groupUuid: $groupUuid,
+            userId: $userId,
+            actorUserId: $actorUserId,
+            removedAt: $removedAt->toIso8601String(),
+        ));
+
+        return $this;
+    }
+
+    public function grantCompartmentAccess(
+        string $groupUuid,
+        string $compartmentUuid,
+        int $actorUserId,
+        CarbonInterface $grantedAt,
+        ?CarbonInterface $expiresAt = null,
+        ?string $notes = null,
+    ): self {
+        $this->recordThat(new GroupCompartmentAccessGranted(
+            groupUuid: $groupUuid,
+            compartmentUuid: $compartmentUuid,
+            actorUserId: $actorUserId,
+            grantedAt: $grantedAt->toIso8601String(),
+            expiresAt: $expiresAt?->toIso8601String(),
+            notes: $notes,
+        ));
+
+        return $this;
+    }
+
+    public function revokeCompartmentAccess(
+        string $groupUuid,
+        string $compartmentUuid,
+        int $actorUserId,
+        CarbonInterface $revokedAt,
+    ): self {
+        $this->recordThat(new GroupCompartmentAccessRevoked(
+            groupUuid: $groupUuid,
+            compartmentUuid: $compartmentUuid,
+            actorUserId: $actorUserId,
+            revokedAt: $revokedAt->toIso8601String(),
+        ));
+
+        return $this;
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource.php
+++ b/locker-backend/app/Filament/Resources/GroupResource.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\GroupResource\Pages;
+use App\Filament\Resources\GroupResource\RelationManagers\CompartmentAccessesRelationManager;
+use App\Filament\Resources\GroupResource\RelationManagers\MembersRelationManager;
+use App\Models\Group;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class GroupResource extends Resource
+{
+    protected static ?string $model = Group::class;
+
+    protected static \BackedEnum|string|null $navigationIcon = 'heroicon-o-user-group';
+
+    public static function form(Schema $form): Schema
+    {
+        // Name/description are set at creation via GroupCreated. v1 defines no
+        // rename event, so editing them directly would drift from the event log
+        // on replay — keep them read-only on edit. See ADR-0020.
+        return $form->schema([
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255)
+                ->disabledOn('edit'),
+            Forms\Components\Textarea::make('description')
+                ->rows(3)
+                ->maxLength(2000)
+                ->disabledOn('edit'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('members_count')
+                    ->label('Members')
+                    ->counts('members')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_by')
+                    ->label('Created by')
+                    ->state(fn (Group $record): ?string => $record->createdByUser?->fullName())
+                    ->placeholder('System')
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                \Filament\Actions\EditAction::make(),
+            ]);
+        // No delete action (v1): groups cannot be deleted. See ADR-0020 / #106.
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            MembersRelationManager::class,
+            CompartmentAccessesRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGroups::route('/'),
+            'create' => Pages\CreateGroup::route('/create'),
+            'edit' => Pages\EditGroup::route('/{record}/edit'),
+        ];
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource/Pages/CreateGroup.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/Pages/CreateGroup.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GroupResource\Pages;
+
+use App\Filament\Resources\GroupResource;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class CreateGroup extends CreateRecord
+{
+    protected static string $resource = GroupResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        /** @var User|null $actor */
+        $actor = Filament::auth()->user();
+
+        return app(GroupAccessService::class)->createGroup(
+            name: $data['name'],
+            description: $data['description'] ?? null,
+            actor: $actor,
+        );
+    }
+
+    /**
+     * The read model is projected asynchronously, so redirect to the list
+     * rather than the edit page (which would route-model-bind the new record).
+     */
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource/Pages/EditGroup.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/Pages/EditGroup.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GroupResource\Pages;
+
+use App\Filament\Resources\GroupResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGroup extends EditRecord
+{
+    protected static string $resource = GroupResource::class;
+
+    // No delete action (v1): groups cannot be deleted. See ADR-0020 / #106.
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource/Pages/ListGroups.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/Pages/ListGroups.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GroupResource\Pages;
+
+use App\Filament\Resources\GroupResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGroups extends ListRecords
+{
+    protected static string $resource = GroupResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/CompartmentAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/CompartmentAccessesRelationManager.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GroupResource\RelationManagers;
+
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\GroupCompartmentAccess;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Carbon;
+
+class CompartmentAccessesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'compartmentAccesses';
+
+    protected static ?string $title = 'Compartment access';
+
+    public function form(Schema $form): Schema
+    {
+        return $form->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('id')
+            ->columns([
+                Tables\Columns\TextColumn::make('compartment.number')
+                    ->label('Compartment')
+                    ->prefix('#')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('compartment.lockerBank.name')
+                    ->label('Locker bank')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('granted_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->dateTime()
+                    ->placeholder('Never')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('revoked_at')
+                    ->dateTime()
+                    ->placeholder('Active')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('notes')
+                    ->limit(40)
+                    ->toggleable(),
+            ])
+            ->headerActions([
+                \Filament\Actions\Action::make('grantAccess')
+                    ->label('Grant access')
+                    ->icon('heroicon-m-key')
+                    ->visible(fn (): bool => $this->currentUserIsAdmin())
+                    ->form([
+                        Forms\Components\Select::make('compartment_id')
+                            ->label('Compartment')
+                            ->required()
+                            ->searchable()
+                            ->options(
+                                Compartment::query()
+                                    ->with('lockerBank')
+                                    ->get()
+                                    ->mapWithKeys(fn (Compartment $compartment): array => [
+                                        (string) $compartment->id => sprintf(
+                                            '%s / #%d',
+                                            $compartment->lockerBank?->name ?? 'Unknown locker bank',
+                                            (int) $compartment->number
+                                        ),
+                                    ])
+                                    ->all()
+                            ),
+                        Forms\Components\DateTimePicker::make('expires_at')
+                            ->label('Expires at')
+                            ->seconds(false),
+                        Forms\Components\Textarea::make('notes')
+                            ->rows(3)
+                            ->maxLength(2000),
+                    ])
+                    ->action(function (array $data): void {
+                        /** @var Group $group */
+                        $group = $this->getOwnerRecord();
+                        /** @var User|null $actor */
+                        $actor = Filament::auth()->user();
+                        /** @var Compartment $compartment */
+                        $compartment = Compartment::query()->findOrFail($data['compartment_id']);
+
+                        $expiresAt = filled($data['expires_at'])
+                            ? Carbon::parse($data['expires_at'])
+                            : null;
+
+                        app(GroupAccessService::class)->grantCompartmentAccess(
+                            group: $group,
+                            compartment: $compartment,
+                            expiresAt: $expiresAt,
+                            notes: $data['notes'] ?? null,
+                            actor: $actor,
+                        );
+
+                        $this->resetTable();
+                    }),
+            ])
+            ->actions([
+                \Filament\Actions\Action::make('revokeAccess')
+                    ->label('Revoke access')
+                    ->color('danger')
+                    ->icon('heroicon-m-no-symbol')
+                    ->visible(fn (): bool => $this->currentUserIsAdmin())
+                    ->requiresConfirmation()
+                    ->action(function (GroupCompartmentAccess $record): void {
+                        /** @var Group $group */
+                        $group = $this->getOwnerRecord();
+                        /** @var User|null $actor */
+                        $actor = Filament::auth()->user();
+
+                        app(GroupAccessService::class)->revokeCompartmentAccess(
+                            group: $group,
+                            compartment: $record->compartment,
+                            actor: $actor,
+                        );
+
+                        $this->resetTable();
+                    }),
+            ]);
+    }
+
+    private function currentUserIsAdmin(): bool
+    {
+        $user = Filament::auth()->user();
+
+        return $user instanceof User && $user->isAdmin();
+    }
+}

--- a/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GroupResource\RelationManagers;
+
+use App\Models\Group;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Carbon;
+
+class MembersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'members';
+
+    public function form(Schema $form): Schema
+    {
+        return $form->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('email')
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Name')
+                    ->state(fn (User $record): string => $record->fullName())
+                    ->searchable(['first_name', 'last_name']),
+                Tables\Columns\TextColumn::make('email')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('pivot.expires_at')
+                    ->label('Expires at')
+                    ->dateTime()
+                    ->placeholder('Never'),
+                Tables\Columns\TextColumn::make('pivot.revoked_at')
+                    ->label('Removed at')
+                    ->dateTime()
+                    ->placeholder('Active'),
+            ])
+            ->headerActions([
+                \Filament\Actions\Action::make('addMember')
+                    ->label('Add member')
+                    ->icon('heroicon-m-user-plus')
+                    ->visible(fn (): bool => $this->currentUserIsAdmin())
+                    ->form([
+                        Forms\Components\Select::make('user_id')
+                            ->label('User')
+                            ->required()
+                            ->searchable()
+                            ->options(
+                                User::query()
+                                    ->orderBy('first_name')
+                                    ->get()
+                                    ->mapWithKeys(fn (User $user): array => [
+                                        $user->id => sprintf('%s (%s)', $user->fullName(), $user->email),
+                                    ])
+                                    ->all()
+                            ),
+                        Forms\Components\DateTimePicker::make('expires_at')
+                            ->label('Expires at')
+                            ->seconds(false),
+                    ])
+                    ->action(function (array $data): void {
+                        /** @var Group $group */
+                        $group = $this->getOwnerRecord();
+                        /** @var User|null $actor */
+                        $actor = Filament::auth()->user();
+                        /** @var User $user */
+                        $user = User::query()->findOrFail($data['user_id']);
+
+                        $expiresAt = filled($data['expires_at'])
+                            ? Carbon::parse($data['expires_at'])
+                            : null;
+
+                        app(GroupAccessService::class)->addUser(
+                            group: $group,
+                            user: $user,
+                            expiresAt: $expiresAt,
+                            actor: $actor,
+                        );
+
+                        $this->resetTable();
+                    }),
+            ])
+            ->actions([
+                \Filament\Actions\Action::make('removeMember')
+                    ->label('Remove')
+                    ->color('danger')
+                    ->icon('heroicon-m-user-minus')
+                    ->visible(fn (): bool => $this->currentUserIsAdmin())
+                    ->requiresConfirmation()
+                    ->action(function (User $record): void {
+                        /** @var Group $group */
+                        $group = $this->getOwnerRecord();
+                        /** @var User|null $actor */
+                        $actor = Filament::auth()->user();
+
+                        app(GroupAccessService::class)->removeUser(
+                            group: $group,
+                            user: $record,
+                            actor: $actor,
+                        );
+
+                        $this->resetTable();
+                    }),
+            ]);
+    }
+
+    private function currentUserIsAdmin(): bool
+    {
+        $user = Filament::auth()->user();
+
+        return $user instanceof User && $user->isAdmin();
+    }
+}

--- a/locker-backend/app/Http/Controllers/CompartmentController.php
+++ b/locker-backend/app/Http/Controllers/CompartmentController.php
@@ -36,15 +36,22 @@ class CompartmentController extends Controller
                     ->orderBy('number'),
             ]);
         } else {
+            // A compartment is accessible if reachable directly OR via a group.
+            $accessibleToUser = function ($query) use ($user): void {
+                $query
+                    ->whereHas('accesses', function ($accessQuery) use ($user): void {
+                        $accessQuery->where('user_id', $user->id)->active();
+                    })
+                    ->orWhereHas('userGroupAccesses', function ($groupQuery) use ($user): void {
+                        $groupQuery->where('user_id', $user->id)->active();
+                    });
+            };
+
             $lockerBanksQuery
-                ->whereHas('compartments.accesses', function ($query) use ($user): void {
-                    $query->where('user_id', $user->id)->active();
-                })
+                ->whereHas('compartments', $accessibleToUser)
                 ->with([
                     'compartments' => fn ($query) => $query
-                        ->whereHas('accesses', function ($accessQuery) use ($user): void {
-                            $accessQuery->where('user_id', $user->id)->active();
-                        })
+                        ->where($accessibleToUser)
                         ->with('item')
                         ->orderBy('number'),
                 ]);

--- a/locker-backend/app/Models/Compartment.php
+++ b/locker-backend/app/Models/Compartment.php
@@ -98,6 +98,16 @@ class Compartment extends Model
     }
 
     /**
+     * Derived effective access via groups (read model maintained by GroupProjector).
+     *
+     * @return HasMany<UserGroupCompartmentAccess, Compartment>
+     */
+    public function userGroupAccesses(): HasMany
+    {
+        return $this->hasMany(UserGroupCompartmentAccess::class);
+    }
+
+    /**
      * @return HasMany<CompartmentAccess, Compartment>
      */
     public function activeAccesses(): HasMany

--- a/locker-backend/app/Models/Group.php
+++ b/locker-backend/app/Models/Group.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\GroupFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Group extends Model
+{
+    /** @use HasFactory<GroupFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'id',
+        'name',
+        'description',
+        'created_by_user_id',
+    ];
+
+    /**
+     * @return BelongsTo<User, Group>
+     */
+    public function createdByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /**
+     * @return BelongsToMany<User, $this>
+     */
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'group_user')
+            ->withPivot(['added_at', 'expires_at', 'revoked_at', 'added_by_user_id', 'removed_by_user_id'])
+            ->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<GroupCompartmentAccess, Group>
+     */
+    public function compartmentAccesses(): HasMany
+    {
+        return $this->hasMany(GroupCompartmentAccess::class);
+    }
+}

--- a/locker-backend/app/Models/GroupCompartmentAccess.php
+++ b/locker-backend/app/Models/GroupCompartmentAccess.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupCompartmentAccess extends Model
+{
+    /** @use HasFactory<\Database\Factories\GroupCompartmentAccessFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'group_id',
+        'compartment_id',
+        'granted_by_user_id',
+        'revoked_by_user_id',
+        'granted_at',
+        'expires_at',
+        'revoked_at',
+        'notes',
+    ];
+
+    protected $casts = [
+        'granted_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'revoked_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Group, GroupCompartmentAccess>
+     */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
+     * @return BelongsTo<Compartment, GroupCompartmentAccess>
+     */
+    public function compartment(): BelongsTo
+    {
+        return $this->belongsTo(Compartment::class);
+    }
+
+    /**
+     * @param  Builder<GroupCompartmentAccess>  $query
+     * @return Builder<GroupCompartmentAccess>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query
+            ->whereNull('revoked_at')
+            ->where(function (Builder $builder): void {
+                $builder->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            });
+    }
+}

--- a/locker-backend/app/Models/UserGroupCompartmentAccess.php
+++ b/locker-backend/app/Models/UserGroupCompartmentAccess.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Derived effective-access read model. Rows are maintained exclusively by
+ * GroupProjector::recomputeGroup(); never write this table directly.
+ */
+class UserGroupCompartmentAccess extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'compartment_id',
+        'group_id',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, UserGroupCompartmentAccess>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Compartment, UserGroupCompartmentAccess>
+     */
+    public function compartment(): BelongsTo
+    {
+        return $this->belongsTo(Compartment::class);
+    }
+
+    /**
+     * @return BelongsTo<Group, UserGroupCompartmentAccess>
+     */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
+     * No revoked_at column: a row only exists while a source grants it, so
+     * "active" is purely the expiry check.
+     *
+     * @param  Builder<UserGroupCompartmentAccess>  $query
+     * @return Builder<UserGroupCompartmentAccess>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where(function (Builder $builder): void {
+            $builder->whereNull('expires_at')
+                ->orWhere('expires_at', '>', now());
+        });
+    }
+}

--- a/locker-backend/app/Projectors/GroupProjector.php
+++ b/locker-backend/app/Projectors/GroupProjector.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Projectors;
+
+use App\Models\Group;
+use App\Models\GroupCompartmentAccess;
+use App\Models\UserGroupCompartmentAccess;
+use App\StorableEvents\GroupCompartmentAccessGranted;
+use App\StorableEvents\GroupCompartmentAccessRevoked;
+use App\StorableEvents\GroupCreated;
+use App\StorableEvents\UserAddedToGroup;
+use App\StorableEvents\UserRemovedFromGroup;
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+
+class GroupProjector extends Projector implements ShouldQueue
+{
+    public function onGroupCreated(GroupCreated $event): void
+    {
+        Group::query()->updateOrCreate(
+            ['id' => $event->groupUuid],
+            [
+                'name' => $event->name,
+                'description' => $event->description,
+                'created_by_user_id' => $event->actorUserId,
+            ]
+        );
+    }
+
+    public function onUserAddedToGroup(UserAddedToGroup $event): void
+    {
+        $expiresAt = $event->expiresAt ? Date::parse($event->expiresAt) : null;
+
+        DB::table('group_user')->updateOrInsert(
+            ['group_id' => $event->groupUuid, 'user_id' => $event->userId],
+            [
+                'added_at' => Date::parse($event->addedAt),
+                'added_by_user_id' => $event->actorUserId,
+                'expires_at' => $expiresAt,
+                'revoked_at' => null,
+                'removed_by_user_id' => null,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+
+        $this->recomputeGroup($event->groupUuid);
+    }
+
+    public function onUserRemovedFromGroup(UserRemovedFromGroup $event): void
+    {
+        DB::table('group_user')
+            ->where('group_id', $event->groupUuid)
+            ->where('user_id', $event->userId)
+            ->update([
+                'revoked_at' => Date::parse($event->removedAt),
+                'removed_by_user_id' => $event->actorUserId,
+                'updated_at' => now(),
+            ]);
+
+        $this->recomputeGroup($event->groupUuid);
+    }
+
+    public function onGroupCompartmentAccessGranted(GroupCompartmentAccessGranted $event): void
+    {
+        GroupCompartmentAccess::query()->updateOrCreate(
+            [
+                'group_id' => $event->groupUuid,
+                'compartment_id' => $event->compartmentUuid,
+            ],
+            [
+                'granted_at' => Date::parse($event->grantedAt),
+                'granted_by_user_id' => $event->actorUserId,
+                'expires_at' => $event->expiresAt ? Date::parse($event->expiresAt) : null,
+                'revoked_at' => null,
+                'revoked_by_user_id' => null,
+                'notes' => $event->notes,
+            ]
+        );
+
+        $this->recomputeGroup($event->groupUuid);
+    }
+
+    public function onGroupCompartmentAccessRevoked(GroupCompartmentAccessRevoked $event): void
+    {
+        GroupCompartmentAccess::query()
+            ->where('group_id', $event->groupUuid)
+            ->where('compartment_id', $event->compartmentUuid)
+            ->update([
+                'revoked_at' => Date::parse($event->revokedAt),
+                'revoked_by_user_id' => $event->actorUserId,
+            ]);
+
+        $this->recomputeGroup($event->groupUuid);
+    }
+
+    /**
+     * Rebuild the derived effective rows touched by one group. Scoped per group
+     * (not a full-table rebuild): we look only at the (user, compartment) pairs
+     * this group could contribute now, plus the pairs it contributed before, and
+     * recompute each from scratch across ALL groups so the union stays correct
+     * and the unique(user_id, compartment_id) constraint always holds.
+     */
+    private function recomputeGroup(string $groupUuid): void
+    {
+        DB::transaction(function () use ($groupUuid): void {
+            $now = now();
+
+            // Active members of this group, with their membership expiry.
+            $members = DB::table('group_user')
+                ->where('group_id', $groupUuid)
+                ->whereNull('revoked_at')
+                ->where(fn ($q) => $q->whereNull('expires_at')->orWhere('expires_at', '>', $now))
+                ->pluck('user_id')
+                ->all();
+
+            // Active compartment grants of this group.
+            $compartmentIds = GroupCompartmentAccess::query()
+                ->where('group_id', $groupUuid)
+                ->active()
+                ->pluck('compartment_id')
+                ->all();
+
+            // Pairs this group could contribute now.
+            $touched = [];
+            foreach ($members as $userId) {
+                foreach ($compartmentIds as $compartmentId) {
+                    $touched["{$userId}|{$compartmentId}"] = [(int) $userId, (string) $compartmentId];
+                }
+            }
+
+            // Plus pairs this group contributed before (so removals are cleaned up).
+            UserGroupCompartmentAccess::query()
+                ->where('group_id', $groupUuid)
+                ->get(['user_id', 'compartment_id'])
+                ->each(function (UserGroupCompartmentAccess $row) use (&$touched): void {
+                    $touched["{$row->user_id}|{$row->compartment_id}"] = [(int) $row->user_id, (string) $row->compartment_id];
+                });
+
+            foreach ($touched as [$userId, $compartmentId]) {
+                $this->recomputePair($userId, $compartmentId, $now);
+            }
+        });
+    }
+
+    /**
+     * Recompute one (user, compartment) effective row from every group that
+     * grants it. Access if any group grants it; effective expiry is the most
+     * permissive (null = never expires wins, otherwise the latest expiry).
+     */
+    private function recomputePair(int $userId, string $compartmentId, CarbonInterface $now): void
+    {
+        // Per contributing group, the path expiry = earliest of membership and grant expiry.
+        $paths = DB::table('group_user as gu')
+            ->join('group_compartment_accesses as gca', 'gca.group_id', '=', 'gu.group_id')
+            ->where('gu.user_id', $userId)
+            ->where('gca.compartment_id', $compartmentId)
+            ->whereNull('gu.revoked_at')
+            ->where(fn ($q) => $q->whereNull('gu.expires_at')->orWhere('gu.expires_at', '>', $now))
+            ->whereNull('gca.revoked_at')
+            ->where(fn ($q) => $q->whereNull('gca.expires_at')->orWhere('gca.expires_at', '>', $now))
+            ->get(['gu.group_id', 'gu.expires_at as member_expires_at', 'gca.expires_at as grant_expires_at']);
+
+        if ($paths->isEmpty()) {
+            UserGroupCompartmentAccess::query()
+                ->where('user_id', $userId)
+                ->where('compartment_id', $compartmentId)
+                ->delete();
+
+            return;
+        }
+
+        $effectiveExpiry = null;       // null beats any concrete date (most permissive)
+        $unlimited = false;
+        $winningGroupId = null;
+
+        foreach ($paths as $path) {
+            $pathExpiry = $this->earliest(
+                $path->member_expires_at ? Date::parse($path->member_expires_at) : null,
+                $path->grant_expires_at ? Date::parse($path->grant_expires_at) : null,
+            );
+
+            if ($pathExpiry === null) {
+                $unlimited = true;
+                $winningGroupId = $path->group_id;
+                break;
+            }
+
+            if ($effectiveExpiry === null || $pathExpiry->greaterThan($effectiveExpiry)) {
+                $effectiveExpiry = $pathExpiry;
+                $winningGroupId = $path->group_id;
+            }
+        }
+
+        UserGroupCompartmentAccess::query()->updateOrCreate(
+            ['user_id' => $userId, 'compartment_id' => $compartmentId],
+            [
+                'group_id' => $winningGroupId,
+                'expires_at' => $unlimited ? null : $effectiveExpiry,
+            ]
+        );
+    }
+
+    private function earliest(?CarbonInterface $a, ?CarbonInterface $b): ?CarbonInterface
+    {
+        if ($a === null) {
+            return $b;
+        }
+
+        if ($b === null) {
+            return $a;
+        }
+
+        return $a->lessThan($b) ? $a : $b;
+    }
+}

--- a/locker-backend/app/Services/CompartmentAccessService.php
+++ b/locker-backend/app/Services/CompartmentAccessService.php
@@ -9,6 +9,7 @@ use App\Aggregates\CompartmentOpenAggregate;
 use App\Models\Compartment;
 use App\Models\CompartmentAccess;
 use App\Models\User;
+use App\Models\UserGroupCompartmentAccess;
 use Carbon\CarbonInterface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
@@ -61,9 +62,27 @@ class CompartmentAccessService
             ->persist();
     }
 
+    /**
+     * Effective access: direct grant OR group-derived access.
+     */
     public function hasActiveAccess(User $user, Compartment $compartment): bool
     {
+        return $this->hasActiveDirectAccess($user, $compartment)
+            || $this->hasActiveGroupAccess($user, $compartment);
+    }
+
+    public function hasActiveDirectAccess(User $user, Compartment $compartment): bool
+    {
         return CompartmentAccess::query()
+            ->where('user_id', $user->id)
+            ->where('compartment_id', $compartment->id)
+            ->active()
+            ->exists();
+    }
+
+    public function hasActiveGroupAccess(User $user, Compartment $compartment): bool
+    {
+        return UserGroupCompartmentAccess::query()
             ->where('user_id', $user->id)
             ->where('compartment_id', $compartment->id)
             ->active()
@@ -112,12 +131,27 @@ class CompartmentAccessService
             ];
         }
 
-        if ($this->hasActiveAccess($user, $compartment)) {
+        // Check direct access first so its authorizationType takes precedence.
+        if ($this->hasActiveDirectAccess($user, $compartment)) {
             $aggregate->authorize(
                 commandId: $commandId,
                 actorUserId: $user->id,
                 compartmentUuid: (string) $compartment->id,
                 authorizationType: 'granted_access'
+            )->persist();
+
+            return [
+                'authorized' => true,
+                'command_id' => $commandId,
+            ];
+        }
+
+        if ($this->hasActiveGroupAccess($user, $compartment)) {
+            $aggregate->authorize(
+                commandId: $commandId,
+                actorUserId: $user->id,
+                compartmentUuid: (string) $compartment->id,
+                authorizationType: 'group_access'
             )->persist();
 
             return [

--- a/locker-backend/app/Services/CompartmentStatusBroadcastService.php
+++ b/locker-backend/app/Services/CompartmentStatusBroadcastService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Models\Compartment;
 use App\Models\CompartmentAccess;
 use App\Models\User;
+use App\Models\UserGroupCompartmentAccess;
 
 class CompartmentStatusBroadcastService
 {
@@ -24,11 +25,17 @@ class CompartmentStatusBroadcastService
             ->pluck('user_id')
             ->all();
 
+        $groupAccessUserIds = UserGroupCompartmentAccess::query()
+            ->where('compartment_id', $compartment->id)
+            ->active()
+            ->pluck('user_id')
+            ->all();
+
         $adminIds = User::query()
             ->whereNotNull('is_admin_since')
             ->pluck('id')
             ->all();
 
-        return array_values(array_unique(array_merge($accessUserIds, $adminIds)));
+        return array_values(array_unique(array_merge($accessUserIds, $groupAccessUserIds, $adminIds)));
     }
 }

--- a/locker-backend/app/Services/GroupAccessService.php
+++ b/locker-backend/app/Services/GroupAccessService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Aggregates\GroupAggregate;
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class GroupAccessService
+{
+    public function createGroup(string $name, ?string $description = null, ?User $actor = null): Group
+    {
+        $actor = $this->ensureCanManageAccess($actor);
+
+        $groupUuid = (string) Str::uuid();
+
+        GroupAggregate::retrieve($groupUuid)
+            ->createGroup(
+                groupUuid: $groupUuid,
+                name: $name,
+                description: $description,
+                actorUserId: $actor->id,
+                createdAt: now(),
+            )
+            ->persist();
+
+        // The read model is built by GroupProjector, which may run on a queue.
+        // Return an in-memory model with the known id so callers do not depend
+        // on the projection having completed yet.
+        $group = new Group([
+            'id' => $groupUuid,
+            'name' => $name,
+            'description' => $description,
+            'created_by_user_id' => $actor->id,
+        ]);
+        $group->id = $groupUuid;
+
+        return $group;
+    }
+
+    public function addUser(Group $group, User $user, ?CarbonInterface $expiresAt = null, ?User $actor = null): void
+    {
+        $actor = $this->ensureCanManageAccess($actor);
+
+        GroupAggregate::retrieve((string) $group->id)
+            ->addUser(
+                groupUuid: (string) $group->id,
+                userId: $user->id,
+                actorUserId: $actor->id,
+                addedAt: now(),
+                expiresAt: $expiresAt,
+            )
+            ->persist();
+    }
+
+    public function removeUser(Group $group, User $user, ?User $actor = null): void
+    {
+        $actor = $this->ensureCanManageAccess($actor);
+
+        GroupAggregate::retrieve((string) $group->id)
+            ->removeUser(
+                groupUuid: (string) $group->id,
+                userId: $user->id,
+                actorUserId: $actor->id,
+                removedAt: now(),
+            )
+            ->persist();
+    }
+
+    public function grantCompartmentAccess(
+        Group $group,
+        Compartment $compartment,
+        ?CarbonInterface $expiresAt = null,
+        ?string $notes = null,
+        ?User $actor = null,
+    ): void {
+        $actor = $this->ensureCanManageAccess($actor);
+
+        GroupAggregate::retrieve((string) $group->id)
+            ->grantCompartmentAccess(
+                groupUuid: (string) $group->id,
+                compartmentUuid: (string) $compartment->id,
+                actorUserId: $actor->id,
+                grantedAt: now(),
+                expiresAt: $expiresAt,
+                notes: $notes,
+            )
+            ->persist();
+    }
+
+    public function revokeCompartmentAccess(Group $group, Compartment $compartment, ?User $actor = null): void
+    {
+        $actor = $this->ensureCanManageAccess($actor);
+
+        GroupAggregate::retrieve((string) $group->id)
+            ->revokeCompartmentAccess(
+                groupUuid: (string) $group->id,
+                compartmentUuid: (string) $compartment->id,
+                actorUserId: $actor->id,
+                revokedAt: now(),
+            )
+            ->persist();
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    private function ensureCanManageAccess(?User $actor): User
+    {
+        $resolvedActor = $this->resolveActor($actor);
+        throw_unless($resolvedActor?->isAdmin(), AuthorizationException::class, 'Only admins can manage groups and group access.');
+
+        return $resolvedActor;
+    }
+
+    private function resolveActor(?User $actor): ?User
+    {
+        if ($actor instanceof User) {
+            return $actor;
+        }
+
+        $authUser = Auth::user();
+
+        return $authUser instanceof User ? $authUser : null;
+    }
+}

--- a/locker-backend/app/StorableEvents/GroupCompartmentAccessGranted.php
+++ b/locker-backend/app/StorableEvents/GroupCompartmentAccessGranted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class GroupCompartmentAccessGranted extends ShouldBeStored
+{
+    public function __construct(
+        public readonly string $groupUuid,
+        public readonly string $compartmentUuid,
+        public readonly int $actorUserId,
+        public readonly string $grantedAt,
+        public readonly ?string $expiresAt = null,
+        public readonly ?string $notes = null,
+    ) {}
+}

--- a/locker-backend/app/StorableEvents/GroupCompartmentAccessRevoked.php
+++ b/locker-backend/app/StorableEvents/GroupCompartmentAccessRevoked.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class GroupCompartmentAccessRevoked extends ShouldBeStored
+{
+    public function __construct(
+        public readonly string $groupUuid,
+        public readonly string $compartmentUuid,
+        public readonly int $actorUserId,
+        public readonly string $revokedAt,
+    ) {}
+}

--- a/locker-backend/app/StorableEvents/GroupCreated.php
+++ b/locker-backend/app/StorableEvents/GroupCreated.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class GroupCreated extends ShouldBeStored
+{
+    public function __construct(
+        public readonly string $groupUuid,
+        public readonly string $name,
+        public readonly ?string $description,
+        public readonly int $actorUserId,
+        public readonly string $createdAt,
+    ) {}
+}

--- a/locker-backend/app/StorableEvents/UserAddedToGroup.php
+++ b/locker-backend/app/StorableEvents/UserAddedToGroup.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class UserAddedToGroup extends ShouldBeStored
+{
+    public function __construct(
+        public readonly string $groupUuid,
+        public readonly int $userId,
+        public readonly int $actorUserId,
+        public readonly string $addedAt,
+        public readonly ?string $expiresAt = null,
+    ) {}
+}

--- a/locker-backend/app/StorableEvents/UserRemovedFromGroup.php
+++ b/locker-backend/app/StorableEvents/UserRemovedFromGroup.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class UserRemovedFromGroup extends ShouldBeStored
+{
+    public function __construct(
+        public readonly string $groupUuid,
+        public readonly int $userId,
+        public readonly int $actorUserId,
+        public readonly string $removedAt,
+    ) {}
+}

--- a/locker-backend/config/event-sourcing.php
+++ b/locker-backend/config/event-sourcing.php
@@ -26,6 +26,7 @@ return [
         App\Projectors\CompartmentProjector::class,
         App\Projectors\CompartmentAccessProjector::class,
         App\Projectors\CompartmentOpenRequestProjector::class,
+        App\Projectors\GroupProjector::class,
         App\Projectors\TermsProjector::class,
     ],
 

--- a/locker-backend/database/factories/GroupCompartmentAccessFactory.php
+++ b/locker-backend/database/factories/GroupCompartmentAccessFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\GroupCompartmentAccess;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GroupCompartmentAccess>
+ */
+class GroupCompartmentAccessFactory extends Factory
+{
+    protected $model = GroupCompartmentAccess::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'compartment_id' => Compartment::factory(),
+            'granted_at' => now(),
+            'expires_at' => null,
+            'revoked_at' => null,
+            'notes' => null,
+        ];
+    }
+}

--- a/locker-backend/database/factories/GroupFactory.php
+++ b/locker-backend/database/factories/GroupFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Group>
+ */
+class GroupFactory extends Factory
+{
+    protected $model = Group::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->words(2, true),
+            'description' => null,
+        ];
+    }
+}

--- a/locker-backend/database/migrations/2026_06_09_000001_create_groups_table.php
+++ b/locker-backend/database/migrations/2026_06_09_000001_create_groups_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('groups', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('groups');
+    }
+};

--- a/locker-backend/database/migrations/2026_06_09_000002_create_group_user_table.php
+++ b/locker-backend/database/migrations/2026_06_09_000002_create_group_user_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_user', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignUuid('group_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('added_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->foreignId('added_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('removed_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['group_id', 'user_id']);
+            $table->index(['user_id', 'revoked_at', 'expires_at']);
+            $table->index(['group_id', 'revoked_at', 'expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_user');
+    }
+};

--- a/locker-backend/database/migrations/2026_06_09_000003_create_group_compartment_accesses_table.php
+++ b/locker-backend/database/migrations/2026_06_09_000003_create_group_compartment_accesses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_compartment_accesses', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignUuid('group_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('compartment_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('granted_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->foreignId('granted_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('revoked_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->unique(['group_id', 'compartment_id']);
+            $table->index(['group_id', 'revoked_at', 'expires_at']);
+            $table->index(['compartment_id', 'revoked_at', 'expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_compartment_accesses');
+    }
+};

--- a/locker-backend/database/migrations/2026_06_09_000004_create_user_group_compartment_accesses_table.php
+++ b/locker-backend/database/migrations/2026_06_09_000004_create_user_group_compartment_accesses_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Derived effective-access table: the flattened (user x compartment) access
+     * produced by GroupProjector from active membership x active group grants.
+     * Never written by hand. A row simply does not exist when no active source
+     * grants it, so there is no revoked_at column here.
+     */
+    public function up(): void
+    {
+        Schema::create('user_group_compartment_accesses', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('compartment_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('group_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'compartment_id']);
+            $table->index(['user_id', 'expires_at']);
+            $table->index(['compartment_id', 'expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_group_compartment_accesses');
+    }
+};

--- a/locker-backend/tests/Feature/GroupAccessTest.php
+++ b/locker-backend/tests/Feature/GroupAccessTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use App\StorableEvents\GroupCreated;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GroupAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createRegularUser(): User
+    {
+        User::factory()->create(); // first user may become admin automatically
+
+        $user = User::factory()->create();
+        $user->is_admin_since = null;
+        $user->save();
+
+        return $user;
+    }
+
+    private function createAdminUser(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    private function service(): GroupAccessService
+    {
+        return app(GroupAccessService::class);
+    }
+
+    public function test_create_group_persists_read_model_and_event(): void
+    {
+        $admin = $this->createAdminUser();
+
+        $group = $this->service()->createGroup('Engineering', 'The eng team', actor: $admin);
+
+        $this->assertDatabaseHas('groups', [
+            'id' => $group->id,
+            'name' => 'Engineering',
+            'created_by_user_id' => $admin->id,
+        ]);
+        $this->assertDatabaseHas('stored_events', [
+            'event_class' => GroupCreated::class,
+        ]);
+    }
+
+    public function test_member_with_group_grant_gets_effective_row(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        $group = $this->service()->createGroup('Team', actor: $admin);
+        $this->service()->addUser($group, $user, actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+
+        $this->assertDatabaseHas('user_group_compartment_accesses', [
+            'user_id' => $user->id,
+            'compartment_id' => (string) $compartment->id,
+            'group_id' => $group->id,
+            'expires_at' => null,
+        ]);
+    }
+
+    public function test_revoking_group_grant_removes_effective_row(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        $group = $this->service()->createGroup('Team', actor: $admin);
+        $this->service()->addUser($group, $user, actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+        $this->service()->revokeCompartmentAccess($group, $compartment, actor: $admin);
+
+        $this->assertDatabaseMissing('user_group_compartment_accesses', [
+            'user_id' => $user->id,
+            'compartment_id' => (string) $compartment->id,
+        ]);
+    }
+
+    public function test_removing_member_removes_effective_row(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        $group = $this->service()->createGroup('Team', actor: $admin);
+        $this->service()->addUser($group, $user, actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+        $this->service()->removeUser($group, $user, actor: $admin);
+
+        $this->assertDatabaseMissing('user_group_compartment_accesses', [
+            'user_id' => $user->id,
+            'compartment_id' => (string) $compartment->id,
+        ]);
+    }
+
+    public function test_effective_expiry_is_earliest_of_membership_and_grant(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        $membershipExpiry = now()->addDays(2)->startOfSecond();
+        $grantExpiry = now()->addDays(10)->startOfSecond();
+
+        $group = $this->service()->createGroup('Team', actor: $admin);
+        $this->service()->addUser($group, $user, expiresAt: $membershipExpiry, actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, expiresAt: $grantExpiry, actor: $admin);
+
+        $row = \App\Models\UserGroupCompartmentAccess::query()
+            ->where('user_id', $user->id)
+            ->where('compartment_id', (string) $compartment->id)
+            ->firstOrFail();
+
+        $this->assertTrue($membershipExpiry->equalTo($row->expires_at), 'effective expiry should be the earlier (membership) expiry');
+    }
+
+    public function test_access_via_two_groups_survives_revoking_one(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        $groupA = $this->service()->createGroup('A', actor: $admin);
+        $groupB = $this->service()->createGroup('B', actor: $admin);
+
+        foreach ([$groupA, $groupB] as $group) {
+            $this->service()->addUser($group, $user, actor: $admin);
+            $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+        }
+
+        // Revoke via group A only; group B still grants it.
+        $this->service()->revokeCompartmentAccess($groupA, $compartment, actor: $admin);
+
+        $this->assertDatabaseHas('user_group_compartment_accesses', [
+            'user_id' => $user->id,
+            'compartment_id' => (string) $compartment->id,
+        ]);
+        $this->assertDatabaseCount('user_group_compartment_accesses', 1);
+    }
+
+    public function test_non_admin_cannot_manage_groups(): void
+    {
+        $user = $this->createRegularUser();
+
+        $this->expectException(AuthorizationException::class);
+        $this->service()->createGroup('Nope', actor: $user);
+    }
+
+    public function test_duplicate_grant_keeps_single_group_grant_row(): void
+    {
+        $admin = $this->createAdminUser();
+        $compartment = Compartment::factory()->create();
+
+        $group = $this->service()->createGroup('Team', actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+        $this->service()->grantCompartmentAccess($group, $compartment, actor: $admin);
+
+        $this->assertDatabaseCount('group_compartment_accesses', 1);
+    }
+}

--- a/locker-backend/tests/Feature/GroupAdminUiTest.php
+++ b/locker-backend/tests/Feature/GroupAdminUiTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\GroupResource;
+use App\Filament\Resources\GroupResource\Pages\CreateGroup;
+use App\Filament\Resources\GroupResource\Pages\EditGroup;
+use App\Filament\Resources\GroupResource\RelationManagers\CompartmentAccessesRelationManager;
+use App\Filament\Resources\GroupResource\RelationManagers\MembersRelationManager;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use Filament\Actions\Action;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use ReflectionClass;
+use Tests\TestCase;
+
+class GroupAdminUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    public function test_group_resource_table_builds(): void
+    {
+        $livewire = $this->createMock(HasTable::class);
+
+        $this->assertInstanceOf(Table::class, GroupResource::table(Table::make($livewire)));
+    }
+
+    public function test_admin_can_load_group_list_and_create_pages(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin)->get(GroupResource::getUrl('index'))->assertOk();
+        $this->actingAs($admin)->get(GroupResource::getUrl('create'))->assertOk();
+    }
+
+    public function test_admin_can_load_group_edit_page(): void
+    {
+        $admin = $this->admin();
+        $group = app(GroupAccessService::class)->createGroup('Engineering', actor: $admin);
+
+        $this->actingAs($admin)
+            ->get(GroupResource::getUrl('edit', ['record' => $group->id]))
+            ->assertOk();
+    }
+
+    public function test_non_admin_cannot_load_group_list(): void
+    {
+        User::factory()->create();
+        $user = User::factory()->create();
+        $user->is_admin_since = null;
+        $user->save();
+
+        $this->actingAs($user)->get(GroupResource::getUrl('index'))->assertForbidden();
+    }
+
+    public function test_create_page_persists_group_through_service(): void
+    {
+        $admin = $this->admin();
+
+        Livewire::actingAs($admin)
+            ->test(CreateGroup::class)
+            ->fillForm([
+                'name' => 'Logistics',
+                'description' => 'Warehouse crew',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('groups', [
+            'name' => 'Logistics',
+            'created_by_user_id' => $admin->id,
+        ]);
+    }
+
+    public function test_group_resource_registers_member_and_compartment_relation_managers(): void
+    {
+        $relations = GroupResource::getRelations();
+
+        $this->assertContains(MembersRelationManager::class, $relations);
+        $this->assertContains(CompartmentAccessesRelationManager::class, $relations);
+    }
+
+    public function test_relation_managers_can_be_instantiated(): void
+    {
+        // Smoke: the relation manager classes resolve and declare their relationship.
+        $this->assertSame('members', $this->relationshipOf(MembersRelationManager::class));
+        $this->assertSame('compartmentAccesses', $this->relationshipOf(CompartmentAccessesRelationManager::class));
+    }
+
+    private function relationshipOf(string $relationManager): string
+    {
+        $property = (new ReflectionClass($relationManager))->getProperty('relationship');
+        $property->setAccessible(true);
+
+        return (string) $property->getValue();
+    }
+
+    public function test_edit_group_page_has_no_delete_action(): void
+    {
+        $page = app(EditGroup::class);
+        $method = (new ReflectionClass($page))->getMethod('getHeaderActions');
+        $method->setAccessible(true);
+
+        $actionNames = collect($method->invoke($page))
+            ->map(fn (Action $action): string => $action->getName())
+            ->all();
+
+        $this->assertNotContains('delete', $actionNames);
+        $this->assertEmpty($actionNames);
+    }
+}

--- a/locker-backend/tests/Feature/GroupEffectiveAccessTest.php
+++ b/locker-backend/tests/Feature/GroupEffectiveAccessTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Compartment;
+use App\Models\User;
+use App\Services\CompartmentStatusBroadcastService;
+use App\Services\GroupAccessService;
+use App\Services\LockerService;
+use App\StorableEvents\CompartmentOpenAuthorized;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
+use Tests\TestCase;
+
+class GroupEffectiveAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createRegularUser(): User
+    {
+        User::factory()->create(); // first user may become admin automatically
+
+        $user = User::factory()->create();
+        $user->is_admin_since = null;
+        $user->save();
+
+        return $user;
+    }
+
+    private function createAdminUser(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    private function groupService(): GroupAccessService
+    {
+        return app(GroupAccessService::class);
+    }
+
+    private function grantGroupAccess(User $user, Compartment $compartment, User $admin): void
+    {
+        $group = $this->groupService()->createGroup('Team', actor: $admin);
+        $this->groupService()->addUser($group, $user, actor: $admin);
+        $this->groupService()->grantCompartmentAccess($group, $compartment, actor: $admin);
+    }
+
+    public function test_group_only_member_can_open_with_group_access_authorization(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+        $this->grantGroupAccess($user, $compartment, $admin);
+
+        $this->mock(LockerService::class, function ($mock): void {
+            $mock->shouldReceive('openCompartment')->once();
+        });
+
+        $response = $this->actingAs($user)->postJson(route('compartments.open', $compartment->id));
+
+        $response->assertStatus(202);
+
+        /** @var ?EloquentStoredEvent $authorizedEvent */
+        $authorizedEvent = EloquentStoredEvent::query()
+            ->where('event_class', CompartmentOpenAuthorized::class)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($authorizedEvent);
+        $this->assertSame('group_access', $authorizedEvent->event_properties['authorizationType'] ?? null);
+    }
+
+    public function test_direct_access_takes_precedence_over_group_access(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+
+        // User reachable both directly and via a group.
+        app(\App\Services\CompartmentAccessService::class)->grantAccess($user, $compartment, actor: $admin);
+        $this->grantGroupAccess($user, $compartment, $admin);
+
+        $this->mock(LockerService::class, function ($mock): void {
+            $mock->shouldReceive('openCompartment')->once();
+        });
+
+        $response = $this->actingAs($user)->postJson(route('compartments.open', $compartment->id));
+
+        $response->assertStatus(202);
+
+        /** @var ?EloquentStoredEvent $authorizedEvent */
+        $authorizedEvent = EloquentStoredEvent::query()
+            ->where('event_class', CompartmentOpenAuthorized::class)
+            ->latest('id')
+            ->first();
+
+        $this->assertSame('granted_access', $authorizedEvent->event_properties['authorizationType'] ?? null);
+    }
+
+    public function test_accessible_endpoint_includes_compartment_reachable_via_group(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+        $this->grantGroupAccess($user, $compartment, $admin);
+
+        $response = $this->actingAs($user)->getJson(route('compartments.accessible'));
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => (string) $compartment->id]);
+    }
+
+    public function test_broadcast_recipients_include_group_only_member(): void
+    {
+        $admin = $this->createAdminUser();
+        $user = $this->createRegularUser();
+        $compartment = Compartment::factory()->create();
+        $this->grantGroupAccess($user, $compartment, $admin);
+
+        $recipients = app(CompartmentStatusBroadcastService::class)
+            ->recipientUserIdsForCompartment($compartment);
+
+        $this->assertContains($user->id, $recipients);
+    }
+}


### PR DESCRIPTION
## Summary
Cherry-picked slice `pr-02-groups-46` from `dev` onto `main`.

**Commits:**
- `3483248` — ADR-0020 (proposed)
- `b6a99a7` — ADR-0020 accepted with review feedback
- `0c27163` — Group aggregate, projector, Filament admin, effective access API

Implements event-sourced groups with projected effective access (direct ∪ group-derived).
Admin-only group management in Filament v1; no group delete.

Part of the incremental dev → main migration (replaces monolithic PR #107).

## Test plan
- [ ] CI green
- [ ] Backend tests pass (includes `GroupAccessTest`, `GroupEffectiveAccessTest`, `GroupAdminUiTest`)
- [ ] Filament: create group, add member, grant compartment access
- [ ] API: `GET /api/compartments/accessible` includes group-derived access

Closes #46

Made with [Cursor](https://cursor.com)