### PR TITLE
refactor(admin): unify & improve assignment pickers across resources (#117)

### DIFF
--- a/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/GroupAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/GroupAccessesRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\CompartmentResource\RelationManagers;
 
 use App\Enums\Permission;
+use App\Filament\Support\AccessPickerOptions;
 use App\Models\Compartment;
 use App\Models\Group;
 use App\Models\GroupCompartmentAccess;
@@ -16,6 +17,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class GroupAccessesRelationManager extends RelationManager
@@ -66,14 +68,12 @@ class GroupAccessesRelationManager extends RelationManager
                     ->icon('heroicon-m-key')
                     ->visible(fn (): bool => $this->currentUserCanManageAccess())
                     ->form([
-                        Forms\Components\Select::make('group_id')
-                            ->label(__('Group'))
+                        Forms\Components\Select::make('group_ids')
+                            ->label(__('Groups'))
                             ->required()
+                            ->multiple()
                             ->searchable()
-                            ->options(fn (): array => Group::query()
-                                ->orderBy('name')
-                                ->pluck('name', 'id')
-                                ->all()),
+                            ->options(fn (): array => $this->grantableGroupOptions()),
                         Forms\Components\DateTimePicker::make('expires_at')
                             ->label(__('Expires at'))
                             ->seconds(false),
@@ -87,20 +87,26 @@ class GroupAccessesRelationManager extends RelationManager
                         $compartment = $this->getOwnerRecord();
                         /** @var User|null $actor */
                         $actor = Filament::auth()->user();
-                        /** @var Group $group */
-                        $group = Group::query()->findOrFail($data['group_id']);
 
                         $expiresAt = filled($data['expires_at'])
                             ? Carbon::parse($data['expires_at'])
                             : null;
 
-                        app(GroupAccessService::class)->grantCompartmentAccess(
-                            group: $group,
-                            compartment: $compartment,
-                            expiresAt: $expiresAt,
-                            notes: $data['notes'] ?? null,
-                            actor: $actor,
-                        );
+                        $service = app(GroupAccessService::class);
+
+                        $groups = Group::query()
+                            ->whereIn('id', $data['group_ids'])
+                            ->get();
+
+                        foreach ($groups as $group) {
+                            $service->grantCompartmentAccess(
+                                group: $group,
+                                compartment: $compartment,
+                                expiresAt: $expiresAt,
+                                notes: $data['notes'] ?? null,
+                                actor: $actor,
+                            );
+                        }
 
                         $this->resetTable();
                     }),
@@ -127,6 +133,31 @@ class GroupAccessesRelationManager extends RelationManager
                         $this->resetTable();
                     }),
             ]);
+    }
+
+    /**
+     * Groups that can be granted access to the owner compartment: excludes
+     * groups that already have active access to it.
+     *
+     * @return array<string, string>
+     */
+    private function grantableGroupOptions(): array
+    {
+        /** @var Compartment $compartment */
+        $compartment = $this->getOwnerRecord();
+
+        return AccessPickerOptions::groups(
+            Group::query()->whereDoesntHave(
+                'compartmentAccesses',
+                fn (Builder $query): Builder => $query
+                    ->where('compartment_id', $compartment->id)
+                    ->whereNull('revoked_at')
+                    ->where(function (Builder $builder): void {
+                        $builder->whereNull('expires_at')
+                            ->orWhere('expires_at', '>', now());
+                    })
+            )
+        );
     }
 
     private function currentUserCanManageAccess(): bool

--- a/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/UserAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/UserAccessesRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\CompartmentResource\RelationManagers;
 
 use App\Enums\Permission;
+use App\Filament\Support\AccessPickerOptions;
 use App\Models\Compartment;
 use App\Models\CompartmentAccess;
 use App\Models\User;
