### PR TITLE
fix(locker-client): harden MQTT command response recovery

### DIFF
--- a/docs/adr/0032-locker-client-command-response-recovery.md
+++ b/docs/adr/0032-locker-client-command-response-recovery.md
@@ -1,0 +1,149 @@
+# ADR-0032: Recover locker-client command responses
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-27
+
+## Context
+
+The locker client receives transaction-bound commands over MQTT, executes local
+side effects, and publishes a final response. MQTT QoS 1 can redeliver packets,
+and a network interruption can occur after a physical command has completed but
+before its response reaches the broker.
+
+The existing transaction deduplication store records only `in_progress` or
+`completed`. A publish attempted while disconnected currently appears
+successful, completed commands do not retain their response, and duplicate
+commands are silently discarded. A process crash can also leave an
+`in_progress` record indefinitely. Repeating an `open_compartment` command
+after such a crash would be unsafe because the outcome of the first physical
+operation is unknown.
+
+ADR-0002 separates the stable business `transaction_id` from the technical
+`message_id` of an individual MQTT publication. ADR-0014 defines persistent
+MQTT sessions and reconnect behavior, but neither decision provides a durable
+application-level response recovery mechanism. ADR-0030 requires a failed
+change-only snapshot publication to remain eligible for a later retry.
+
+## Decision
+
+1. An MQTT publish must fail when no connected MQTT client can accept the
+   message. A publish callback without an error is the boundary at which the
+   client considers a QoS 1 message accepted by the broker.
+2. Transaction handlers return a semantic `CommandResponseBody`; they do not
+   publish or persist responses themselves.
+3. The command dispatcher stores the complete semantic final response in the
+   existing command record before attempting to publish it. The record is
+   `completed` and pending delivery until the publish succeeds.
+4. A successful publish records a delivery timestamp. A crash between broker
+   acknowledgement and that local update can cause a response to be published
+   again; this is safe because the backend deduplicates by `transaction_id`.
+5. A duplicate completed command never executes its handler again. If its
+   record contains a final response, the dispatcher publishes that response
+   again. Each publication keeps the original `transaction_id` and receives a
+   new `message_id` in accordance with ADR-0002.
+6. On startup, persisted `in_progress` records are treated as commands with an
+   unknown outcome. The dispatcher does not execute their handlers. It replaces
+   each record with a deterministic final error response using the existing
+   `UNKNOWN_ERROR` code and queues that response for delivery.
+7. The MQTT transport exposes a connection callback. Startup and reconnect
+   paths flush pending responses through the dispatcher without polling or
+   application-level reconnect timers.
+8. Flushes are serialized within the process. Repeated reconnect and duplicate
+   events may safely republish a response but cannot repeat the command side
+   effect.
+9. The existing dedup JSON format is extended additively. Legacy completed
+   records without a stored response remain readable and continue to suppress
+   command execution, but no response is invented for them.
+10. Snapshot publication state advances only after a successful publish, so an
+    unchanged snapshot remains eligible after a disconnected publish attempt.
+
+The MQTT payload contract does not change. `UNKNOWN_ERROR` is already a valid
+command response code, and response replays intentionally use new technical
+message identifiers.
+
+## Alternatives Considered
+
+### Store responses in a separate outbox file
+
+- Pros: Separates delivery state from inbound command deduplication.
+- Cons: Creates two persistence sources whose updates must be coordinated.
+- Why not chosen: The command record already owns transaction lifecycle state
+  and can store its final response without cross-file consistency problems.
+
+### Rely only on persistent MQTT sessions and QoS 1
+
+- Pros: Requires no application persistence changes.
+- Cons: Cannot recover a response that was never handed to a connected MQTT
+  client and cannot resolve commands left `in_progress` by a process crash.
+- Why not chosen: Broker sessions do not cover the local execution-to-publish
+  gap.
+
+### Repeat interrupted commands after startup
+
+- Pros: Could complete commands that crashed before reaching the hardware.
+- Cons: Could pulse a physical relay twice when the crash occurred after the
+  hardware operation.
+- Why not chosen: Physical safety takes precedence when the outcome is unknown.
+
+### Add a new interrupted-command error code
+
+- Pros: Makes the recovery condition explicit on the wire.
+- Cons: Changes the shared MQTT contract and requires coordinated rollout.
+- Why not chosen: `UNKNOWN_ERROR` accurately represents the unknown outcome and
+  is already contract compliant.
+
+## Consequences
+
+### Positive
+
+- Completed physical commands are not repeated merely because their response
+  was disconnected or lost.
+- Final responses survive process restarts and are retried on reconnect.
+- Duplicate commands can recover a missing response without repeating side
+  effects.
+- `open_compartment` and `apply_config` share one finalization path.
+- Existing dedup files and MQTT consumers remain compatible.
+
+### Negative
+
+- Command records now retain response data and delivery metadata, increasing
+  the dedup file size.
+- A response can be delivered more than once when the process crashes after
+  broker acknowledgement but before recording delivery.
+- Legacy completed records cannot be replayed because their original responses
+  were never stored.
+
+### Risks
+
+- The current dedup file write strategy is not fully atomic. General atomic
+  persistence remains scoped to issue #168; this change does not introduce a
+  second file or broaden that work.
+- A malformed legacy file can still prevent startup. This decision preserves
+  the existing compatibility behavior rather than introducing a general
+  migration framework.
+- Replayed responses must remain idempotent at the backend. Existing
+  transaction-level response deduplication provides this mitigation.
+
+### Rollout / Migration
+
+- Deploy the updated locker client without changing MQTT topics or schemas.
+- Existing records are loaded additively. Persisted `in_progress` records are
+  finalized as pending `UNKNOWN_ERROR` responses on first startup.
+- Existing completed records without response data continue to block duplicate
+  hardware execution and are otherwise left unchanged.
+- Validate reconnect and restart recovery before production cutover.
+
+## References
+
+- GitHub issue #171
+- GitHub issue #168
+- `docs/adr/0002-mqtt-message-id-and-transaction-id-separation.md`
+- `docs/adr/0014-locker-client-mqtt-session-and-reconnect.md`
+- `docs/adr/0030-batched-door-polling-and-change-only-snapshots.md`
+- `locker-client/src/adapters/mqtt/command-dispatcher.ts`
+- `locker-client/src/adapters/mqtt/dedup-store.ts`

--- a/locker-client/.gitignore
+++ b/locker-client/.gitignore
@@ -10,3 +10,5 @@ coverage/
 /data/
 .mqtt-client-id
 .mqtt-credentials.json
+
+.e2e-171/