@@ -15,6 +16,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class UserAccessesRelationManager extends RelationManager
@@ -71,21 +73,12 @@ class UserAccessesRelationManager extends RelationManager
                     ->icon('heroicon-m-key')
                     ->visible(fn (): bool => $this->currentUserCanManageAccess())
                     ->form([
-                        Forms\Components\Select::make('user_id')
-                            ->label(__('User'))
+                        Forms\Components\Select::make('user_ids')
+                            ->label(__('Users'))
                             ->required()
+                            ->multiple()
                             ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => User::query()
-                                ->where('email', 'like', "%{$search}%")
-                                ->orWhere('first_name', 'like', "%{$search}%")
-                                ->orWhere('last_name', 'like', "%{$search}%")
-                                ->limit(50)
-                                ->get()
-                                ->mapWithKeys(fn (User $user): array => [
-                                    $user->id => sprintf('%s (%s)', $user->fullName(), $user->email),
-                                ])
-                                ->all())
-                            ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->email),
+                            ->options(fn (): array => $this->grantableUserOptions()),
                         Forms\Components\DateTimePicker::make('expires_at')
                             ->label(__('Expires at'))
                             ->seconds(false),
@@ -99,20 +92,26 @@ class UserAccessesRelationManager extends RelationManager
                         $compartment = $this->getOwnerRecord();
                         /** @var User|null $actor */
                         $actor = Filament::auth()->user();
-                        /** @var User $user */
-                        $user = User::query()->findOrFail($data['user_id']);
 
                         $expiresAt = filled($data['expires_at'])
                             ? Carbon::parse($data['expires_at'])
                             : null;
 
-                        app(CompartmentAccessService::class)->grantAccess(
-                            user: $user,
-                            compartment: $compartment,
-                            expiresAt: $expiresAt,
-                            notes: $data['notes'] ?? null,
-                            actor: $actor,
-                        );
+                        $service = app(CompartmentAccessService::class);
+
+                        $users = User::query()
+                            ->whereIn('id', $data['user_ids'])
+                            ->get();
+
+                        foreach ($users as $user) {
+                            $service->grantAccess(
+                                user: $user,
+                                compartment: $compartment,
+                                expiresAt: $expiresAt,
+                                notes: $data['notes'] ?? null,
+                                actor: $actor,
+                            );
+                        }
 
                         $this->resetTable();
                     }),
@@ -139,6 +138,25 @@ class UserAccessesRelationManager extends RelationManager
                         $this->resetTable();
                     }),
             ]);
+    }
+
+    /**
+     * Users who can be granted access to the owner compartment: excludes users
+     * that already have active access to it.
+     *
+     * @return array<string, string>
+     */
+    private function grantableUserOptions(): array
+    {
+        /** @var Compartment $compartment */
+        $compartment = $this->getOwnerRecord();
+
+        return AccessPickerOptions::users(
+            User::query()->whereDoesntHave(
+                'activeCompartmentAccesses',
+                fn (Builder $query): Builder => $query->where('compartment_id', $compartment->id)
+            )
+        );
     }
 
     private function currentUserCanManageAccess(): bool

--- a/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/CompartmentAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/CompartmentAccessesRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\GroupResource\RelationManagers;
 
 use App\Enums\Permission;
+use App\Filament\Support\AccessPickerOptions;
 use App\Models\Compartment;
 use App\Models\Group;
 use App\Models\GroupCompartmentAccess;
@@ -16,6 +17,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class CompartmentAccessesRelationManager extends RelationManager
@@ -69,23 +71,12 @@ class CompartmentAccessesRelationManager extends RelationManager
                     ->icon('heroicon-m-key')
                     ->visible(fn (): bool => $this->currentUserCanManageGroups())
                     ->form([
-                        Forms\Components\Select::make('compartment_id')
-                            ->label(__('Compartment'))
+                        Forms\Components\Select::make('compartment_ids')
+                            ->label(__('Compartments'))
                             ->required()
+                            ->multiple()
                             ->searchable()
-                            ->options(
-                                Compartment::query()
-                                    ->with('lockerBank')
-                                    ->get()
-                                    ->mapWithKeys(fn (Compartment $compartment): array => [
-                                        (string) $compartment->id => sprintf(
-                                            '%s / #%d',
-                                            $compartment->lockerBank->name,
-                                            (int) $compartment->number
-                                        ),
-                                    ])
-                                    ->all()
-                            ),
+                            ->options(fn (): array => $this->grantableCompartmentOptions()),
                         Forms\Components\DateTimePicker::make('expires_at')
                             ->label(__('Expires at'))
                             ->seconds(false),
@@ -99,20 +90,26 @@ class CompartmentAccessesRelationManager extends RelationManager
                         $group = $this->getOwnerRecord();
                         /** @var User|null $actor */
                         $actor = Filament::auth()->user();
-                        /** @var Compartment $compartment */
-                        $compartment = Compartment::query()->findOrFail($data['compartment_id']);
 
                         $expiresAt = filled($data['expires_at'])
                             ? Carbon::parse($data['expires_at'])
                             : null;
 
-                        app(GroupAccessService::class)->grantCompartmentAccess(
-                            group: $group,
-                            compartment: $compartment,
-                            expiresAt: $expiresAt,
-                            notes: $data['notes'] ?? null,
-                            actor: $actor,
-                        );
+                        $service = app(GroupAccessService::class);
+
+                        $compartments = Compartment::query()
+                            ->whereIn('id', $data['compartment_ids'])
+                            ->get();
+
+                        foreach ($compartments as $compartment) {
+                            $service->grantCompartmentAccess(
+                                group: $group,
+                                compartment: $compartment,
+                                expiresAt: $expiresAt,
+                                notes: $data['notes'] ?? null,
+                                actor: $actor,
+                            );
+                        }
 
                         $this->resetTable();
                     }),
@@ -139,6 +136,31 @@ class CompartmentAccessesRelationManager extends RelationManager
                         $this->resetTable();
                     }),
             ]);
+    }
+
+    /**
+     * Grantable compartments for the owner group: excludes compartments the
+     * group already has active access to.
+     *
+     * @return array<string, string>
+     */
+    private function grantableCompartmentOptions(): array
+    {
+        /** @var Group $group */
+        $group = $this->getOwnerRecord();
+
+        return AccessPickerOptions::compartments(
+            Compartment::query()->whereDoesntHave(
+                'groupAccesses',
+                fn (Builder $query): Builder => $query
+                    ->where('group_id', $group->id)
+                    ->whereNull('revoked_at')
+                    ->where(function (Builder $builder): void {
+                        $builder->whereNull('expires_at')
+                            ->orWhere('expires_at', '>', now());
+                    })
+            )
+        );
     }
 
     private function currentUserCanManageGroups(): bool

--- a/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
+++ b/locker-backend/app/Filament/Resources/GroupResource/RelationManagers/MembersRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\GroupResource\RelationManagers;
 
 use App\Enums\Permission;
+use App\Filament\Support\AccessPickerOptions;
 use App\Models\Group;
 use App\Models\User;
 use App\Services\GroupAccessService;
@@ -14,6 +15,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class MembersRelationManager extends RelationManager
@@ -52,19 +54,12 @@ class MembersRelationManager extends RelationManager
                     ->icon('heroicon-m-user-plus')
                     ->visible(fn (): bool => $this->currentUserCanManageGroups())
                     ->form([
-                        Forms\Components\Select::make('user_id')
-                            ->label(__('User'))
+                        Forms\Components\Select::make('user_ids')
+                            ->label(__('Users'))
                             ->required()
+                            ->multiple()
                             ->searchable()
-                            ->options(
-                                User::query()
-                                    ->orderBy('first_name')
-                                    ->get()
-                                    ->mapWithKeys(fn (User $user): array => [
-                                        $user->id => sprintf('%s (%s)', $user->fullName(), $user->email),
-                                    ])
-                                    ->all()
-                            ),
+                            ->options(fn (): array => $this->addableUserOptions()),
                         Forms\Components\DateTimePicker::make('expires_at')
                             ->label(__('Expires at'))
                             ->seconds(false),
@@ -74,19 +69,25 @@ class MembersRelationManager extends RelationManager
                         $group = $this->getOwnerRecord();
                         /** @var User|null $actor */
                         $actor = Filament::auth()->user();
-                        /** @var User $user */
-                        $user = User::query()->findOrFail($data['user_id']);
 
                         $expiresAt = filled($data['expires_at'])
                             ? Carbon::parse($data['expires_at'])
                             : null;
 
-                        app(GroupAccessService::class)->addUser(
-                            group: $group,
-                            user: $user,
-                            expiresAt: $expiresAt,
-                            actor: $actor,
-                        );
+                        $service = app(GroupAccessService::class);
+
+                        $users = User::query()
+                            ->whereIn('id', $data['user_ids'])
+                            ->get();
+
+                        foreach ($users as $user) {
+                            $service->addUser(
+                                group: $group,
+                                user: $user,
+                                expiresAt: $expiresAt,
+                                actor: $actor,
+                            );
+                        }
 
                         $this->resetTable();
                     }),