--- a/locker-client/src/adapters/mqtt/command-dispatcher.ts
+++ b/locker-client/src/adapters/mqtt/command-dispatcher.ts
@@ -34,6 +34,7 @@ interface ValidatedCommand extends ResolvedCommand {
 export class CommandDispatcher {
   private readonly handlers = new Map<string, InboundCommandHandler<unknown>>();
   private flushInFlight: Promise<void> | null = null;
+  private flushRequested = false;
 
   constructor(
     private readonly guard: InboundProtocolGuard,
@@ -76,11 +77,12 @@ export class CommandDispatcher {
   }
 
   flushPendingResponses(): Promise<void> {
+    this.flushRequested = true;
     if (this.flushInFlight) {
       return this.flushInFlight;
     }
 
-    this.flushInFlight = this.flushPendingResponsesInternal().finally(() => {
+    this.flushInFlight = this.flushPendingResponsesUntilIdle().finally(() => {
       this.flushInFlight = null;
     });
     return this.flushInFlight;
@@ -169,7 +171,7 @@ export class CommandDispatcher {
     const existing = this.dedup.getCommandRecord(transactionId);
     if (existing?.status === 'completed') {
       if (existing.response) {
-        await this.publishFinalResponse(transactionId, existing.response);
+        await this.replayFinalResponse(transactionId, existing.response);
       } else {
         logger.warn('Cannot replay legacy completed command without stored response', {
           action,
@@ -193,7 +195,7 @@ export class CommandDispatcher {
       if (dedupResult === 'duplicate_completed') {
         const existing = this.dedup.getCommandRecord(transactionId);
         if (existing?.response) {
-          await this.publishFinalResponse(transactionId, existing.response);
+          await this.replayFinalResponse(transactionId, existing.response);
         } else {
           logger.warn('Cannot replay legacy completed command without stored response', {
             action,
@@ -249,6 +251,21 @@ export class CommandDispatcher {
     for (const { transactionId, record } of pending) {
       await this.publishFinalResponse(transactionId, record.response!);
     }
+  }
+
+  private async flushPendingResponsesUntilIdle(): Promise<void> {
+    while (this.flushRequested) {
+      this.flushRequested = false;
+      await this.flushPendingResponsesInternal();
+    }
+  }
+
+  private async replayFinalResponse(
+    transactionId: string,
+    response: CommandResponseBody,
+  ): Promise<void> {
+    this.dedup.markCommandResponsePending(transactionId);
+    await this.publishFinalResponse(transactionId, response);
   }
 
   private async publishFinalResponse(

--- a/locker-client/src/adapters/mqtt/command-dispatcher.ts
+++ b/locker-client/src/adapters/mqtt/command-dispatcher.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 import { InboundProtocolGuard } from './inbound-protocol-guard';
-import type { DedupStorePort, OutboundMqttPort } from '../../ports/mqtt.port';
-import { mapErrorToMqttCode } from '../../domain/errors';
+import type { CommandResponseBody, DedupStorePort, OutboundMqttPort } from '../../ports/mqtt.port';
+import { mapErrorToMqttCode, MqttErrorCode } from '../../domain/errors';
 import { formatZodValidationError } from '../../domain/mqtt-parsing';
 import { logger } from '../../infrastructure/logging';
 
@@ -13,15 +13,27 @@ export interface InboundCommandHandler<TPayload> {
   readonly action: string;
   readonly schema: z.ZodType<TPayload>;
   requiresTransactionId(): boolean;
-  handle(context: CommandContext, payload: TPayload): Promise<void>;
+  handle(context: CommandContext, payload: TPayload): Promise<CommandResponseBody>;
 }
 
 interface TransactionCommandPayload {
   transaction_id: string;
 }
 
+interface ResolvedCommand {
+  action: string;
+  handler: InboundCommandHandler<unknown>;
+  payload: Record<string, unknown>;
+}
+
+interface ValidatedCommand extends ResolvedCommand {
+  data: unknown;
+  transactionId: string;
+}
+
 export class CommandDispatcher {
   private readonly handlers = new Map<string, InboundCommandHandler<unknown>>();
+  private flushInFlight: Promise<void> | null = null;
 
   constructor(
     private readonly guard: InboundProtocolGuard,
@@ -34,26 +46,75 @@ export class CommandDispatcher {
   }
 
   async dispatch(topic: string, rawMessage: string): Promise<void> {
+    const resolved = this.parseAndResolveHandler(topic, rawMessage);
+    if (!resolved) {
+      return;
+    }
+
+    const command = await this.validateCommand(topic, resolved);
+    if (!command || (await this.handleDuplicateCommand(command))) {
+      return;
+    }
+
+    const response = await this.executeCommand(topic, command);
+    await this.finalizeCommand(command, response);
+  }
+
+  recoverInterruptedCommands(): void {
+    for (const { transactionId, record } of this.dedup.listCommandRecords()) {
+      if (record.status !== 'in_progress') {
+        continue;
+      }
+      this.dedup.markCommandCompleted(transactionId, record.action, {
+        action: record.action,
+        result: 'error',
+        transaction_id: transactionId,
+        error_code: MqttErrorCode.UNKNOWN_ERROR,
+        message: 'Command outcome is unknown after locker-client restart.',
+      });
+    }
+  }
+
+  flushPendingResponses(): Promise<void> {
+    if (this.flushInFlight) {
+      return this.flushInFlight;
+    }
+
+    this.flushInFlight = this.flushPendingResponsesInternal().finally(() => {
+      this.flushInFlight = null;
+    });
+    return this.flushInFlight;
+  }
+
+  private parseAndResolveHandler(topic: string, rawMessage: string): ResolvedCommand | null {
     let payload: Record<string, unknown>;
     try {
       payload = JSON.parse(rawMessage) as Record<string, unknown>;
     } catch {
       logger.warn('Dropped inbound MQTT command with invalid JSON', { topic });
-      return;
+      return null;
     }
 
     const action = payload.action;
     if (typeof action !== 'string') {
       logger.warn('Dropped inbound MQTT command without action', { topic });
-      return;
+      return null;
     }
 
     const handler = this.handlers.get(action);
     if (!handler) {
       logger.warn('Dropped inbound MQTT command with unknown action', { topic, action });
-      return;
+      return null;
     }
 
+    return { action, handler, payload };
+  }
+
+  private async validateCommand(
+    topic: string,
+    command: ResolvedCommand,
+  ): Promise<ValidatedCommand | null> {
+    const { action, handler, payload } = command;
     const guardResult = this.guard.allow(payload, {
       requiresTransactionId: handler.requiresTransactionId(),
     });
@@ -63,7 +124,7 @@ export class CommandDispatcher {
         action,
         reason: guardResult.reason,
       });
-      return;
+      return null;
     }
 
     const parsed = handler.schema.safeParse(payload);
@@ -73,45 +134,135 @@ export class CommandDispatcher {
         action,
         validationErrors: formatZodValidationError(parsed.error),
       });
-      await this.outbound.publishCommandResponse({
-        action,
-        result: 'error',
-        transaction_id:
-          typeof payload.transaction_id === 'string' ? payload.transaction_id : 'unknown',
-        error_code: 'INVALID_COMMAND',
-        message: 'Command validation failed',
-      });
+      await this.handleInvalidCommand(action, payload);
+      return null;
+    }
+
+    return {
+      ...command,
+      data: parsed.data,
+      transactionId: (parsed.data as TransactionCommandPayload).transaction_id,
+    };
+  }
+
+  private async handleInvalidCommand(
+    action: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const transactionId =
+      typeof payload.transaction_id === 'string' && payload.transaction_id.trim() !== ''
+        ? payload.transaction_id
+        : null;
+    const response: CommandResponseBody = {
+      action,
+      result: 'error',
+      transaction_id: transactionId ?? 'unknown',
+      error_code: MqttErrorCode.INVALID_COMMAND,
+      message: 'Command validation failed',
+    };
+
+    if (!transactionId) {
+      await this.outbound.publishCommandResponse(response);
       return;
     }
 
-    const lockerUuid = extractLockerUuid(topic);
-    const command = parsed.data as TransactionCommandPayload;
+    const existing = this.dedup.getCommandRecord(transactionId);
+    if (existing?.status === 'completed') {
+      if (existing.response) {
+        await this.publishFinalResponse(transactionId, existing.response);
+      } else {
+        logger.warn('Cannot replay legacy completed command without stored response', {
+          action,
+          transactionId,
+        });
+      }
+      return;
+    }
+    if (existing?.status === 'in_progress') {
+      return;
+    }
 
+    this.dedup.markCommandCompleted(transactionId, action, response);
+    await this.publishFinalResponse(transactionId, response);
+  }
+
+  private async handleDuplicateCommand(command: ValidatedCommand): Promise<boolean> {
+    const { action, handler, transactionId } = command;
     if (handler.requiresTransactionId()) {
-      const dedupResult = await this.guardTransactionExecution(action, command.transaction_id);
+      const dedupResult = await this.guardTransactionExecution(action, transactionId);
       if (dedupResult === 'duplicate_completed') {
-        return;
+        const existing = this.dedup.getCommandRecord(transactionId);
+        if (existing?.response) {
+          await this.publishFinalResponse(transactionId, existing.response);
+        } else {
+          logger.warn('Cannot replay legacy completed command without stored response', {
+            action,
+            transactionId,
+          });
+        }
+        return true;
       }
       if (dedupResult === 'duplicate_in_progress') {
-        return;
+        return true;
       }
     }
 
+    return false;
+  }
+
+  private async executeCommand(
+    topic: string,
+    command: ValidatedCommand,
+  ): Promise<CommandResponseBody> {
+    const { action, handler, data, transactionId } = command;
     try {
-      await handler.handle({ lockerUuid }, parsed.data);
-      if (handler.requiresTransactionId()) {
-        this.dedup.markCommandCompleted(command.transaction_id, action);
-      }
+      return await handler.handle({ lockerUuid: extractLockerUuid(topic) }, data);
     } catch (error) {
-      if (handler.requiresTransactionId()) {
-        this.dedup.markCommandCompleted(command.transaction_id, action);
-      }
-      await this.outbound.publishCommandResponse({
+      return {
         action,
         result: 'error',
-        transaction_id: command.transaction_id,
+        transaction_id: transactionId,
         error_code: mapErrorToMqttCode(error),
         message: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async finalizeCommand(
+    command: ValidatedCommand,
+    response: CommandResponseBody,
+  ): Promise<void> {
+    const { action, handler, transactionId } = command;
+    if (handler.requiresTransactionId()) {
+      this.dedup.markCommandCompleted(transactionId, action, response);
+    }
+    await this.publishFinalResponse(transactionId, response);
+  }
+
+  private async flushPendingResponsesInternal(): Promise<void> {
+    const pending = this.dedup
+      .listCommandRecords()
+      .filter(
+        ({ record }) =>
+          record.status === 'completed' && record.response && !record.responseDeliveredAt,
+      );
+    for (const { transactionId, record } of pending) {
+      await this.publishFinalResponse(transactionId, record.response!);
+    }
+  }
+
+  private async publishFinalResponse(
+    transactionId: string,
+    response: CommandResponseBody,
+  ): Promise<void> {
+    try {
+      await this.outbound.publishCommandResponse(response);
+      this.dedup.markCommandResponseDelivered(transactionId);
+    } catch (error) {
+      logger.warn('MQTT command response remains pending', {
+        action: response.action,
+        transactionId,
+        error: error instanceof Error ? error.message : 'Unknown publish error',
       });
     }
   }

--- a/locker-client/src/adapters/mqtt/dedup-store.ts
+++ b/locker-client/src/adapters/mqtt/dedup-store.ts
@@ -1,14 +1,6 @@
 import fs from 'fs';
-import type { DedupStorePort } from '../../ports/mqtt.port';
+import type { CommandRecord, CommandResponseBody, DedupStorePort } from '../../ports/mqtt.port';
 import { MQTT_DEDUP_STATE_FILE } from '../../infrastructure/paths';
-
-type CommandStatus = 'in_progress' | 'completed';
-
-interface CommandRecord {
-  action: string;
-  status: CommandStatus;
-  updatedAt: string;
-}
 
 interface DedupState {
   seenMessageIds: Record<string, string>;
@@ -17,6 +9,8 @@ interface DedupState {
 
 export class FileDedupStore implements DedupStorePort {
   private state: DedupState | null = null;
+
+  constructor(private readonly filePath: string = MQTT_DEDUP_STATE_FILE) {}
 
   hasSeenMessageId(messageId: string): boolean {
     const state = this.loadState();
@@ -34,6 +28,13 @@ export class FileDedupStore implements DedupStorePort {
     return state.commandRecords[transactionId] ?? null;
   }
 
+  listCommandRecords(): Array<{ transactionId: string; record: CommandRecord }> {
+    return Object.entries(this.loadState().commandRecords).map(([transactionId, record]) => ({
+      transactionId,
+      record,
+    }));
+  }
+
   markCommandInProgress(transactionId: string, action: string): void {
     const state = this.loadState();
     state.commandRecords[transactionId] = {
@@ -44,13 +45,25 @@ export class FileDedupStore implements DedupStorePort {
     this.saveState(state);
   }
 
-  markCommandCompleted(transactionId: string, action: string): void {
+  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void {
     const state = this.loadState();
     state.commandRecords[transactionId] = {
       action,
       status: 'completed',
       updatedAt: new Date().toISOString(),
+      response,
     };
+    this.saveState(state);
+  }
+
+  markCommandResponseDelivered(transactionId: string): void {
+    const state = this.loadState();
+    const record = state.commandRecords[transactionId];
+    if (!record || record.status !== 'completed' || !record.response) {
+      return;
+    }
+    record.responseDeliveredAt = new Date().toISOString();
+    record.updatedAt = record.responseDeliveredAt;
     this.saveState(state);
   }
 
@@ -60,14 +73,12 @@ export class FileDedupStore implements DedupStorePort {
     }
 
     const empty: DedupState = { seenMessageIds: {}, commandRecords: {} };
-    if (!fs.existsSync(MQTT_DEDUP_STATE_FILE)) {
+    if (!fs.existsSync(this.filePath)) {
       this.state = empty;
       return empty;
     }
 
-    const parsed = JSON.parse(
-      fs.readFileSync(MQTT_DEDUP_STATE_FILE, 'utf8'),
-    ) as Partial<DedupState>;
+    const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as Partial<DedupState>;
     this.state = {
       seenMessageIds: parsed.seenMessageIds ?? {},
       commandRecords: parsed.commandRecords ?? {},
@@ -77,7 +88,7 @@ export class FileDedupStore implements DedupStorePort {
 
   private saveState(state: DedupState): void {
     this.state = state;
-    fs.writeFileSync(MQTT_DEDUP_STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
+    fs.writeFileSync(this.filePath, JSON.stringify(state, null, 2), 'utf8');
   }
 }
 
@@ -97,6 +108,13 @@ export class InMemoryDedupStore implements DedupStorePort {
     return this.commandRecords.get(transactionId) ?? null;
   }
 
+  listCommandRecords(): Array<{ transactionId: string; record: CommandRecord }> {
+    return Array.from(this.commandRecords, ([transactionId, record]) => ({
+      transactionId,
+      record,
+    }));
+  }
+
   markCommandInProgress(transactionId: string, action: string): void {
     this.commandRecords.set(transactionId, {
       action,
@@ -105,11 +123,25 @@ export class InMemoryDedupStore implements DedupStorePort {
     });
   }
 
-  markCommandCompleted(transactionId: string, action: string): void {
+  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void {
     this.commandRecords.set(transactionId, {
       action,
       status: 'completed',
       updatedAt: new Date().toISOString(),
+      response,
+    });
+  }
+
+  markCommandResponseDelivered(transactionId: string): void {
+    const record = this.commandRecords.get(transactionId);
+    if (!record || record.status !== 'completed' || !record.response) {
+      return;
+    }
+    const deliveredAt = new Date().toISOString();
+    this.commandRecords.set(transactionId, {
+      ...record,
+      updatedAt: deliveredAt,
+      responseDeliveredAt: deliveredAt,
     });
   }
 }

--- a/locker-client/src/adapters/mqtt/dedup-store.ts
+++ b/locker-client/src/adapters/mqtt/dedup-store.ts
@@ -19,8 +19,13 @@ export class FileDedupStore implements DedupStorePort {
 
   rememberMessageId(messageId: string): void {
     const state = this.loadState();
-    state.seenMessageIds[messageId] = new Date().toISOString();
-    this.saveState(state);
+    this.saveState({
+      ...state,
+      seenMessageIds: {
+        ...state.seenMessageIds,
+        [messageId]: new Date().toISOString(),
+      },
+    });
   }
 
   getCommandRecord(transactionId: string): CommandRecord | null {
@@ -37,23 +42,58 @@ export class FileDedupStore implements DedupStorePort {
 
   markCommandInProgress(transactionId: string, action: string): void {
     const state = this.loadState();
-    state.commandRecords[transactionId] = {
-      action,
-      status: 'in_progress',
-      updatedAt: new Date().toISOString(),
-    };
-    this.saveState(state);
+    this.saveState({
+      ...state,
+      commandRecords: {
+        ...state.commandRecords,
+        [transactionId]: {
+          action,
+          status: 'in_progress',
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
   }
 
   markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void {
     const state = this.loadState();
-    state.commandRecords[transactionId] = {
-      action,
-      status: 'completed',
-      updatedAt: new Date().toISOString(),
-      response,
-    };
-    this.saveState(state);
+    this.saveState({
+      ...state,
+      commandRecords: {
+        ...state.commandRecords,
+        [transactionId]: {
+          action,
+          status: 'completed',
+          updatedAt: new Date().toISOString(),
+          response,
+        },
+      },
+    });
+  }
+
+  markCommandResponsePending(transactionId: string): void {
+    const state = this.loadState();
+    const record = state.commandRecords[transactionId];
+    if (
+      !record ||
+      record.status !== 'completed' ||
+      !record.response ||
+      !record.responseDeliveredAt
+    ) {
+      return;
+    }
+    const pendingRecord = { ...record };
+    delete pendingRecord.responseDeliveredAt;
+    this.saveState({
+      ...state,
+      commandRecords: {
+        ...state.commandRecords,
+        [transactionId]: {
+          ...pendingRecord,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
   }
 
   markCommandResponseDelivered(transactionId: string): void {
@@ -62,9 +102,18 @@ export class FileDedupStore implements DedupStorePort {
     if (!record || record.status !== 'completed' || !record.response) {
       return;
     }
-    record.responseDeliveredAt = new Date().toISOString();
-    record.updatedAt = record.responseDeliveredAt;
-    this.saveState(state);
+    const deliveredAt = new Date().toISOString();
+    this.saveState({
+      ...state,
+      commandRecords: {
+        ...state.commandRecords,
+        [transactionId]: {
+          ...record,
+          updatedAt: deliveredAt,
+          responseDeliveredAt: deliveredAt,
+        },
+      },
+    });
   }
 
   private loadState(): DedupState {
@@ -87,8 +136,8 @@ export class FileDedupStore implements DedupStorePort {
   }
 
   private saveState(state: DedupState): void {
-    this.state = state;
     fs.writeFileSync(this.filePath, JSON.stringify(state, null, 2), 'utf8');
+    this.state = state;
   }
 }
 
@@ -129,6 +178,24 @@ export class InMemoryDedupStore implements DedupStorePort {
       status: 'completed',
       updatedAt: new Date().toISOString(),
       response,
+    });
+  }
+
+  markCommandResponsePending(transactionId: string): void {
+    const record = this.commandRecords.get(transactionId);
+    if (
+      !record ||
+      record.status !== 'completed' ||
+      !record.response ||
+      !record.responseDeliveredAt
+    ) {
+      return;
+    }
+    const pendingRecord = { ...record };
+    delete pendingRecord.responseDeliveredAt;
+    this.commandRecords.set(transactionId, {
+      ...pendingRecord,
+      updatedAt: new Date().toISOString(),
     });
   }
 

--- a/locker-client/src/adapters/mqtt/handlers/apply-config.handler.ts
+++ b/locker-client/src/adapters/mqtt/handlers/apply-config.handler.ts
@@ -1,11 +1,9 @@
 import type { CommandContext, InboundCommandHandler } from '../command-dispatcher';
 import { applyConfigCommandSchema, type ApplyConfigCommand } from '../../../domain/mqtt-schemas';
 import type { ApplyConfigUseCase } from '../../../application/apply-config';
-import type { OutboundMqttPort } from '../../../ports/mqtt.port';
 
 export function createApplyConfigHandler(deps: {
   applyConfig: ApplyConfigUseCase;
-  outbound: OutboundMqttPort;
 }): InboundCommandHandler<ApplyConfigCommand> {
   return {
     action: 'apply_config',
@@ -14,13 +12,13 @@ export function createApplyConfigHandler(deps: {
     async handle(_ctx: CommandContext, command: ApplyConfigCommand) {
       const result = await deps.applyConfig.execute(command);
 
-      await deps.outbound.publishCommandResponse({
+      return {
         action: command.action,
         result: 'success',
         transaction_id: command.transaction_id,
         applied_config_hash: result.appliedConfigHash,
         message: result.message,
-      });
+      };
     },
   };
 }

--- a/locker-client/src/adapters/mqtt/handlers/open-compartment.handler.ts
+++ b/locker-client/src/adapters/mqtt/handlers/open-compartment.handler.ts
@@ -4,12 +4,10 @@ import {
   type OpenCompartmentCommand,
 } from '../../../domain/mqtt-schemas';
 import type { OpenCompartmentUseCase } from '../../../application/open-compartment';
-import type { OutboundMqttPort } from '../../../ports/mqtt.port';
 import type { PollCompartmentStateUseCase } from '../../../application/state-publishing';
 
 export function createOpenCompartmentHandler(deps: {
   openCompartment: OpenCompartmentUseCase;
-  outbound: OutboundMqttPort;
   pollSnapshot: PollCompartmentStateUseCase;
 }): InboundCommandHandler<OpenCompartmentCommand> {
   return {
@@ -20,12 +18,12 @@ export function createOpenCompartmentHandler(deps: {
       await deps.openCompartment.execute(command.data.compartment_number);
       await deps.pollSnapshot.pollAndPublish(true);
 
-      await deps.outbound.publishCommandResponse({
+      return {
         action: command.action,
         result: 'success',
         transaction_id: command.transaction_id,
         message: 'Compartment opened.',
-      });
+      };
     },
   };
 }

--- a/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
+++ b/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
@@ -15,6 +15,7 @@ export class MqttTransportAdapter implements MessageTransportPort {
   private reconnectAttempts = 0;
   private connectInFlight: Promise<void> | null = null;
   private messageHandler: ((topic: string, payload: Buffer) => void) | null = null;
+  private readonly connectedHandlers: Array<() => void | Promise<void>> = [];
   private readonly transport: MqttTransportSettings;
 
   constructor(transport: MqttTransportSettings) {
@@ -79,15 +80,7 @@ export class MqttTransportAdapter implements MessageTransportPort {
     payload: string,
     options: OutboundPublishOptions = {},
   ): Promise<void> {
-    if (!this.client?.connected) {
-      logger.warn('MQTT publish skipped while disconnected', {
-        topic,
-        connectionState: this.connectionState,
-      });
-      return;
-    }
-
-    const client = this.client;
+    const client = this.requireClient();
     return new Promise((resolve, reject) => {
       client.publish(
         topic,
@@ -109,6 +102,10 @@ export class MqttTransportAdapter implements MessageTransportPort {
     if (this.client) {
       this.client.on('message', handler);
     }
+  }
+
+  onConnected(handler: () => void | Promise<void>): void {
+    this.connectedHandlers.push(handler);
   }
 
   private connectInternal(brokerUrl: string, options: Record<string, unknown>): Promise<void> {
@@ -137,6 +134,7 @@ export class MqttTransportAdapter implements MessageTransportPort {
         this.connectionState = 'connected';
         initialConnectSettled = true;
         resolve();
+        this.notifyConnected();
       });
 
       this.client.on('error', (error) => {
@@ -176,6 +174,16 @@ export class MqttTransportAdapter implements MessageTransportPort {
         this.connectionState = 'reconnecting';
       });
     });
+  }
+
+  private notifyConnected(): void {
+    for (const handler of this.connectedHandlers) {
+      Promise.resolve(handler()).catch((error: unknown) => {
+        logger.warn('MQTT connected handler failed', {
+          error: error instanceof Error ? error.message : 'Unknown connected handler error',
+        });
+      });
+    }
   }
 
   private requireClient(): MqttClient {

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -138,16 +138,16 @@ export async function createApp(): Promise<AppContext> {
   dispatcher.register(
     createOpenCompartmentHandler({
       openCompartment,
-      outbound,
       pollSnapshot,
     }),
   );
-  dispatcher.register(createApplyConfigHandler({ applyConfig, outbound }));
+  dispatcher.register(createApplyConfigHandler({ applyConfig }));
+  dispatcher.recoverInterruptedCommands();
+  transport.onConnected(() => dispatcher.flushPendingResponses());
+  await dispatcher.flushPendingResponses();
 
   transport.onMessage((topic, payload) => {
-    if (topic === commandTopic) {
-      void dispatcher.dispatch(topic, payload.toString());
-    }
+    dispatchMqttMessage(dispatcher, commandTopic, topic, payload);
   });
 
   await transport.subscribe(commandTopic);
@@ -171,6 +171,28 @@ export async function createApp(): Promise<AppContext> {
       await transport.disconnect();
     },
   };
+}
+
+interface DispatchErrorLogger {
+  error(message: string, metadata?: Record<string, unknown>): unknown;
+}
+
+export function dispatchMqttMessage(
+  dispatcher: Pick<CommandDispatcher, 'dispatch'>,
+  commandTopic: string,
+  topic: string,
+  payload: Buffer,
+  log: DispatchErrorLogger = logger,
+): void {
+  if (topic !== commandTopic) {
+    return;
+  }
+
+  void dispatcher.dispatch(topic, payload.toString()).catch((error: unknown) => {
+    log.error('Unexpected MQTT command dispatch failure', {
+      error: error instanceof Error ? error.message : 'Unknown dispatch error',
+    });
+  });
 }
 
 function sleep(ms: number): Promise<void> {

--- a/locker-client/src/ports/mqtt.port.ts
+++ b/locker-client/src/ports/mqtt.port.ts
@@ -29,6 +29,7 @@ export interface MessageTransportPort {
   subscribe(topic: string): Promise<void>;
   publish(topic: string, payload: string, options?: OutboundPublishOptions): Promise<void>;
   onMessage(handler: (topic: string, payload: Buffer) => void): void;
+  onConnected(handler: () => void | Promise<void>): void;
   getConnectionState(): MqttConnectionState;
   getTransportSettings(): MqttTransportSettings;
 }
@@ -41,12 +42,20 @@ export interface MqttTransportSettings {
   maxReconnectAttempts: number;
 }
 
+export interface CommandRecord {
+  action: string;
+  status: 'in_progress' | 'completed';
+  updatedAt: string;
+  response?: CommandResponseBody;
+  responseDeliveredAt?: string;
+}
+
 export interface DedupStorePort {
   hasSeenMessageId(messageId: string): boolean;
   rememberMessageId(messageId: string): void;
-  getCommandRecord(
-    transactionId: string,
-  ): { action: string; status: 'in_progress' | 'completed' } | null;
+  getCommandRecord(transactionId: string): CommandRecord | null;
+  listCommandRecords(): Array<{ transactionId: string; record: CommandRecord }>;
   markCommandInProgress(transactionId: string, action: string): void;
-  markCommandCompleted(transactionId: string, action: string): void;
+  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void;
+  markCommandResponseDelivered(transactionId: string): void;
 }

--- a/locker-client/src/ports/mqtt.port.ts
+++ b/locker-client/src/ports/mqtt.port.ts
@@ -57,5 +57,6 @@ export interface DedupStorePort {
   listCommandRecords(): Array<{ transactionId: string; record: CommandRecord }>;
   markCommandInProgress(transactionId: string, action: string): void;
   markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void;
+  markCommandResponsePending(transactionId: string): void;
   markCommandResponseDelivered(transactionId: string): void;
 }

--- a/locker-client/tests/application/state-publishing.test.ts
+++ b/locker-client/tests/application/state-publishing.test.ts
@@ -100,15 +100,16 @@ test('publishes initial unknown immediately when no known state exists', async (
   assert.equal(outbound.snapshots[0]?.compartments[0]?.door_state, 'unknown');
 });
 
-test('retries an unchanged snapshot after a failed publish', async () => {
+test('retries an unchanged snapshot after disconnect and reconnect', async () => {
   const bus = new FakeLockerBus([1]);
   const outbound = new RecordingOutbound();
-  outbound.failNextPublish = true;
+  outbound.connected = false;
   const poll = createPoll(bus, outbound);
 
   await poll.pollAndPublish();
   assert.equal(outbound.snapshots.length, 0);
 
+  outbound.connected = true;
   await poll.pollAndPublish();
   assert.equal(outbound.snapshots.length, 1);
 });
@@ -277,6 +278,7 @@ function queueNestedMicrotask(depth: number, callback: () => void): void {
 
 class RecordingOutbound implements OutboundMqttPort {
   failNextPublish = false;
+  connected = true;
   afterPublish: (() => void) | undefined;
   readonly snapshots: Array<{
     topic: string;
@@ -289,7 +291,7 @@ class RecordingOutbound implements OutboundMqttPort {
     body: Record<string, unknown>,
     options?: OutboundPublishOptions,
   ): Promise<void> {
-    if (this.failNextPublish) {
+    if (!this.connected || this.failNextPublish) {
       this.failNextPublish = false;
       throw new Error('MQTT unavailable');
     }

--- a/locker-client/tests/contract/mqttImplementationContract.test.ts
+++ b/locker-client/tests/contract/mqttImplementationContract.test.ts
@@ -46,9 +46,9 @@ test('handler-built open_compartment success matches AsyncAPI schema', async () 
     outbound,
     'locker/test/state/compartments',
   );
-  const handler = createOpenCompartmentHandler({ openCompartment, outbound, pollSnapshot });
+  const handler = createOpenCompartmentHandler({ openCompartment, pollSnapshot });
 
-  await handler.handle(
+  const responseBody = await handler.handle(
     { lockerUuid: 'test' },
     {
       action: 'open_compartment',
@@ -58,6 +58,7 @@ test('handler-built open_compartment success matches AsyncAPI schema', async () 
       data: { compartment_number: 1 },
     },
   );
+  await outbound.publishCommandResponse(responseBody);
 
   openCompartment.stopAllMonitoring();
 
@@ -86,9 +87,9 @@ test('handler-built apply_config success matches AsyncAPI schema', async () => {
     restartHeartbeat: () => undefined,
     restartPolling: () => undefined,
   });
-  const handler = createApplyConfigHandler({ applyConfig, outbound });
+  const handler = createApplyConfigHandler({ applyConfig });
 
-  await handler.handle(
+  const responseBody = await handler.handle(
     { lockerUuid: 'test' },
     {
       action: 'apply_config',
@@ -102,6 +103,7 @@ test('handler-built apply_config success matches AsyncAPI schema', async () => {
       },
     },
   );
+  await outbound.publishCommandResponse(responseBody);
 
   const response = published
     .map(parsePublishedPayload)
@@ -130,7 +132,7 @@ test('dispatcher-built validation error matches AsyncAPI schema', async () => {
   );
   const dedup = new InMemoryDedupStore();
   const dispatcher = new CommandDispatcher(new InboundProtocolGuard(dedup), outbound, dedup);
-  dispatcher.register(createOpenCompartmentHandler({ openCompartment, outbound, pollSnapshot }));
+  dispatcher.register(createOpenCompartmentHandler({ openCompartment, pollSnapshot }));
 
   await dispatcher.dispatch(
     'locker/test/command',
@@ -174,7 +176,7 @@ test('dispatcher-built handler error matches AsyncAPI schema', async () => {
   );
   const dedup = new InMemoryDedupStore();
   const dispatcher = new CommandDispatcher(new InboundProtocolGuard(dedup), outbound, dedup);
-  dispatcher.register(createOpenCompartmentHandler({ openCompartment, outbound, pollSnapshot }));
+  dispatcher.register(createOpenCompartmentHandler({ openCompartment, pollSnapshot }));
 
   await dispatcher.dispatch(
     'locker/test/command',

--- a/locker-client/tests/handlers/apply-config.handler.test.ts
+++ b/locker-client/tests/handlers/apply-config.handler.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createApplyConfigHandler } from '../../src/adapters/mqtt/handlers/apply-config.handler';
 import { ApplyConfigUseCase } from '../../src/application/apply-config';
-import { OutboundMqttAdapter } from '../../src/adapters/mqtt/outbound-mqtt.adapter';
 import { computeAppliedConfigHash } from '../../src/domain/config-normalization';
 import { FakeLockerBus } from '../helpers/fake-locker-bus';
 import { MemoryOverlayStore } from '../helpers/memory-overlay-store';
@@ -15,15 +14,6 @@ function createApplyConfigHarness() {
   const overlayStore = new MemoryOverlayStore();
   const config = createTestConfigRepository({ compartments });
 
-  const published: string[] = [];
-  const outbound = new OutboundMqttAdapter(
-    async (_topic, payload) => {
-      published.push(payload);
-    },
-    'locker/test/response',
-    () => '2026-06-16T12:00:00.000Z',
-  );
-
   const applyConfig = new ApplyConfigUseCase({
     overlayStore,
     config,
@@ -32,16 +22,16 @@ function createApplyConfigHarness() {
     restartPolling: () => undefined,
   });
 
-  const handler = createApplyConfigHandler({ applyConfig, outbound });
+  const handler = createApplyConfigHandler({ applyConfig });
 
-  return { handler, published, overlayStore };
+  return { handler, overlayStore };
 }
 
-test('apply_config handler publishes success with applied_config_hash', async () => {
-  const { handler, published, overlayStore } = createApplyConfigHarness();
+test('apply_config handler returns success with applied_config_hash', async () => {
+  const { handler, overlayStore } = createApplyConfigHarness();
   const configHash = computeAppliedConfigHash(compartments);
 
-  await handler.handle(
+  const response = await handler.handle(
     { lockerUuid: 'test' },
     {
       action: 'apply_config',
@@ -57,12 +47,6 @@ test('apply_config handler publishes success with applied_config_hash', async ()
   );
 
   assert.ok(overlayStore.load()?.appliedConfigHash);
-  assert.equal(published.length, 1);
-  const response = JSON.parse(published[0]!) as {
-    action: string;
-    result: string;
-    applied_config_hash: string;
-  };
   assert.equal(response.action, 'apply_config');
   assert.equal(response.result, 'success');
   assert.equal(response.applied_config_hash, configHash);
@@ -83,7 +67,6 @@ test('apply_config handler propagates runtime apply failures', async () => {
       restartHeartbeat: () => undefined,
       restartPolling: () => undefined,
     }),
-    outbound: new OutboundMqttAdapter(async () => undefined, 'locker/test/response'),
   });
 
   await assert.rejects(

--- a/locker-client/tests/handlers/open-compartment.handler.test.ts
+++ b/locker-client/tests/handlers/open-compartment.handler.test.ts
@@ -8,7 +8,7 @@ import { PollCompartmentStateUseCase } from '../../src/application/state-publish
 import { RunAfterCompleteScheduler } from '../../src/infrastructure/scheduler';
 import { createTestConfigRepository } from '../helpers/test-config-repository';
 
-test('open compartment handler responds success and preserves transaction_id', async () => {
+test('open compartment handler returns success and preserves transaction_id', async () => {
   const bus = new FakeLockerBus([1]);
   const published: string[] = [];
   const outbound = new OutboundMqttAdapter(
@@ -31,11 +31,10 @@ test('open compartment handler responds success and preserves transaction_id', a
   );
   const handler = createOpenCompartmentHandler({
     openCompartment,
-    outbound,
     pollSnapshot,
   });
 
-  await handler.handle(
+  const response = await handler.handle(
     { lockerUuid: 'test' },
     {
       action: 'open_compartment',
@@ -48,18 +47,13 @@ test('open compartment handler responds success and preserves transaction_id', a
 
   openCompartment.stopAllMonitoring();
   assert.equal(bus.flashCalls.length, 1);
-  const responsePayload = published
-    .map((payload) => JSON.parse(payload) as { result?: string })
-    .find((message) => message.result === 'success');
-  assert.ok(responsePayload);
-  const response = responsePayload as {
-    result: string;
-    transaction_id: string;
-    message_id: string;
-    timestamp: string;
-  };
   assert.equal(response.result, 'success');
   assert.equal(response.transaction_id, 'tx-abc');
-  assert.equal(typeof response.message_id, 'string');
-  assert.equal(response.timestamp, '2026-06-16T12:00:00.000Z');
+  assert.equal(response.message, 'Compartment opened.');
+  assert.equal(
+    published
+      .map((payload) => JSON.parse(payload) as { compartments?: unknown[] })
+      .filter((payload) => payload.compartments).length,
+    1,
+  );
 });

--- a/locker-client/tests/helpers/fake-mqtt-transport.ts
+++ b/locker-client/tests/helpers/fake-mqtt-transport.ts
@@ -10,6 +10,7 @@ export class FakeMqttTransport implements MessageTransportPort {
   readonly subscriptions: string[] = [];
   private state: MqttConnectionState = 'disconnected';
   private messageHandler: ((topic: string, payload: Buffer) => void) | null = null;
+  private readonly connectedHandlers: Array<() => void | Promise<void>> = [];
   private readonly transport: MqttTransportSettings;
 
   constructor(
@@ -45,8 +46,9 @@ export class FakeMqttTransport implements MessageTransportPort {
     this.state = 'reconnecting';
   }
 
-  simulateBrokerRestore(): void {
+  async simulateBrokerRestore(): Promise<void> {
     this.state = 'connected';
+    await Promise.all(this.connectedHandlers.map((handler) => handler()));
   }
 
   async subscribe(topic: string): Promise<void> {
@@ -54,11 +56,18 @@ export class FakeMqttTransport implements MessageTransportPort {
   }
 
   async publish(topic: string, payload: string, _options?: OutboundPublishOptions): Promise<void> {
+    if (this.state !== 'connected') {
+      throw new Error('MQTT client is not connected');
+    }
     this.published.push({ topic, payload });
   }
 
   onMessage(handler: (topic: string, payload: Buffer) => void): void {
     this.messageHandler = handler;
+  }
+
+  onConnected(handler: () => void | Promise<void>): void {
+    this.connectedHandlers.push(handler);
   }
 
   emitMessage(topic: string, payload: Record<string, unknown>): void {

--- a/locker-client/tests/unit/command-dispatcher.test.ts
+++ b/locker-client/tests/unit/command-dispatcher.test.ts
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { test } from 'node:test';
 import { CommandDispatcher } from '../../src/adapters/mqtt/command-dispatcher';
 import { InboundProtocolGuard } from '../../src/adapters/mqtt/inbound-protocol-guard';
-import { InMemoryDedupStore } from '../../src/adapters/mqtt/dedup-store';
+import { FileDedupStore, InMemoryDedupStore } from '../../src/adapters/mqtt/dedup-store';
 import { OutboundMqttAdapter } from '../../src/adapters/mqtt/outbound-mqtt.adapter';
 import { createOpenCompartmentHandler } from '../../src/adapters/mqtt/handlers/open-compartment.handler';
 import { createApplyConfigHandler } from '../../src/adapters/mqtt/handlers/apply-config.handler';
@@ -12,9 +15,11 @@ import { PollCompartmentStateUseCase } from '../../src/application/state-publish
 import { RunAfterCompleteScheduler } from '../../src/infrastructure/scheduler';
 import { computeAppliedConfigHash } from '../../src/domain/config-normalization';
 import { FakeLockerBus } from '../helpers/fake-locker-bus';
+import { FakeMqttTransport } from '../helpers/fake-mqtt-transport';
 import { MemoryOverlayStore } from '../helpers/memory-overlay-store';
 import { createTestConfigRepository } from '../helpers/test-config-repository';
 import type { ConfigRepositoryPort } from '../../src/ports/config.port';
+import type { DedupStorePort } from '../../src/ports/mqtt.port';
 
 const configStub: ConfigRepositoryPort = {
   load: () => ({
@@ -38,11 +43,17 @@ const configStub: ConfigRepositoryPort = {
   }),
 };
 
-function createDispatcherHarness(bus = new FakeLockerBus([1])) {
-  const dedup = new InMemoryDedupStore();
+function createDispatcherHarness(
+  bus = new FakeLockerBus([1]),
+  dedup: DedupStorePort = new InMemoryDedupStore(),
+) {
   const published: string[] = [];
+  let connected = true;
   const outbound = new OutboundMqttAdapter(
     async (_topic, payload) => {
+      if (!connected) {
+        throw new Error('MQTT client is not connected');
+      }
       published.push(payload);
     },
     'locker/test/response',
@@ -63,7 +74,6 @@ function createDispatcherHarness(bus = new FakeLockerBus([1])) {
   dispatcher.register(
     createOpenCompartmentHandler({
       openCompartment,
-      outbound,
       pollSnapshot,
     }),
   );
@@ -72,8 +82,12 @@ function createDispatcherHarness(bus = new FakeLockerBus([1])) {
     bus,
     dedup,
     dispatcher,
+    outbound,
     openCompartment,
     published,
+    setConnected(value: boolean) {
+      connected = value;
+    },
   };
 }
 
@@ -149,6 +163,94 @@ test('dispatcher rejects invalid payload with structured error', async () => {
   assert.equal(response.error_code, 'INVALID_COMMAND');
 });
 
+test('invalid response remains persistently pending after publish failure and can be flushed', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-invalid-response-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, 'dedup.json');
+  const { bus, dispatcher, openCompartment, outbound, published, setConnected } =
+    createDispatcherHarness(new FakeLockerBus([1]), new FileDedupStore(file));
+  setConnected(false);
+
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-invalid-pending',
+      message_id: 'msg-invalid-pending',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 0 },
+    }),
+  );
+
+  const restartedStore = new FileDedupStore(file);
+  const pendingRecord = restartedStore.getCommandRecord('txn-invalid-pending');
+  assert.equal(bus.flashCalls.length, 0);
+  assert.equal(pendingRecord?.status, 'completed');
+  assert.equal(pendingRecord?.response?.error_code, 'INVALID_COMMAND');
+  assert.equal(pendingRecord?.responseDeliveredAt, undefined);
+
+  setConnected(true);
+  const restartedDispatcher = new CommandDispatcher(
+    new InboundProtocolGuard(restartedStore),
+    outbound,
+    restartedStore,
+  );
+  await restartedDispatcher.flushPendingResponses();
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(commandResponses(published).length, 1);
+  assert.ok(restartedStore.getCommandRecord('txn-invalid-pending')?.responseDeliveredAt);
+});
+
+test('invalid duplicate does not overwrite a completed success response', async () => {
+  const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
+  const successResponse = {
+    action: 'open_compartment',
+    result: 'success' as const,
+    transaction_id: 'txn-invalid-duplicate',
+    message: 'Compartment opened.',
+  };
+  dedup.markCommandCompleted('txn-invalid-duplicate', 'open_compartment', successResponse);
+
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-invalid-duplicate',
+      message_id: 'msg-invalid-duplicate',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 0 },
+    }),
+  );
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(bus.flashCalls.length, 0);
+  assert.deepEqual(dedup.getCommandRecord('txn-invalid-duplicate')?.response, successResponse);
+  assert.equal(commandResponses(published)[0]?.result, 'success');
+});
+
+test('invalid duplicate leaves an in_progress command untouched', async () => {
+  const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
+  dedup.markCommandInProgress('txn-invalid-in-progress', 'open_compartment');
+  const existing = dedup.getCommandRecord('txn-invalid-in-progress');
+
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-invalid-in-progress',
+      message_id: 'msg-invalid-in-progress',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 0 },
+    }),
+  );
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(bus.flashCalls.length, 0);
+  assert.deepEqual(dedup.getCommandRecord('txn-invalid-in-progress'), existing);
+  assert.equal(commandResponses(published).length, 0);
+});
+
 test('dispatcher rejects missing transaction_id without side effects', async () => {
   const { bus, dispatcher, openCompartment, published } = createDispatcherHarness();
 
@@ -168,7 +270,7 @@ test('dispatcher rejects missing transaction_id without side effects', async () 
   assert.equal(published.length, 0);
 });
 
-test('failed open marks completed and duplicate retry is silently ignored', async () => {
+test('failed open stores and replays its error without retrying hardware', async () => {
   const bus = new FakeLockerBus([1]);
   let flashAttempts = 0;
   const originalFlash = bus.flashRelay.bind(bus);
@@ -207,15 +309,23 @@ test('failed open marks completed and duplicate retry is silently ignored', asyn
   openCompartment.stopAllMonitoring();
 
   const responses = commandResponses(published);
-  assert.equal(responses.length, 1);
-  assert.equal(responses[0]?.result, 'error');
+  assert.equal(responses.length, 2);
+  assert.equal(
+    responses.every((response) => response.result === 'error'),
+    true,
+  );
   assert.equal(flashAttempts, 1);
   assert.equal(dedup.getCommandRecord('txn-retry')?.status, 'completed');
 });
 
-test('duplicate completed open_compartment is silently ignored', async () => {
+test('duplicate completed open_compartment replays its stored response', async () => {
   const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
-  dedup.markCommandCompleted('txn-dup', 'open_compartment');
+  dedup.markCommandCompleted('txn-dup', 'open_compartment', {
+    action: 'open_compartment',
+    result: 'success',
+    transaction_id: 'txn-dup',
+    message: 'Compartment opened.',
+  });
 
   await dispatcher.dispatch(
     'locker/test/command',
@@ -230,10 +340,11 @@ test('duplicate completed open_compartment is silently ignored', async () => {
 
   openCompartment.stopAllMonitoring();
   assert.equal(bus.flashCalls.length, 0);
-  assert.equal(commandResponses(published).length, 0);
+  assert.equal(commandResponses(published).length, 1);
+  assert.equal(commandResponses(published)[0]?.transaction_id, 'txn-dup');
 });
 
-test('apply_config deduplicates completed transaction without re-running', async () => {
+test('apply_config replays a completed response without re-running', async () => {
   const bus = new FakeLockerBus([1]);
   const dedup = new InMemoryDedupStore();
   const published: string[] = [];
@@ -242,17 +353,24 @@ test('apply_config deduplicates completed transaction without re-running', async
   }, 'locker/test/response');
   const compartments = [{ compartment_number: 1, slaveId: 1, address: 0 }];
   const configHash = computeAppliedConfigHash(compartments);
+  const overlayStore = new MemoryOverlayStore();
   const applyConfig = new ApplyConfigUseCase({
-    overlayStore: new MemoryOverlayStore(),
+    overlayStore,
     config: createTestConfigRepository({ compartments }),
     bus,
     restartHeartbeat: () => undefined,
     restartPolling: () => undefined,
   });
   const dispatcher = new CommandDispatcher(new InboundProtocolGuard(dedup), outbound, dedup);
-  dispatcher.register(createApplyConfigHandler({ applyConfig, outbound }));
+  dispatcher.register(createApplyConfigHandler({ applyConfig }));
 
-  dedup.markCommandCompleted('txn-apply-dup', 'apply_config');
+  dedup.markCommandCompleted('txn-apply-dup', 'apply_config', {
+    action: 'apply_config',
+    result: 'success',
+    transaction_id: 'txn-apply-dup',
+    applied_config_hash: configHash,
+    message: 'Configuration applied.',
+  });
 
   await dispatcher.dispatch(
     'locker/test/command',
@@ -269,5 +387,163 @@ test('apply_config deduplicates completed transaction without re-running', async
     }),
   );
 
-  assert.equal(commandResponses(published).length, 0);
+  assert.equal(commandResponses(published).length, 1);
+  assert.equal(overlayStore.load(), null);
+});
+
+test('open response publish failure keeps a replayable final response', async () => {
+  const { bus, dedup, dispatcher, openCompartment, published, setConnected } =
+    createDispatcherHarness();
+  setConnected(false);
+
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-pending-open',
+      message_id: 'msg-pending-open',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 1 },
+    }),
+  );
+
+  const pendingRecord = dedup.getCommandRecord('txn-pending-open');
+  assert.equal(bus.flashCalls.length, 1);
+  assert.equal(pendingRecord?.status, 'completed');
+  assert.equal(pendingRecord?.response?.result, 'success');
+  assert.equal(pendingRecord?.responseDeliveredAt, undefined);
+
+  setConnected(true);
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-pending-open',
+      message_id: 'msg-pending-open-retry',
+      timestamp: '2026-04-11T10:00:01Z',
+      data: { compartment_number: 1 },
+    }),
+  );
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(bus.flashCalls.length, 1);
+  assert.equal(commandResponses(published).length, 1);
+  assert.ok(dedup.getCommandRecord('txn-pending-open')?.responseDeliveredAt);
+});
+
+test('startup recovery finalizes in_progress without executing hardware', async () => {
+  const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
+  dedup.markCommandInProgress('txn-interrupted', 'open_compartment');
+
+  dispatcher.recoverInterruptedCommands();
+  const recovered = dedup.getCommandRecord('txn-interrupted');
+
+  assert.equal(bus.flashCalls.length, 0);
+  assert.equal(recovered?.status, 'completed');
+  assert.equal(recovered?.response?.result, 'error');
+  assert.equal(recovered?.response?.error_code, 'UNKNOWN_ERROR');
+  assert.equal(recovered?.responseDeliveredAt, undefined);
+
+  await dispatcher.flushPendingResponses();
+  openCompartment.stopAllMonitoring();
+  assert.equal(commandResponses(published).length, 1);
+  assert.ok(dedup.getCommandRecord('txn-interrupted')?.responseDeliveredAt);
+});
+
+test('reconnect flushes pending responses without repeating hardware', async () => {
+  const { bus, dedup, dispatcher, openCompartment, published, setConnected } =
+    createDispatcherHarness();
+  const transport = new FakeMqttTransport();
+  await transport.connect();
+  transport.onConnected(async () => {
+    setConnected(true);
+    await dispatcher.flushPendingResponses();
+  });
+
+  setConnected(false);
+  transport.simulateBrokerDrop();
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-reconnect',
+      message_id: 'msg-reconnect',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 1 },
+    }),
+  );
+
+  await transport.simulateBrokerRestore();
+  transport.simulateBrokerDrop();
+  await transport.simulateBrokerRestore();
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-reconnect',
+      message_id: 'msg-reconnect-duplicate',
+      timestamp: '2026-04-11T10:00:01Z',
+      data: { compartment_number: 1 },
+    }),
+  );
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(bus.flashCalls.length, 1);
+  assert.equal(commandResponses(published).length, 2);
+  assert.ok(dedup.getCommandRecord('txn-reconnect')?.responseDeliveredAt);
+});
+
+test('apply_config response recovers without applying config twice', async () => {
+  const bus = new FakeLockerBus([1]);
+  const dedup = new InMemoryDedupStore();
+  const published: string[] = [];
+  let connected = false;
+  const outbound = new OutboundMqttAdapter(async (_topic, payload) => {
+    if (!connected) {
+      throw new Error('MQTT client is not connected');
+    }
+    published.push(payload);
+  }, 'locker/test/response');
+  const compartments = [{ compartment_number: 1, slaveId: 1, address: 0 }];
+  const configHash = computeAppliedConfigHash(compartments);
+  const applyConfig = new ApplyConfigUseCase({
+    overlayStore: new MemoryOverlayStore(),
+    config: createTestConfigRepository({ compartments }),
+    bus,
+    restartHeartbeat: () => undefined,
+    restartPolling: () => undefined,
+  });
+  let applyCalls = 0;
+  const execute = applyConfig.execute.bind(applyConfig);
+  applyConfig.execute = async (command) => {
+    applyCalls++;
+    return execute(command);
+  };
+  const dispatcher = new CommandDispatcher(new InboundProtocolGuard(dedup), outbound, dedup);
+  dispatcher.register(createApplyConfigHandler({ applyConfig }));
+  const command = {
+    action: 'apply_config',
+    transaction_id: 'txn-apply-pending',
+    message_id: 'msg-apply-pending',
+    timestamp: '2026-04-11T10:00:00Z',
+    data: {
+      config_hash: configHash,
+      heartbeat_interval_seconds: 30,
+      compartments,
+    },
+  };
+
+  await dispatcher.dispatch('locker/test/command', JSON.stringify(command));
+  connected = true;
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({ ...command, message_id: 'msg-apply-pending-retry' }),
+  );
+
+  assert.equal(applyCalls, 1);
+  assert.equal(commandResponses(published).length, 1);
+  assert.equal(
+    dedup.getCommandRecord('txn-apply-pending')?.response?.applied_config_hash,
+    configHash,
+  );
 });

--- a/locker-client/tests/unit/command-dispatcher.test.ts
+++ b/locker-client/tests/unit/command-dispatcher.test.ts
@@ -48,9 +48,11 @@ function createDispatcherHarness(
   dedup: DedupStorePort = new InMemoryDedupStore(),
 ) {
   const published: string[] = [];
+  const attempted: string[] = [];
   let connected = true;
   const outbound = new OutboundMqttAdapter(
     async (_topic, payload) => {
+      attempted.push(payload);
       if (!connected) {
         throw new Error('MQTT client is not connected');
       }
@@ -85,6 +87,7 @@ function createDispatcherHarness(
     outbound,
     openCompartment,
     published,
+    attempted,
     setConnected(value: boolean) {
       connected = value;
     },
@@ -491,6 +494,103 @@ test('reconnect flushes pending responses without repeating hardware', async () 
   assert.equal(bus.flashCalls.length, 1);
   assert.equal(commandResponses(published).length, 2);
   assert.ok(dedup.getCommandRecord('txn-reconnect')?.responseDeliveredAt);
+});
+
+test('failed delivered duplicate replay is pending and flushes on reconnect', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-delivered-replay-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, 'dedup.json');
+  const { bus, dedup, dispatcher, openCompartment, published, attempted, setConnected } =
+    createDispatcherHarness(new FakeLockerBus([1]), new FileDedupStore(file));
+  t.after(() => openCompartment.stopAllMonitoring());
+  const transport = new FakeMqttTransport();
+  await transport.connect();
+  transport.onConnected(() => dispatcher.flushPendingResponses());
+  const command = {
+    action: 'open_compartment',
+    transaction_id: 'txn-delivered-replay',
+    message_id: 'msg-delivered-original',
+    timestamp: '2026-04-11T10:00:00Z',
+    data: { compartment_number: 1 },
+  };
+
+  await dispatcher.dispatch('locker/test/command', JSON.stringify(command));
+  assert.ok(dedup.getCommandRecord(command.transaction_id)?.responseDeliveredAt);
+
+  setConnected(false);
+  transport.simulateBrokerDrop();
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      ...command,
+      message_id: 'msg-delivered-duplicate',
+      timestamp: '2026-04-11T10:00:01Z',
+    }),
+  );
+
+  assert.equal(bus.flashCalls.length, 1);
+  assert.equal(dedup.getCommandRecord(command.transaction_id)?.responseDeliveredAt, undefined);
+  assert.equal(
+    new FileDedupStore(file).getCommandRecord(command.transaction_id)?.responseDeliveredAt,
+    undefined,
+  );
+
+  setConnected(true);
+  await transport.simulateBrokerRestore();
+
+  assert.equal(bus.flashCalls.length, 1);
+  assert.equal(commandResponses(published).length, 2);
+  assert.ok(dedup.getCommandRecord(command.transaction_id)?.responseDeliveredAt);
+  const responseMessageIds = attempted
+    .map((payload) => JSON.parse(payload) as { message_id: string; result?: string })
+    .filter((payload) => payload.result === 'success' || payload.result === 'error')
+    .map((payload) => payload.message_id);
+  assert.equal(new Set(responseMessageIds).size, 3);
+});
+
+test('flush rescans when requested while another flush is active', async () => {
+  const dedup = new InMemoryDedupStore();
+  dedup.markCommandCompleted('txn-first', 'open_compartment', {
+    action: 'open_compartment',
+    result: 'success',
+    transaction_id: 'txn-first',
+  });
+  let releaseFirstPublish: (() => void) | undefined;
+  const firstPublishBlocked = new Promise<void>((resolve) => {
+    releaseFirstPublish = resolve;
+  });
+  let firstPublishStarted: (() => void) | undefined;
+  const firstPublishHasStarted = new Promise<void>((resolve) => {
+    firstPublishStarted = resolve;
+  });
+  const publishedTransactions: string[] = [];
+  const outbound = new OutboundMqttAdapter(async (_topic, payload) => {
+    const transactionId = (JSON.parse(payload) as { transaction_id: string }).transaction_id;
+    publishedTransactions.push(transactionId);
+    if (transactionId === 'txn-first') {
+      firstPublishStarted?.();
+      await firstPublishBlocked;
+    }
+  }, 'locker/test/response');
+  const dispatcher = new CommandDispatcher(new InboundProtocolGuard(dedup), outbound, dedup);
+
+  const firstFlush = dispatcher.flushPendingResponses();
+  await firstPublishHasStarted;
+  dedup.markCommandCompleted('txn-second', 'open_compartment', {
+    action: 'open_compartment',
+    result: 'success',
+    transaction_id: 'txn-second',
+  });
+  const followUpFlush = dispatcher.flushPendingResponses();
+  assert.equal(firstFlush, followUpFlush);
+  assert.deepEqual(publishedTransactions, ['txn-first']);
+
+  releaseFirstPublish?.();
+  await Promise.all([firstFlush, followUpFlush]);
+
+  assert.deepEqual(publishedTransactions, ['txn-first', 'txn-second']);
+  assert.ok(dedup.getCommandRecord('txn-first')?.responseDeliveredAt);
+  assert.ok(dedup.getCommandRecord('txn-second')?.responseDeliveredAt);
 });
 
 test('apply_config response recovers without applying config twice', async () => {

--- a/locker-client/tests/unit/create-app.test.ts
+++ b/locker-client/tests/unit/create-app.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { dispatchMqttMessage } from '../../src/bootstrap/createApp';
+
+test('MQTT message boundary logs unexpected dispatcher rejections without payload', async () => {
+  const logged: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+  const dispatcher = {
+    async dispatch(): Promise<void> {
+      throw new Error('dispatch exploded');
+    },
+  };
+  const log = {
+    error(message: string, metadata?: Record<string, unknown>) {
+      logged.push({ message, metadata });
+    },
+  };
+
+  dispatchMqttMessage(
+    dispatcher,
+    'locker/test/command',
+    'locker/test/command',
+    Buffer.from('secret command payload'),
+    log,
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(logged, [
+    {
+      message: 'Unexpected MQTT command dispatch failure',
+      metadata: { error: 'dispatch exploded' },
+    },
+  ]);
+  assert.equal(JSON.stringify(logged).includes('secret command payload'), false);
+});

--- a/locker-client/tests/unit/dedup-store.test.ts
+++ b/locker-client/tests/unit/dedup-store.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+import { CommandDispatcher } from '../../src/adapters/mqtt/command-dispatcher';
+import { FileDedupStore } from '../../src/adapters/mqtt/dedup-store';
+import { InboundProtocolGuard } from '../../src/adapters/mqtt/inbound-protocol-guard';
+import { OutboundMqttAdapter } from '../../src/adapters/mqtt/outbound-mqtt.adapter';
+
+test('completed response survives a store restart and can be sent', async (t) => {
+  const file = createStoreFile(t);
+  const store = new FileDedupStore(file);
+  store.markCommandCompleted('txn-completed', 'open_compartment', {
+    action: 'open_compartment',
+    result: 'success',
+    transaction_id: 'txn-completed',
+    message: 'Compartment opened.',
+  });
+
+  const restartedStore = new FileDedupStore(file);
+  const record = restartedStore.getCommandRecord('txn-completed');
+
+  assert.equal(record?.status, 'completed');
+  assert.equal(record?.response?.transaction_id, 'txn-completed');
+  assert.equal(record?.responseDeliveredAt, undefined);
+  assert.deepEqual(
+    restartedStore.listCommandRecords().map(({ transactionId }) => transactionId),
+    ['txn-completed'],
+  );
+
+  const published: string[] = [];
+  const dispatcher = new CommandDispatcher(
+    new InboundProtocolGuard(restartedStore),
+    new OutboundMqttAdapter(async (_topic, payload) => {
+      published.push(payload);
+    }, 'locker/test/response'),
+    restartedStore,
+  );
+  await dispatcher.flushPendingResponses();
+
+  assert.equal(published.length, 1);
+  assert.ok(restartedStore.getCommandRecord('txn-completed')?.responseDeliveredAt);
+});
+
+test('in_progress record survives a store restart', (t) => {
+  const file = createStoreFile(t);
+  new FileDedupStore(file).markCommandInProgress('txn-interrupted', 'open_compartment');
+
+  const record = new FileDedupStore(file).getCommandRecord('txn-interrupted');
+
+  assert.equal(record?.status, 'in_progress');
+  assert.equal(record?.action, 'open_compartment');
+});
+
+test('legacy dedup files remain readable without response fields', (t) => {
+  const file = createStoreFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      seenMessageIds: {
+        'msg-legacy': '2026-04-11T10:00:00.000Z',
+      },
+      commandRecords: {
+        'txn-legacy': {
+          action: 'open_compartment',
+          status: 'completed',
+          updatedAt: '2026-04-11T10:00:01.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+
+  const store = new FileDedupStore(file);
+
+  assert.equal(store.hasSeenMessageId('msg-legacy'), true);
+  assert.deepEqual(store.getCommandRecord('txn-legacy'), {
+    action: 'open_compartment',
+    status: 'completed',
+    updatedAt: '2026-04-11T10:00:01.000Z',
+  });
+});
+
+function createStoreFile(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-dedup-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return path.join(directory, 'dedup.json');
+}

--- a/locker-client/tests/unit/dedup-store.test.ts
+++ b/locker-client/tests/unit/dedup-store.test.ts
@@ -82,8 +82,38 @@ test('legacy dedup files remain readable without response fields', (t) => {
   });
 });
 
+test('write failures leave the cached state unchanged', (t) => {
+  const messageFile = createStoreFile(t);
+  const messageStore = new FileDedupStore(messageFile);
+  messageStore.rememberMessageId('msg-existing');
+  replaceFileWithDirectory(messageFile);
+
+  assert.throws(() => messageStore.rememberMessageId('msg-failed'));
+  assert.equal(messageStore.hasSeenMessageId('msg-existing'), true);
+  assert.equal(messageStore.hasSeenMessageId('msg-failed'), false);
+
+  const commandFile = createStoreFile(t);
+  const commandStore = new FileDedupStore(commandFile);
+  commandStore.markCommandCompleted('txn-pending', 'open_compartment', {
+    action: 'open_compartment',
+    result: 'success',
+    transaction_id: 'txn-pending',
+  });
+  const stateBeforeFailedWrite = commandStore.getCommandRecord('txn-pending');
+  replaceFileWithDirectory(commandFile);
+
+  assert.throws(() => commandStore.markCommandResponseDelivered('txn-pending'));
+  assert.deepEqual(commandStore.getCommandRecord('txn-pending'), stateBeforeFailedWrite);
+  assert.equal(commandStore.getCommandRecord('txn-pending')?.responseDeliveredAt, undefined);
+});
+
 function createStoreFile(t: TestContext): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-dedup-'));
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
   return path.join(directory, 'dedup.json');
+}
+
+function replaceFileWithDirectory(file: string): void {
+  fs.rmSync(file);
+  fs.mkdirSync(file);
 }

--- a/locker-client/tests/unit/mqtt-transport.test.ts
+++ b/locker-client/tests/unit/mqtt-transport.test.ts
@@ -15,7 +15,7 @@ test('MqttTransportAdapter defaults to unlimited reconnect', () => {
 });
 
 // Full broker reconnect integration (aedes + live mqtt.connect) is not wired in CI yet.
-// These tests cover the observable contract: connection state transitions and graceful publish skip.
+// These tests cover the observable contract: connection state transitions and publish failure.
 test('MqttTransportAdapter reports reconnecting after simulated broker drop', () => {
   const transport = new MqttTransportAdapter({
     clean: false,
@@ -31,7 +31,7 @@ test('MqttTransportAdapter reports reconnecting after simulated broker drop', ()
   assert.equal(transport.getConnectionState(), 'reconnecting');
 });
 
-test('MqttTransportAdapter publish skips gracefully while disconnected', async () => {
+test('MqttTransportAdapter publish fails while disconnected', async () => {
   const transport = new MqttTransportAdapter({
     clean: false,
     keepalive: 60,
@@ -40,8 +40,32 @@ test('MqttTransportAdapter publish skips gracefully while disconnected', async (
     maxReconnectAttempts: 0,
   });
 
-  await assert.doesNotReject(() =>
-    transport.publish('locker/test/state/heartbeat', JSON.stringify({ uptime_seconds: 1 })),
+  await assert.rejects(
+    () => transport.publish('locker/test/state/heartbeat', JSON.stringify({ uptime_seconds: 1 })),
+    /not connected/,
   );
   assert.equal(transport.getConnectionState(), 'disconnected');
+});
+
+test('MqttTransportAdapter notifies registered connected handlers', async () => {
+  const transport = new MqttTransportAdapter({
+    clean: false,
+    keepalive: 60,
+    reconnectPeriod: 5000,
+    connectTimeout: 30000,
+    maxReconnectAttempts: 0,
+  });
+  let notifications = 0;
+  transport.onConnected(() => {
+    notifications++;
+  });
+
+  (
+    transport as unknown as {
+      notifyConnected(): void;
+    }
+  ).notifyConnected();
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(notifications, 1);
 });

--- a/locker-client/tests/unit/provision-device.test.ts
+++ b/locker-client/tests/unit/provision-device.test.ts
@@ -27,6 +27,8 @@ class FakeMessageTransport implements MessageTransportPort {
     this.messageHandler = handler;
   }
 
+  onConnected(_handler: () => void | Promise<void>): void {}
+
   emitMessage(topic: string, payload: Record<string, unknown>): void {
     this.messageHandler?.(topic, Buffer.from(JSON.stringify(payload)));
   }


### PR DESCRIPTION
## Summary
- Recover and replay MQTT command responses after disconnect/reconnect so hardware side effects are not repeated (#171).
- Harden medium-severity recovery: keep responses pending before flush/replay, coalesce overlapping flush requests, and use copy-on-write in the dedup store so failed writes leave cached state unchanged.
- Related backend follow-up: #188.

## Test plan
- [x] `pnpm check` and `pnpm test` in `locker-client` (123 unit tests passing)
- [x] Hardware E2E for MQTT command recovery (Issue #171 scenarios)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)