@@ -113,6 +114,31 @@ class MembersRelationManager extends RelationManager
                         $this->resetTable();
                     }),
             ]);
+    }
+
+    /**
+     * Users who can be added to the owner group: excludes users that are
+     * already active members.
+     *
+     * @return array<string, string>
+     */
+    private function addableUserOptions(): array
+    {
+        /** @var Group $group */
+        $group = $this->getOwnerRecord();
+
+        $activeMemberIds = $group->members()
+            ->wherePivotNull('revoked_at')
+            ->where(function (Builder $query): void {
+                $query->whereNull('group_user.expires_at')
+                    ->orWhere('group_user.expires_at', '>', now());
+            })
+            ->pluck('users.id')
+            ->all();
+
+        return AccessPickerOptions::users(
+            User::query()->whereNotIn('id', $activeMemberIds)
+        );
     }
 
     private function currentUserCanManageGroups(): bool

--- a/locker-backend/app/Filament/Resources/UserResource/RelationManagers/CompartmentAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/UserResource/RelationManagers/CompartmentAccessesRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\UserResource\RelationManagers;
 
 use App\Enums\Permission;
+use App\Filament\Support\AccessPickerOptions;
 use App\Models\Compartment;
 use App\Models\CompartmentAccess;
 use App\Models\User;
@@ -15,6 +16,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class CompartmentAccessesRelationManager extends RelationManager
@@ -87,23 +89,12 @@ class CompartmentAccessesRelationManager extends RelationManager
                     ->icon('heroicon-m-key')
                     ->visible(fn (): bool => $this->currentUserCanManageAccess())
                     ->form([
-                        Forms\Components\Select::make('compartment_id')
-                            ->label(__('Compartment'))
+                        Forms\Components\Select::make('compartment_ids')
+                            ->label(__('Compartments'))
                             ->required()
+                            ->multiple()
                             ->searchable()
-                            ->options(
-                                Compartment::query()
-                                    ->with('lockerBank')
-                                    ->get()
-                                    ->mapWithKeys(fn (Compartment $compartment): array => [
-                                        (string) $compartment->id => sprintf(
-                                            '%s / #%d',
-                                            $compartment->lockerBank->name,
-                                            (int) $compartment->number
-                                        ),
-                                    ])
-                                    ->all()
-                            ),
+                            ->options(fn (): array => $this->grantableCompartmentOptions()),
                         Forms\Components\DateTimePicker::make('expires_at')
                             ->label(__('Expires at'))
                             ->seconds(false),
@@ -117,20 +108,26 @@ class CompartmentAccessesRelationManager extends RelationManager
                         $user = $this->getOwnerRecord();
                         /** @var User|null $actor */
                         $actor = Filament::auth()->user();
-                        /** @var Compartment $compartment */
-                        $compartment = Compartment::query()->findOrFail($data['compartment_id']);
 
                         $expiresAt = filled($data['expires_at'])
                             ? Carbon::parse($data['expires_at'])
                             : null;
 
-                        app(CompartmentAccessService::class)->grantAccess(
-                            user: $user,
-                            compartment: $compartment,
-                            expiresAt: $expiresAt,
-                            notes: $data['notes'] ?? null,
-                            actor: $actor
-                        );
+                        $service = app(CompartmentAccessService::class);
+
+                        $compartments = Compartment::query()
+                            ->whereIn('id', $data['compartment_ids'])
+                            ->get();
+
+                        foreach ($compartments as $compartment) {
+                            $service->grantAccess(
+                                user: $user,
+                                compartment: $compartment,
+                                expiresAt: $expiresAt,
+                                notes: $data['notes'] ?? null,
+                                actor: $actor
+                            );
+                        }
 
                         $this->resetTable();
                     }),
@@ -157,6 +154,25 @@ class CompartmentAccessesRelationManager extends RelationManager
                         $this->resetTable();
                     }),
             ]);
+    }
+
+    /**
+     * Grantable compartments for the owner user: excludes compartments the
+     * user already has active access to.
+     *
+     * @return array<string, string>
+     */
+    private function grantableCompartmentOptions(): array
+    {
+        /** @var User $user */
+        $user = $this->getOwnerRecord();
+
+        return AccessPickerOptions::compartments(
+            Compartment::query()->whereDoesntHave(
+                'activeAccesses',
+                fn (Builder $query): Builder => $query->where('user_id', $user->id)
+            )
+        );
     }
 
     private function currentUserCanManageAccess(): bool

--- a/locker-backend/app/Filament/Support/AccessPickerOptions.php
+++ b/locker-backend/app/Filament/Support/AccessPickerOptions.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Support;
+
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Shared option builders for admin-panel assignment pickers, so compartment,
+ * user, and group selects stay consistently sorted and labelled across the
+ * Filament relation managers (see issue #117).
+ *
+ * Each method takes a pre-filtered query — the caller is responsible for
+ * excluding already-assigned records via `whereDoesntHave`/`whereNotIn`.
+ */
+final class AccessPickerOptions
+{
+    /**
+     * Compartments sorted by locker bank name, then compartment number,
+     * labelled "{locker bank name} / #{compartment number}".
+     *
+     * @param  Builder<Compartment>  $query
+     * @return array<string, string>
+     */
+    public static function compartments(Builder $query): array
+    {
+        return $query
+            ->with('lockerBank')
+            ->join('locker_banks', 'locker_banks.id', '=', 'compartments.locker_bank_id')
+            ->orderBy('locker_banks.name')
+            ->orderBy('compartments.number')
+            ->select('compartments.*')
+            ->get()
+            ->mapWithKeys(fn (Compartment $compartment): array => [
+                (string) $compartment->id => sprintf(
+                    '%s / #%d',
+                    $compartment->lockerBank->name,
+                    (int) $compartment->number
+                ),
+            ])
+            ->all();
+    }
+
+    /**
+     * Users sorted by name, labelled "{full name} ({email})".
+     *
+     * @param  Builder<User>  $query
+     * @return array<string, string>
+     */
+    public static function users(Builder $query): array
+    {
+        return $query
+            ->orderBy('first_name')
+            ->orderBy('last_name')
+            ->get()
+            ->mapWithKeys(fn (User $user): array => [
+                (string) $user->id => sprintf('%s (%s)', $user->fullName(), $user->email),
+            ])
+            ->all();
+    }
+
+    /**
+     * Groups sorted by name, labelled by name.
+     *
+     * @param  Builder<Group>  $query
+     * @return array<string, string>
+     */
+    public static function groups(Builder $query): array
+    {
+        return $query
+            ->orderBy('name')
+            ->get()
+            ->mapWithKeys(fn (Group $group): array => [
+                (string) $group->id => (string) $group->name,
+            ])
+            ->all();
+    }
+}

--- a/locker-backend/tests/Feature/CompartmentAccessPickersTest.php
+++ b/locker-backend/tests/Feature/CompartmentAccessPickersTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\CompartmentResource\Pages\ViewCompartment;
+use App\Filament\Resources\CompartmentResource\RelationManagers\GroupAccessesRelationManager;
+use App\Filament\Resources\CompartmentResource\RelationManagers\UserAccessesRelationManager;
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\GroupCompartmentAccess;
+use App\Models\User;
+use App\Services\CompartmentAccessService;
+use App\Services\GroupAccessService;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class CompartmentAccessPickersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    private function pickerOptions(string $relationManager, string $method, Compartment $compartment): array
+    {
+        $component = Livewire::test($relationManager, [
+            'ownerRecord' => $compartment,
+            'pageClass' => ViewCompartment::class,
+        ]);
+
+        $reflection = new ReflectionMethod($relationManager, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invoke($component->instance());
+    }
+
+    public function test_user_picker_grants_multiple_users_and_excludes_active_access(): void
+    {
+        $admin = $this->admin();
+        $compartment = Compartment::factory()->create();
+        $first = User::factory()->create();
+        $second = User::factory()->create();
+        $alreadyGranted = User::factory()->create();
+
+        app(CompartmentAccessService::class)->grantAccess(
+            user: $alreadyGranted,
+            compartment: $compartment,
+            actor: $admin,
+        );
+
+        $options = $this->pickerOptions(UserAccessesRelationManager::class, 'grantableUserOptions', $compartment);
+        $this->assertArrayHasKey((string) $first->id, $options);
+        $this->assertArrayNotHasKey((string) $alreadyGranted->id, $options);
+
+        Livewire::actingAs($admin)
+            ->test(UserAccessesRelationManager::class, [
+                'ownerRecord' => $compartment,
+                'pageClass' => ViewCompartment::class,
+            ])
+            ->callAction(TestAction::make('grantAccess')->table(), data: [
+                'user_ids' => [(string) $first->id, (string) $second->id],
+            ])
+            ->assertHasNoActionErrors();
+
+        $service = app(CompartmentAccessService::class);
+        $this->assertTrue($service->hasActiveAccess($first, $compartment));
+        $this->assertTrue($service->hasActiveAccess($second, $compartment));
+    }
+
+    public function test_group_picker_grants_multiple_groups_and_excludes_active_access(): void
+    {
+        $admin = $this->admin();
+        $compartment = Compartment::factory()->create();
+        $first = Group::factory()->create();
+        $second = Group::factory()->create();
+        $alreadyGranted = Group::factory()->create();
+
+        app(GroupAccessService::class)->grantCompartmentAccess(
+            group: $alreadyGranted,
+            compartment: $compartment,
+            actor: $admin,
+        );
+
+        $options = $this->pickerOptions(GroupAccessesRelationManager::class, 'grantableGroupOptions', $compartment);
+        $this->assertArrayHasKey((string) $first->id, $options);
+        $this->assertArrayNotHasKey((string) $alreadyGranted->id, $options);
+
+        Livewire::actingAs($admin)
+            ->test(GroupAccessesRelationManager::class, [
+                'ownerRecord' => $compartment,
+                'pageClass' => ViewCompartment::class,
+            ])
+            ->callAction(TestAction::make('grantAccess')->table(), data: [
+                'group_ids' => [(string) $first->id, (string) $second->id],
+            ])
+            ->assertHasNoActionErrors();
+
+        foreach ([$first, $second] as $group) {
+            $this->assertTrue(
+                GroupCompartmentAccess::query()
+                    ->where('group_id', $group->id)
+                    ->where('compartment_id', $compartment->id)
+                    ->active()
+                    ->exists()
+            );
+        }
+    }
+}

--- a/locker-backend/tests/Feature/CompartmentAccessesRelationManagerTest.php
+++ b/locker-backend/tests/Feature/CompartmentAccessesRelationManagerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\UserResource\Pages\EditUser;
+use App\Filament\Resources\UserResource\RelationManagers\CompartmentAccessesRelationManager;
+use App\Models\Compartment;
+use App\Models\LockerBank;
+use App\Models\User;
+use App\Services\CompartmentAccessService;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CompartmentAccessesRelationManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    public function test_grant_access_assigns_multiple_compartments_in_one_action(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $lockerBank = LockerBank::factory()->create();
+        $first = Compartment::factory()->for($lockerBank)->create(['number' => 1]);
+        $second = Compartment::factory()->for($lockerBank)->create(['number' => 2]);
+
+        Livewire::actingAs($admin)
+            ->test(CompartmentAccessesRelationManager::class, [
+                'ownerRecord' => $user,
+                'pageClass' => EditUser::class,
+            ])
+            ->callAction(TestAction::make('grantAccess')->table(), data: [
+                'compartment_ids' => [(string) $first->id, (string) $second->id],
+            ])
+            ->assertHasNoActionErrors();
+
+        $service = app(CompartmentAccessService::class);
+        $this->assertTrue($service->hasActiveAccess($user, $first));
+        $this->assertTrue($service->hasActiveAccess($user, $second));
+    }
+
+    public function test_grant_picker_excludes_compartments_with_active_access(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+        $lockerBank = LockerBank::factory()->create();
+        $alreadyGranted = Compartment::factory()->for($lockerBank)->create(['number' => 1]);
+        $available = Compartment::factory()->for($lockerBank)->create(['number' => 2]);
+
+        app(CompartmentAccessService::class)->grantAccess(
+            user: $user,
+            compartment: $alreadyGranted,
+            actor: $admin,
+        );
+
+        $component = Livewire::actingAs($admin)
+            ->test(CompartmentAccessesRelationManager::class, [
+                'ownerRecord' => $user,
+                'pageClass' => EditUser::class,
+            ]);
+
+        $reflection = new \ReflectionMethod(CompartmentAccessesRelationManager::class, 'grantableCompartmentOptions');
+        $reflection->setAccessible(true);
+        $options = $reflection->invoke($component->instance());
+
+        $this->assertArrayHasKey((string) $available->id, $options);
+        $this->assertArrayNotHasKey((string) $alreadyGranted->id, $options);
+    }
+
+    public function test_grant_picker_sorts_by_locker_bank_then_compartment_number(): void
+    {
+        $admin = $this->admin();
+        $user = User::factory()->create();
+
+        $bankB = LockerBank::factory()->create(['name' => 'Bravo']);
+        $bankA = LockerBank::factory()->create(['name' => 'Alpha']);
+        $bravo2 = Compartment::factory()->for($bankB)->create(['number' => 2]);
+        $bravo1 = Compartment::factory()->for($bankB)->create(['number' => 1]);
+        $alpha1 = Compartment::factory()->for($bankA)->create(['number' => 1]);
+
+        $component = Livewire::actingAs($admin)
+            ->test(CompartmentAccessesRelationManager::class, [
+                'ownerRecord' => $user,
+                'pageClass' => EditUser::class,
+            ]);
+
+        $reflection = new \ReflectionMethod(CompartmentAccessesRelationManager::class, 'grantableCompartmentOptions');
+        $reflection->setAccessible(true);
+        $options = $reflection->invoke($component->instance());
+
+        $this->assertSame([
+            (string) $alpha1->id,
+            (string) $bravo1->id,
+            (string) $bravo2->id,
+        ], array_keys($options));
+    }
+}

--- a/locker-backend/tests/Feature/GroupAccessPickersTest.php
+++ b/locker-backend/tests/Feature/GroupAccessPickersTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\GroupResource\Pages\EditGroup;
+use App\Filament\Resources\GroupResource\RelationManagers\CompartmentAccessesRelationManager;
+use App\Filament\Resources\GroupResource\RelationManagers\MembersRelationManager;
+use App\Models\Compartment;
+use App\Models\Group;
+use App\Models\GroupCompartmentAccess;
+use App\Models\User;
+use App\Services\GroupAccessService;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class GroupAccessPickersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    private function pickerOptions(string $relationManager, string $method, Group $group): array
+    {
+        $component = Livewire::test($relationManager, [
+            'ownerRecord' => $group,
+            'pageClass' => EditGroup::class,
+        ]);
+
+        $reflection = new ReflectionMethod($relationManager, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invoke($component->instance());
+    }
+
+    public function test_compartment_picker_grants_multiple_and_excludes_active_access(): void
+    {
+        $admin = $this->admin();
+        $group = Group::factory()->create();
+        $first = Compartment::factory()->create();
+        $second = Compartment::factory()->create();
+        $alreadyGranted = Compartment::factory()->create();
+
+        app(GroupAccessService::class)->grantCompartmentAccess(
+            group: $group,
+            compartment: $alreadyGranted,
+            actor: $admin,
+        );
+
+        $options = $this->pickerOptions(CompartmentAccessesRelationManager::class, 'grantableCompartmentOptions', $group);
+        $this->assertArrayHasKey((string) $first->id, $options);
+        $this->assertArrayNotHasKey((string) $alreadyGranted->id, $options);
+
+        Livewire::actingAs($admin)
+            ->test(CompartmentAccessesRelationManager::class, [
+                'ownerRecord' => $group,
+                'pageClass' => EditGroup::class,
+            ])
+            ->callAction(TestAction::make('grantAccess')->table(), data: [
+                'compartment_ids' => [(string) $first->id, (string) $second->id],
+            ])
+            ->assertHasNoActionErrors();
+
+        foreach ([$first, $second] as $compartment) {
+            $this->assertTrue(
+                GroupCompartmentAccess::query()
+                    ->where('group_id', $group->id)
+                    ->where('compartment_id', $compartment->id)
+                    ->active()
+                    ->exists()
+            );
+        }
+    }
+
+    public function test_member_picker_adds_multiple_and_excludes_active_members(): void
+    {
+        $admin = $this->admin();
+        $group = Group::factory()->create();
+        $first = User::factory()->create();
+        $second = User::factory()->create();
+        $existingMember = User::factory()->create();
+
+        app(GroupAccessService::class)->addUser(
+            group: $group,
+            user: $existingMember,
+            actor: $admin,
+        );
+
+        $options = $this->pickerOptions(MembersRelationManager::class, 'addableUserOptions', $group);
+        $this->assertArrayHasKey((string) $first->id, $options);
+        $this->assertArrayNotHasKey((string) $existingMember->id, $options);
+
+        Livewire::actingAs($admin)
+            ->test(MembersRelationManager::class, [
+                'ownerRecord' => $group,
+                'pageClass' => EditGroup::class,
+            ])
+            ->callAction(TestAction::make('addMember')->table(), data: [
+                'user_ids' => [(string) $first->id, (string) $second->id],
+            ])
+            ->assertHasNoActionErrors();
+
+        $memberIds = $group->fresh()->members->pluck('id')->all();
+        $this->assertContains($first->id, $memberIds);
+        $this->assertContains($second->id, $memberIds);
+    }
+}


### PR DESCRIPTION
Closes #117.

## What

Improves the admin-panel assignment pickers so granting access is consistent and less tedious. Applies the same four improvements to **all five** assignment relation managers:

- **Multi-select** — assign multiple records in one action (loops the existing service per record)
- **Sorted options** — compartments by locker bank → number; users/groups by name
- **Excludes already-assigned** — drops records the target already has *active* access to
- **Shared label format** — `{bank} / #{number}`, `{name} ({email})`, `{name}`

Pickers touched: User→Compartment, Group→Compartment, Compartment→User, Compartment→Group, Group→Member.

## How

New `App\Filament\Support\AccessPickerOptions` helper centralizes the sort + label logic (the part with real drift/bug risk); each relation manager supplies its own exclusion query and event-sourced grant/add path is unchanged.

## Scope notes

- The issue's checklist covered only the User→Compartment picker; the linked comment asked to also review the other four — done here in one pass.
- Exclusion uses **active individual/group access** only (matches `scopeActive`); expired/revoked access correctly reappears in the picker.
- **Form-component extraction** (from the comment) was considered and deliberately left out: remaining field config is declarative and near-trivial, so a factory adds indirection without meaningfully reducing drift risk.
- No ADR: admin-UI only, no contract/MQTT/Modbus/infra change.

## Tests

3 feature tests (7 cases): multi-grant + exclusion for every picker, plus sort-order for the primary one. Full suite green (234 passing), Pint + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)