### PR TITLE
fix(locker-client): harden local persistence and credentials

### DIFF
--- a/docs/adr/0033-locker-client-local-persistence-hardening.md
+++ b/docs/adr/0033-locker-client-local-persistence-hardening.md
@@ -1,0 +1,208 @@
+# ADR-0033: Harden locker-client local persistence
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-11
+
+## Context
+
+The locker client keeps four persistent files in `DATA_DIR`:
+
+- `.mqtt-client-id` preserves the MQTT session identity.
+- `.mqtt-credentials.json` contains the provisioned MQTT username and password.
+- `.runtime-config-overlay.json` contains the backend-managed physical compartment
+  mapping and heartbeat interval.
+- `.mqtt-dedup-state.json` contains seen MQTT message identifiers, command
+  execution records, final responses, and response-delivery timestamps.
+
+These files previously used independent direct writes. A crash or storage error
+could therefore expose a partial JSON document. File modes were not consistently
+restricted, malformed credentials could be mistaken for an unprovisioned device,
+and deduplication data had no retention policy. ADR-0032 deliberately deferred
+atomic persistence and bounded retention to issue #168.
+
+The runtime overlay determines which physical relay a command can address.
+Silently discarding a malformed overlay could therefore change physical behavior.
+Deduplication and response state also protects against repeating a physical
+operation whose outcome is already known or uncertain.
+
+Atomic replacement protects individual writes but does not serialize multiple
+locker-client processes sharing one `DATA_DIR`. Concurrent writers could each
+hold stale in-memory state and overwrite the other's newer state.
+
+## Decision
+
+1. All locker-client files under `DATA_DIR` use one dependency-free synchronous
+   persistence utility. It creates a unique temporary file in the destination
+   directory, completes and flushes the write, applies the requested mode, and
+   atomically renames the temporary file over the destination. Temporary files
+   are removed after pre-rename failures, and the previous destination remains
+   unchanged. The containing directory is flushed where the filesystem supports
+   it.
+2. Newly created data directories use mode `0700`. All four persistent files use
+   mode `0600`. Existing credential files are hardened to `0600` before they are
+   read.
+3. Persistent corruption is fail-closed and is reported with
+   `PersistentStateCorruptedError`. Error messages identify only the state type
+   and file path; they never include credentials, payloads, or persisted content.
+4. Existing but malformed or incomplete credentials block startup and remain
+   untouched. Only an absent credential file starts provisioning.
+5. A malformed, empty, or unsupported runtime overlay blocks startup and remains
+   untouched. The client never falls back to an empty physical mapping when an
+   overlay file exists. This supersedes only ADR-0009's permissive corruption
+   fallback; its base-config/runtime-overlay ownership decision remains accepted.
+6. Malformed deduplication, command, response, or delivery state blocks startup
+   before MQTT command processing begins and remains untouched.
+7. An absent client-ID file creates a new random identity atomically. An existing
+   empty or syntactically invalid client-ID file blocks startup and remains
+   untouched. An operator can recover explicitly by restoring a valid identifier,
+   configuring `MQTT_CLIENT_ID`, or deleting the invalid file to request a new
+   identity. Deletion intentionally abandons the previous MQTT session.
+8. Dedup state format version 2 adds a top-level `version` marker and normalizes
+   command records. A transaction ID exists only as the `commandRecords` map key,
+   and the action exists only on the command record. The stored response contains
+   only response-specific fields such as `result`, `message`, `error_code`, and
+   `applied_config_hash`; the dispatcher reconstructs the complete MQTT response
+   from the map key, record action, and stored response.
+   Legacy unversioned files are validated, pruned, and rewritten atomically.
+   Their full responses are normalized only when their `transaction_id` and
+   `action` exactly match the enclosing map key and command record. A mismatch is
+   corruption and blocks startup.
+9. Seen message identifiers are retained for 30 days and capped at 10,000.
+   Pruning orders entries by timestamp and then identifier, retaining the newest
+   entries deterministically.
+10. Version 2 requires `in_progress` records to have no final response or delivery
+    timestamp, and ordinary `completed` records to have a final response. Legacy
+    completed records that predate response persistence are migrated with an
+    explicit `legacyResponseUnavailable: true` marker; they have neither a
+    response nor a delivery timestamp and continue to suppress physical
+    execution.
+11. Completed command records with a stored response and a delivery timestamp are
+    retained for 30 days after delivery. A completed response without a delivery
+    timestamp is never pruned. Marked legacy completed records without a response
+    are never pruned because delivery is unknown. `in_progress` records and
+    recovered unknown-outcome records are never pruned until ADR-0032 has
+    finalized and delivered their response. Migration and pruning never invoke a
+    command handler.
+12. The MQTT topics, payload schemas, and ADR-0032 recovery behavior do not
+    change. This decision does not implement general age-based command rejection.
+13. The production Docker entrypoint permits one writer per
+    `${DATA_DIR:-/data}` by acquiring an exclusive, nonblocking util-linux
+    `flock` on `.locker-client.lock`. `--no-fork` makes the lock-owning process
+    the client itself, preserving direct signal delivery and holding the lock for
+    the client's lifetime. Lock contention fails closed with exit code `75`.
+    The kernel releases the lock on normal exit, crash, `SIGKILL`, or container
+    restart; the lock file may remain and is not stale-lock evidence.
+14. This single-writer guarantee assumes a local Linux filesystem. Lock
+    semantics on NFS and CIFS are not guaranteed, and starting Node directly
+    outside the production entrypoint bypasses the lock.
+15. The production image remains root-based for now. Raspberry Pi serial devices
+    commonly use a host-specific supplementary group, and the current Compose
+    deployment has no safe, portable group-ID mapping. Choosing a fixed group or
+    broadening device permissions would either break hardware access or weaken
+    host security. `/config` remains read-only and `/data` writable. A separate
+    deployment change must introduce an explicit site-provided serial GID and
+    matching volume ownership before changing the image user.
+
+## Alternatives Considered
+
+### Continue direct writes and recover malformed files automatically
+
+- Pros: Minimal implementation and fewer startup failures.
+- Cons: A crash can lose the old and new state; automatic recovery can repeat a
+  physical operation or discard a valid physical mapping.
+- Why not chosen: Availability does not outweigh credential, state, and physical
+  safety.
+
+### Use a database or third-party atomic-file package
+
+- Pros: Mature transactions or less custom filesystem code.
+- Cons: Adds runtime and operational complexity for four small local files.
+- Why not chosen: Same-directory temporary files plus atomic rename provide the
+  required boundary without a new dependency.
+
+### Prune all old completed and in-progress commands
+
+- Pros: Places a strict upper bound on every part of the state file.
+- Cons: Could discard an undelivered final response or permit physical
+  re-execution after an unknown outcome.
+- Why not chosen: Only acknowledged final records have a safe retention boundary.
+
+### Run the production container as a fixed non-root user immediately
+
+- Pros: Reduces privileges inside the container.
+- Cons: Raspberry Pi serial group IDs vary, and bind-mounted `/data` ownership
+  must match the selected runtime UID.
+- Why not chosen: No portable mapping exists in the current deployment contract;
+  guessing it would break serial access or require unsafe permissions.
+
+## Consequences
+
+### Positive
+
+- Interrupted writes do not replace valid local state with partial content.
+- Credentials and state are owner-readable only.
+- Corruption stops command processing instead of silently weakening deduplication
+  or changing physical mapping.
+- Dedup growth is bounded where a safe deletion boundary exists.
+- Existing ADR-0032 state migrates without repeating hardware operations.
+- The production deployment prevents concurrent processes from overwriting each
+  other's local state.
+
+### Negative
+
+- Corrupt files require explicit operator recovery.
+- Pending, legacy, and unknown-outcome records can grow until their safe terminal
+  state is known.
+- The container still runs as root pending an explicit serial-group deployment
+  contract.
+- Direct Node starts and deployments on filesystems without reliable Linux
+  `flock` semantics do not receive the single-writer guarantee.
+
+### Risks
+
+- Filesystems without directory `fsync` support have a weaker guarantee across
+  sudden power loss after rename; the utility still flushes the file itself.
+- Deleting a corrupt client-ID file starts a new MQTT session and can abandon
+  broker-queued messages for the old identity. Operators must make that choice
+  deliberately.
+- Incorrect host ownership can make `/data` unwritable. Deployment instructions
+  require private host directories and prohibit `chmod 777`.
+- Lock contention stops the new process with exit code `75`; operators must
+  resolve the concurrent deployment rather than delete the persistent lock file.
+
+## Rollout / Migration
+
+- Back up `/data` before upgrading.
+- Ensure the host `data` directory is private and writable by the current
+  container deployment.
+- Keep production startup routed through the image entrypoint and use a local
+  Linux bind mount for `/data`. A remaining `.locker-client.lock` requires no
+  cleanup; verify whether a process holds it before diagnosing contention.
+- On first access, valid unversioned dedup state is atomically rewritten as
+  normalized version 2 and safe retention rules are applied. Full legacy
+  responses are stripped of redundant identity fields after consistency
+  validation; response-less completed records receive the explicit legacy
+  marker.
+- Existing credentials are changed to mode `0600` during startup.
+- If startup reports persistent corruption, stop the service and inspect or
+  restore that specific file. Do not replace dedup or overlay state with an empty
+  file.
+- Validate a future non-root rollout separately with the real serial-device group
+  and explicit `/data` ownership before changing the image user.
+
+## References
+
+- GitHub issue #168
+- GitHub issue #171
+- `docs/adr/0009-locker-client-runtime-config-overlay.md`
+- `docs/adr/0014-locker-client-mqtt-session-and-reconnect.md`
+- `docs/adr/0032-locker-client-command-response-recovery.md`
+- `locker-client/Dockerfile`
+- `locker-client/docker-entrypoint.sh`
+- `locker-client/src/infrastructure/file-persistence.ts`
+- `locker-client/src/adapters/mqtt/dedup-store.ts`

--- a/locker-client/Dockerfile
+++ b/locker-client/Dockerfile
@@ -12,12 +12,17 @@ FROM node:22-slim
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends util-linux \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data /config
+
 COPY package.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
-
-RUN mkdir -p /data /config
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/locker-client-entrypoint
 
 VOLUME ["/data", "/config"]
 
+ENTRYPOINT ["locker-client-entrypoint"]
 CMD ["node", "dist/src/main.js"]

--- a/locker-client/README.md
+++ b/locker-client/README.md
@@ -18,6 +18,7 @@ pulses (100–500ms). Never energize relays via software ON/OFF timers.
 ```bash
 cp .env.example .env
 mkdir -p config data
+chmod 700 data
 cp locker-config.yml.example config/locker-config.yml
 
 # Set PROVISIONING_TOKEN in .env for the first startup and adjust the serial port.
@@ -33,6 +34,45 @@ Required mounts:
 
 - `/config/locker-config.yml`: operator-managed Modbus/base configuration
 - `/data`: client identity, MQTT credentials, runtime config, and dedup state
+
+Keep the host `data` directory private (`0700`). The client creates persistent
+files with mode `0600` and atomically replaces them. Never make the data directory
+world-writable and do not use `chmod 777`.
+
+The production image permits only one running client per `DATA_DIR`. Its
+entrypoint takes a nonblocking Linux `flock` on
+`/data/.locker-client.lock` (or `${DATA_DIR}/.locker-client.lock`) before starting
+Node and exits with code `75` if another process holds the lock. The lock belongs
+to the running client process and is released automatically when that process
+exits or is killed. The lock file itself may remain and must not be treated as
+stale state or deleted for recovery.
+
+This guarantee assumes `/data` is a bind mount on a local Linux filesystem, as in
+the provided Raspberry Pi deployment. Lock behavior on NFS and CIFS is not
+guaranteed. Starting Node directly outside the production Docker entrypoint
+bypasses this deployment lock.
+
+The persisted files are:
+
+- `.mqtt-client-id`: stable MQTT session identity
+- `.mqtt-credentials.json`: provisioned MQTT credentials
+- `.runtime-config-overlay.json`: backend-managed physical mapping
+- `.mqtt-dedup-state.json`: message deduplication, command outcomes, and pending
+  responses
+
+If an existing credentials, runtime-overlay, or dedup file is corrupt, startup
+fails without replacing it. Restore the file from backup or repair it while the
+service is stopped. An invalid client-ID file is also retained; restore it, set a
+valid `MQTT_CLIENT_ID`, or deliberately delete it to create a new MQTT session.
+Deleting dedup state or an invalid client ID can discard safety/session history
+and must not be used as an automatic recovery action.
+
+The production image currently remains root-based because Raspberry Pi serial
+device group IDs are host-specific. `/config` is mounted read-only and `/data` is
+writable, but switching to a fixed non-root UID without also mapping the real
+serial-device GID would break hardware access. Do not work around this with broad
+serial-device permissions. A non-root rollout must first provide an explicit
+serial GID and matching ownership for the host `data` directory.
 
 ## Development
 
@@ -52,6 +92,8 @@ in `/data/.runtime-config-overlay.json`. Until that first apply completes,
 `open_compartment` commands fail and compartment snapshots stay empty.
 
 See [ADR-0025](../docs/adr/0025-locker-client-v2-runtime-only-compartment-mapping.md).
+Persistence and corruption behavior is defined in
+[ADR-0033](../docs/adr/0033-locker-client-local-persistence-hardening.md).
 
 ## MQTT resilience
 

--- a/locker-client/docker-entrypoint.sh
+++ b/locker-client/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+data_dir=${DATA_DIR:-/data}
+lock_file="$data_dir/.locker-client.lock"
+
+umask 077
+mkdir -p "$data_dir"
+touch "$lock_file"
+chmod 600 "$lock_file"
+
+exec flock \
+    --exclusive \
+    --nonblock \
+    --no-fork \
+    --conflict-exit-code 75 \
+    -- \
+    "$lock_file" \
+    "$@"

--- a/locker-client/setup.sh
+++ b/locker-client/setup.sh
@@ -10,6 +10,10 @@ echo ""
 # Create directories
 echo "Creating directories..."
 mkdir -p config data
+chmod 700 data
+if [ -f data/.mqtt-credentials.json ]; then
+    chmod 600 data/.mqtt-credentials.json
+fi
 
 # Download docker-compose.yml if not present
 if [ ! -f docker-compose.yml ]; then

--- a/locker-client/src/adapters/config/runtime-overlay.store.ts
+++ b/locker-client/src/adapters/config/runtime-overlay.store.ts
@@ -3,29 +3,45 @@ import type { CompartmentConfig } from '../../domain/compartment';
 import type { RuntimeConfigOverlay } from '../../domain/config';
 import { normalizeCompartments } from '../../domain/config-normalization';
 import { RUNTIME_CONFIG_OVERLAY_FILE } from '../../infrastructure/paths';
+import {
+  atomicWriteFileSync,
+  PersistentStateCorruptedError,
+} from '../../infrastructure/file-persistence';
 
 const MAX_RELAY_ADDRESS = 7;
 
 export function sanitizeRuntimeConfigOverlay(value: unknown): RuntimeConfigOverlay {
   const overlay = value as Record<string, unknown> | null;
-  if (overlay === null || typeof overlay !== 'object') {
+  if (overlay === null || typeof overlay !== 'object' || Array.isArray(overlay)) {
     throw new Error('runtime config overlay must be an object');
+  }
+  const allowedKeys = new Set(['mqtt', 'compartments', 'appliedConfigHash', 'updatedAt']);
+  const keys = Object.keys(overlay);
+  if (keys.length === 0 || keys.some((key) => !allowedKeys.has(key))) {
+    throw new Error('runtime config overlay contains unsupported fields');
   }
 
   const sanitized: RuntimeConfigOverlay = {};
 
   if (overlay.mqtt !== undefined) {
-    const mqtt = overlay.mqtt as Record<string, unknown>;
+    const mqtt = overlay.mqtt as Record<string, unknown> | null;
     if (
-      mqtt.heartbeatInterval !== undefined &&
-      Number.isInteger(mqtt.heartbeatInterval) &&
-      Number(mqtt.heartbeatInterval) > 0
+      mqtt === null ||
+      typeof mqtt !== 'object' ||
+      Array.isArray(mqtt) ||
+      Object.keys(mqtt).some((key) => key !== 'heartbeatInterval') ||
+      !Number.isInteger(mqtt.heartbeatInterval) ||
+      Number(mqtt.heartbeatInterval) <= 0
     ) {
-      sanitized.mqtt = { heartbeatInterval: Number(mqtt.heartbeatInterval) };
+      throw new Error('invalid mqtt settings in overlay');
     }
+    sanitized.mqtt = { heartbeatInterval: Number(mqtt.heartbeatInterval) };
   }
 
   if (overlay.compartments !== undefined) {
+    if (!Array.isArray(overlay.compartments)) {
+      throw new Error('compartments in overlay must be an array');
+    }
     sanitized.compartments = normalizeCompartments(
       (overlay.compartments as CompartmentConfig[]).map((entry) => {
         if (
@@ -55,33 +71,47 @@ export function sanitizeRuntimeConfigOverlay(value: unknown): RuntimeConfigOverl
   }
 
   if (overlay.updatedAt !== undefined) {
-    sanitized.updatedAt = String(overlay.updatedAt);
+    if (typeof overlay.updatedAt !== 'string' || !Number.isFinite(Date.parse(overlay.updatedAt))) {
+      throw new Error('invalid updatedAt');
+    }
+    sanitized.updatedAt = overlay.updatedAt;
   }
 
   return sanitized;
 }
 
 export class FileRuntimeOverlayStore {
+  constructor(private readonly filePath: string = RUNTIME_CONFIG_OVERLAY_FILE) {}
+
   load(): RuntimeConfigOverlay | null {
-    if (!fs.existsSync(RUNTIME_CONFIG_OVERLAY_FILE)) {
+    if (!fs.existsSync(this.filePath)) {
       return null;
     }
-    const raw = fs.readFileSync(RUNTIME_CONFIG_OVERLAY_FILE, 'utf8').trim();
-    if (!raw) {
-      return null;
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf8').trim();
+      if (!raw) {
+        throw new PersistentStateCorruptedError('runtime configuration overlay', this.filePath);
+      }
+      return sanitizeRuntimeConfigOverlay(JSON.parse(raw));
+    } catch (error) {
+      if (error instanceof PersistentStateCorruptedError) {
+        throw error;
+      }
+      throw new PersistentStateCorruptedError('runtime configuration overlay', this.filePath, {
+        cause: error,
+      });
     }
-    return sanitizeRuntimeConfigOverlay(JSON.parse(raw));
   }
 
   save(overlay: RuntimeConfigOverlay): RuntimeConfigOverlay {
     const sanitized = sanitizeRuntimeConfigOverlay(overlay);
-    fs.writeFileSync(RUNTIME_CONFIG_OVERLAY_FILE, JSON.stringify(sanitized, null, 2), 'utf8');
+    atomicWriteFileSync(this.filePath, JSON.stringify(sanitized, null, 2), { mode: 0o600 });
     return sanitized;
   }
 
   clear(): void {
-    if (fs.existsSync(RUNTIME_CONFIG_OVERLAY_FILE)) {
-      fs.unlinkSync(RUNTIME_CONFIG_OVERLAY_FILE);
+    if (fs.existsSync(this.filePath)) {
+      fs.unlinkSync(this.filePath);
     }
   }
 }

--- a/locker-client/src/adapters/config/runtime-overlay.store.ts
+++ b/locker-client/src/adapters/config/runtime-overlay.store.ts
@@ -6,6 +6,7 @@ import { RUNTIME_CONFIG_OVERLAY_FILE } from '../../infrastructure/paths';
 import {
   atomicWriteFileSync,
   PersistentStateCorruptedError,
+  readPrivateFileSync,
 } from '../../infrastructure/file-persistence';
 
 const MAX_RELAY_ADDRESS = 7;
@@ -88,7 +89,7 @@ export class FileRuntimeOverlayStore {
       return null;
     }
     try {
-      const raw = fs.readFileSync(this.filePath, 'utf8').trim();
+      const raw = readPrivateFileSync(this.filePath).toString('utf8').trim();
       if (!raw) {
         throw new PersistentStateCorruptedError('runtime configuration overlay', this.filePath);
       }

--- a/locker-client/src/adapters/config/yaml-config.repository.ts
+++ b/locker-client/src/adapters/config/yaml-config.repository.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../domain/config';
 import { deriveConfiguredSlaveIds } from '../../domain/config';
 import { normalizeFlashDurationMs } from '../../domain/compartment';
-import type { ConfigRepositoryPort } from '../../ports/config.port';
+import type { ConfigRepositoryPort, RuntimeOverlayStorePort } from '../../ports/config.port';
 import type { MqttTransportSettings } from '../../ports/mqtt.port';
 import { CONFIG_FILE } from '../../infrastructure/paths';
 import { FileRuntimeOverlayStore } from './runtime-overlay.store';
@@ -57,7 +57,7 @@ export class YamlConfigRepository implements ConfigRepositoryPort {
   private config: EffectiveLockerConfig | null = null;
 
   constructor(
-    private readonly overlayStore = new FileRuntimeOverlayStore(),
+    private readonly overlayStore: RuntimeOverlayStorePort = new FileRuntimeOverlayStore(),
     private readonly configFilePath: string = CONFIG_FILE,
   ) {}
 

--- a/locker-client/src/adapters/mqtt/command-dispatcher.ts
+++ b/locker-client/src/adapters/mqtt/command-dispatcher.ts
@@ -1,6 +1,11 @@
 import type { z } from 'zod';
 import { InboundProtocolGuard } from './inbound-protocol-guard';
-import type { CommandResponseBody, DedupStorePort, OutboundMqttPort } from '../../ports/mqtt.port';
+import type {
+  CommandResponseBody,
+  DedupStorePort,
+  OutboundMqttPort,
+  StoredCommandResponse,
+} from '../../ports/mqtt.port';
 import { mapErrorToMqttCode, MqttErrorCode } from '../../domain/errors';
 import { formatZodValidationError } from '../../domain/mqtt-parsing';
 import { logger } from '../../infrastructure/logging';
@@ -67,9 +72,7 @@ export class CommandDispatcher {
         continue;
       }
       this.dedup.markCommandCompleted(transactionId, record.action, {
-        action: record.action,
         result: 'error',
-        transaction_id: transactionId,
         error_code: MqttErrorCode.UNKNOWN_ERROR,
         message: 'Command outcome is unknown after locker-client restart.',
       });
@@ -171,7 +174,7 @@ export class CommandDispatcher {
     const existing = this.dedup.getCommandRecord(transactionId);
     if (existing?.status === 'completed') {
       if (existing.response) {
-        await this.replayFinalResponse(transactionId, existing.response);
+        await this.replayFinalResponse(transactionId, existing.action, existing.response);
       } else {
         logger.warn('Cannot replay legacy completed command without stored response', {
           action,
@@ -184,7 +187,7 @@ export class CommandDispatcher {
       return;
     }
 
-    this.dedup.markCommandCompleted(transactionId, action, response);
+    this.dedup.markCommandCompleted(transactionId, action, toStoredCommandResponse(response));
     await this.publishFinalResponse(transactionId, response);
   }
 
@@ -195,7 +198,7 @@ export class CommandDispatcher {
       if (dedupResult === 'duplicate_completed') {
         const existing = this.dedup.getCommandRecord(transactionId);
         if (existing?.response) {
-          await this.replayFinalResponse(transactionId, existing.response);
+          await this.replayFinalResponse(transactionId, existing.action, existing.response);
         } else {
           logger.warn('Cannot replay legacy completed command without stored response', {
             action,
@@ -236,7 +239,7 @@ export class CommandDispatcher {
   ): Promise<void> {
     const { action, handler, transactionId } = command;
     if (handler.requiresTransactionId()) {
-      this.dedup.markCommandCompleted(transactionId, action, response);
+      this.dedup.markCommandCompleted(transactionId, action, toStoredCommandResponse(response));
     }
     await this.publishFinalResponse(transactionId, response);
   }
@@ -249,7 +252,9 @@ export class CommandDispatcher {
           record.status === 'completed' && record.response && !record.responseDeliveredAt,
       );
     for (const { transactionId, record } of pending) {
-      await this.publishFinalResponse(transactionId, record.response!);
+      if (record.response) {
+        await this.publishStoredResponse(transactionId, record.action, record.response);
+      }
     }
   }
 
@@ -262,10 +267,23 @@ export class CommandDispatcher {
 
   private async replayFinalResponse(
     transactionId: string,
-    response: CommandResponseBody,
+    action: string,
+    response: StoredCommandResponse,
   ): Promise<void> {
     this.dedup.markCommandResponsePending(transactionId);
-    await this.publishFinalResponse(transactionId, response);
+    await this.publishStoredResponse(transactionId, action, response);
+  }
+
+  private async publishStoredResponse(
+    transactionId: string,
+    action: string,
+    response: StoredCommandResponse,
+  ): Promise<void> {
+    await this.publishFinalResponse(transactionId, {
+      action,
+      transaction_id: transactionId,
+      ...response,
+    });
   }
 
   private async publishFinalResponse(
@@ -304,4 +322,9 @@ export class CommandDispatcher {
 function extractLockerUuid(topic: string): string {
   const parts = topic.split('/');
   return parts[1] ?? '';
+}
+
+function toStoredCommandResponse(response: CommandResponseBody): StoredCommandResponse {
+  const { action: _action, transaction_id: _transactionId, ...storedResponse } = response;
+  return storedResponse;
 }

--- a/locker-client/src/adapters/mqtt/dedup-store.ts
+++ b/locker-client/src/adapters/mqtt/dedup-store.ts
@@ -5,6 +5,7 @@ import { MQTT_DEDUP_STATE_FILE } from '../../infrastructure/paths';
 import {
   atomicWriteFileSync,
   PersistentStateCorruptedError,
+  readPrivateFileSync,
 } from '../../infrastructure/file-persistence';
 
 interface DedupState {
@@ -246,7 +247,7 @@ export class FileDedupStore implements DedupStorePort {
     let loaded: DedupState;
     let migratedLegacy = false;
     try {
-      const raw: unknown = JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+      const raw: unknown = JSON.parse(readPrivateFileSync(this.filePath).toString('utf8'));
       if (hasVersionMarker(raw)) {
         const parsed = persistedDedupStateSchema.parse(raw);
         loaded = {

--- a/locker-client/src/adapters/mqtt/dedup-store.ts
+++ b/locker-client/src/adapters/mqtt/dedup-store.ts
@@ -1,16 +1,128 @@
 import fs from 'fs';
-import type { CommandRecord, CommandResponseBody, DedupStorePort } from '../../ports/mqtt.port';
+import { z } from 'zod';
+import type { CommandRecord, DedupStorePort, StoredCommandResponse } from '../../ports/mqtt.port';
 import { MQTT_DEDUP_STATE_FILE } from '../../infrastructure/paths';
+import {
+  atomicWriteFileSync,
+  PersistentStateCorruptedError,
+} from '../../infrastructure/file-persistence';
 
 interface DedupState {
   seenMessageIds: Record<string, string>;
   commandRecords: Record<string, CommandRecord>;
 }
 
+interface PersistedDedupState extends DedupState {
+  version: 2;
+}
+
+interface DedupStoreOptions {
+  now?: () => Date;
+  seenMessageIdTtlMs?: number;
+  maxSeenMessageIds?: number;
+  deliveredCommandRetentionMs?: number;
+}
+
+export const DEFAULT_SEEN_MESSAGE_ID_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const DEFAULT_MAX_SEEN_MESSAGE_IDS = 10_000;
+export const DEFAULT_DELIVERED_COMMAND_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+const timestampSchema = z.string().refine((value) => Number.isFinite(Date.parse(value)));
+const storedResponseSchema = z
+  .object({
+    result: z.enum(['success', 'error']),
+    message: z.string().optional(),
+    error_code: z.string().optional(),
+    applied_config_hash: z.string().optional(),
+  })
+  .strict();
+const legacyResponseSchema = storedResponseSchema.extend({
+  action: z.string(),
+  transaction_id: z.string(),
+});
+const inProgressCommandRecordSchema = z
+  .object({
+    action: z.string(),
+    status: z.literal('in_progress'),
+    updatedAt: timestampSchema,
+  })
+  .strict();
+const completedCommandRecordSchema = z
+  .object({
+    action: z.string(),
+    status: z.literal('completed'),
+    updatedAt: timestampSchema,
+    response: storedResponseSchema,
+    responseDeliveredAt: timestampSchema.optional(),
+  })
+  .strict();
+const legacyCompletedCommandRecordSchema = z
+  .object({
+    action: z.string(),
+    status: z.literal('completed'),
+    updatedAt: timestampSchema,
+    legacyResponseUnavailable: z.literal(true),
+  })
+  .strict();
+const commandRecordSchema = z.union([
+  inProgressCommandRecordSchema,
+  completedCommandRecordSchema,
+  legacyCompletedCommandRecordSchema,
+]);
+const persistedDedupStateSchema = z
+  .object({
+    version: z.literal(2),
+    seenMessageIds: z.record(z.string(), timestampSchema).default({}),
+    commandRecords: z.record(z.string(), commandRecordSchema).default({}),
+  })
+  .strict();
+const unversionedCommandRecordSchema = z.union([
+  inProgressCommandRecordSchema,
+  z
+    .object({
+      action: z.string(),
+      status: z.literal('completed'),
+      updatedAt: timestampSchema,
+      response: legacyResponseSchema,
+      responseDeliveredAt: timestampSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.string(),
+      status: z.literal('completed'),
+      updatedAt: timestampSchema,
+    })
+    .strict(),
+]);
+const unversionedDedupStateSchema = z
+  .object({
+    seenMessageIds: z.record(z.string(), timestampSchema).default({}),
+    commandRecords: z.record(z.string(), unversionedCommandRecordSchema).default({}),
+  })
+  .strict();
+
 export class FileDedupStore implements DedupStorePort {
   private state: DedupState | null = null;
+  private readonly now: () => Date;
+  private readonly seenMessageIdTtlMs: number;
+  private readonly maxSeenMessageIds: number;
+  private readonly deliveredCommandRetentionMs: number;
 
-  constructor(private readonly filePath: string = MQTT_DEDUP_STATE_FILE) {}
+  constructor(
+    private readonly filePath: string = MQTT_DEDUP_STATE_FILE,
+    options: DedupStoreOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.seenMessageIdTtlMs = options.seenMessageIdTtlMs ?? DEFAULT_SEEN_MESSAGE_ID_TTL_MS;
+    this.maxSeenMessageIds = options.maxSeenMessageIds ?? DEFAULT_MAX_SEEN_MESSAGE_IDS;
+    this.deliveredCommandRetentionMs =
+      options.deliveredCommandRetentionMs ?? DEFAULT_DELIVERED_COMMAND_RETENTION_MS;
+  }
+
+  assertHealthy(): void {
+    this.loadState();
+  }
 
   hasSeenMessageId(messageId: string): boolean {
     const state = this.loadState();
@@ -23,7 +135,7 @@ export class FileDedupStore implements DedupStorePort {
       ...state,
       seenMessageIds: {
         ...state.seenMessageIds,
-        [messageId]: new Date().toISOString(),
+        [messageId]: this.now().toISOString(),
       },
     });
   }
@@ -49,13 +161,17 @@ export class FileDedupStore implements DedupStorePort {
         [transactionId]: {
           action,
           status: 'in_progress',
-          updatedAt: new Date().toISOString(),
+          updatedAt: this.now().toISOString(),
         },
       },
     });
   }
 
-  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void {
+  markCommandCompleted(
+    transactionId: string,
+    action: string,
+    response: StoredCommandResponse,
+  ): void {
     const state = this.loadState();
     this.saveState({
       ...state,
@@ -64,7 +180,7 @@ export class FileDedupStore implements DedupStorePort {
         [transactionId]: {
           action,
           status: 'completed',
-          updatedAt: new Date().toISOString(),
+          updatedAt: this.now().toISOString(),
           response,
         },
       },
@@ -90,7 +206,7 @@ export class FileDedupStore implements DedupStorePort {
         ...state.commandRecords,
         [transactionId]: {
           ...pendingRecord,
-          updatedAt: new Date().toISOString(),
+          updatedAt: this.now().toISOString(),
         },
       },
     });
@@ -102,7 +218,7 @@ export class FileDedupStore implements DedupStorePort {
     if (!record || record.status !== 'completed' || !record.response) {
       return;
     }
-    const deliveredAt = new Date().toISOString();
+    const deliveredAt = this.now().toISOString();
     this.saveState({
       ...state,
       commandRecords: {
@@ -127,17 +243,68 @@ export class FileDedupStore implements DedupStorePort {
       return empty;
     }
 
-    const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as Partial<DedupState>;
-    this.state = {
-      seenMessageIds: parsed.seenMessageIds ?? {},
-      commandRecords: parsed.commandRecords ?? {},
-    };
-    return this.state;
+    let loaded: DedupState;
+    let migratedLegacy = false;
+    try {
+      const raw: unknown = JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+      if (hasVersionMarker(raw)) {
+        const parsed = persistedDedupStateSchema.parse(raw);
+        loaded = {
+          seenMessageIds: parsed.seenMessageIds,
+          commandRecords: parsed.commandRecords,
+        };
+      } else {
+        loaded = migrateUnversionedState(unversionedDedupStateSchema.parse(raw));
+        migratedLegacy = true;
+      }
+    } catch (error) {
+      throw new PersistentStateCorruptedError(
+        'MQTT deduplication and response state',
+        this.filePath,
+        { cause: error },
+      );
+    }
+    const pruned = this.pruneState(loaded);
+    if (migratedLegacy || JSON.stringify(pruned) !== JSON.stringify(loaded)) {
+      this.writeState(pruned);
+    }
+    this.state = pruned;
+    return pruned;
   }
 
   private saveState(state: DedupState): void {
-    fs.writeFileSync(this.filePath, JSON.stringify(state, null, 2), 'utf8');
-    this.state = state;
+    const pruned = this.pruneState(state);
+    this.writeState(pruned);
+    this.state = pruned;
+  }
+
+  private writeState(state: DedupState): void {
+    const persisted: PersistedDedupState = { version: 2, ...state };
+    atomicWriteFileSync(this.filePath, JSON.stringify(persisted, null, 2), { mode: 0o600 });
+  }
+
+  private pruneState(state: DedupState): DedupState {
+    const now = this.now().getTime();
+    const seenCutoff = now - this.seenMessageIdTtlMs;
+    const retainedMessageIds = Object.entries(state.seenMessageIds)
+      .filter(([, timestamp]) => Date.parse(timestamp) >= seenCutoff)
+      .toSorted(
+        ([idA, timestampA], [idB, timestampB]) =>
+          Date.parse(timestampA) - Date.parse(timestampB) || idA.localeCompare(idB),
+      )
+      .slice(-this.maxSeenMessageIds);
+    const commandCutoff = now - this.deliveredCommandRetentionMs;
+    const retainedCommandRecords = Object.entries(state.commandRecords).filter(([, record]) => {
+      if (record.status !== 'completed' || !record.response || !record.responseDeliveredAt) {
+        return true;
+      }
+      return Date.parse(record.responseDeliveredAt) >= commandCutoff;
+    });
+
+    return {
+      seenMessageIds: Object.fromEntries(retainedMessageIds),
+      commandRecords: Object.fromEntries(retainedCommandRecords),
+    };
   }
 }
 
@@ -172,7 +339,11 @@ export class InMemoryDedupStore implements DedupStorePort {
     });
   }
 
-  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void {
+  markCommandCompleted(
+    transactionId: string,
+    action: string,
+    response: StoredCommandResponse,
+  ): void {
     this.commandRecords.set(transactionId, {
       action,
       status: 'completed',
@@ -211,4 +382,46 @@ export class InMemoryDedupStore implements DedupStorePort {
       responseDeliveredAt: deliveredAt,
     });
   }
+}
+
+function hasVersionMarker(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && 'version' in value;
+}
+
+function migrateUnversionedState(state: z.infer<typeof unversionedDedupStateSchema>): DedupState {
+  const commandRecords = Object.fromEntries(
+    Object.entries(state.commandRecords).map(([transactionId, record]) => {
+      if (record.status === 'in_progress') {
+        return [transactionId, record];
+      }
+      if (!('response' in record)) {
+        return [
+          transactionId,
+          {
+            ...record,
+            legacyResponseUnavailable: true as const,
+          },
+        ];
+      }
+      if (
+        record.response.transaction_id !== transactionId ||
+        record.response.action !== record.action
+      ) {
+        throw new Error('Legacy command response identity does not match its command record');
+      }
+      const { action: _action, transaction_id: _transactionId, ...response } = record.response;
+      return [
+        transactionId,
+        {
+          ...record,
+          response,
+        },
+      ];
+    }),
+  );
+
+  return {
+    seenMessageIds: state.seenMessageIds,
+    commandRecords,
+  };
 }

--- a/locker-client/src/adapters/persistence/file-credential.store.ts
+++ b/locker-client/src/adapters/persistence/file-credential.store.ts
@@ -2,6 +2,10 @@ import fs from 'fs';
 import { z } from 'zod';
 import type { CredentialStorePort } from '../../ports/config.port';
 import { MQTT_CREDENTIALS_FILE } from '../../infrastructure/paths';
+import {
+  atomicWriteFileSync,
+  PersistentStateCorruptedError,
+} from '../../infrastructure/file-persistence';
 
 const credentialsSchema = z.object({
   username: z.string().min(1),
@@ -9,17 +13,33 @@ const credentialsSchema = z.object({
 });
 
 export class FileCredentialStore implements CredentialStorePort {
+  constructor(private readonly filePath: string = MQTT_CREDENTIALS_FILE) {}
+
   getCredentials(): { username: string; password: string } | null {
-    if (!fs.existsSync(MQTT_CREDENTIALS_FILE)) {
+    if (!fs.existsSync(this.filePath)) {
       return null;
     }
-    const raw = JSON.parse(fs.readFileSync(MQTT_CREDENTIALS_FILE, 'utf8'));
-    const parsed = credentialsSchema.safeParse(raw);
-    return parsed.success ? parsed.data : null;
+    fs.chmodSync(this.filePath, 0o600);
+    try {
+      const raw: unknown = JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+      const parsed = credentialsSchema.safeParse(raw);
+      if (!parsed.success) {
+        throw new PersistentStateCorruptedError('MQTT credentials', this.filePath);
+      }
+      return parsed.data;
+    } catch (error) {
+      if (error instanceof PersistentStateCorruptedError) {
+        throw error;
+      }
+      throw new PersistentStateCorruptedError('MQTT credentials', this.filePath, {
+        cause: error,
+      });
+    }
   }
 
   saveCredentials(credentials: { username: string; password: string }): void {
-    fs.writeFileSync(MQTT_CREDENTIALS_FILE, JSON.stringify(credentials, null, 2), 'utf8');
+    const parsed = credentialsSchema.parse(credentials);
+    atomicWriteFileSync(this.filePath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
   }
 
   isProvisioned(): boolean {

--- a/locker-client/src/adapters/persistence/file-credential.store.ts
+++ b/locker-client/src/adapters/persistence/file-credential.store.ts
@@ -5,6 +5,7 @@ import { MQTT_CREDENTIALS_FILE } from '../../infrastructure/paths';
 import {
   atomicWriteFileSync,
   PersistentStateCorruptedError,
+  readPrivateFileSync,
 } from '../../infrastructure/file-persistence';
 
 const credentialsSchema = z.object({
@@ -19,9 +20,8 @@ export class FileCredentialStore implements CredentialStorePort {
     if (!fs.existsSync(this.filePath)) {
       return null;
     }
-    fs.chmodSync(this.filePath, 0o600);
     try {
-      const raw: unknown = JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+      const raw: unknown = JSON.parse(readPrivateFileSync(this.filePath).toString('utf8'));
       const parsed = credentialsSchema.safeParse(raw);
       if (!parsed.success) {
         throw new PersistentStateCorruptedError('MQTT credentials', this.filePath);

--- a/locker-client/src/application/provision-device.ts
+++ b/locker-client/src/application/provision-device.ts
@@ -5,24 +5,41 @@ import { MqttSchemaValidationError, parseProvisioningResponse } from '../domain/
 import type { CredentialStorePort } from '../ports/config.port';
 import type { MessageTransportPort } from '../ports/mqtt.port';
 import { logger } from '../infrastructure/logging';
+import {
+  atomicWriteFileSync,
+  PersistentStateCorruptedError,
+} from '../infrastructure/file-persistence';
 
 export const DEFAULT_MQTT_BROKER_URL = 'mqtt://open-locker.cloud';
 
 export function getOrCreateClientId(clientIdFilePath: string): string {
-  if (process.env.MQTT_CLIENT_ID) {
-    return process.env.MQTT_CLIENT_ID;
+  const configuredClientId = process.env.MQTT_CLIENT_ID?.trim();
+  if (configuredClientId) {
+    validateClientId(configuredClientId, 'MQTT_CLIENT_ID');
+    return configuredClientId;
   }
 
   if (fs.existsSync(clientIdFilePath)) {
     const existing = fs.readFileSync(clientIdFilePath, 'utf8').trim();
-    if (existing) {
-      return existing;
+    try {
+      validateClientId(existing, clientIdFilePath);
+    } catch (error) {
+      throw new PersistentStateCorruptedError('MQTT client ID', clientIdFilePath, {
+        cause: error,
+      });
     }
+    return existing;
   }
 
   const clientId = `locker-client-${randomBytes(4).toString('hex')}`;
-  fs.writeFileSync(clientIdFilePath, clientId, 'utf8');
+  atomicWriteFileSync(clientIdFilePath, clientId, { mode: 0o600 });
   return clientId;
+}
+
+function validateClientId(clientId: string, source: string): void {
+  if (!/^[A-Za-z0-9:_-]{1,128}$/.test(clientId)) {
+    throw new Error(`Invalid MQTT client ID in ${source}`);
+  }
 }
 
 export function getRequiredProvisioningDefaults(): {

--- a/locker-client/src/application/provision-device.ts
+++ b/locker-client/src/application/provision-device.ts
@@ -8,6 +8,7 @@ import { logger } from '../infrastructure/logging';
 import {
   atomicWriteFileSync,
   PersistentStateCorruptedError,
+  readPrivateFileSync,
 } from '../infrastructure/file-persistence';
 
 export const DEFAULT_MQTT_BROKER_URL = 'mqtt://open-locker.cloud';
@@ -20,7 +21,7 @@ export function getOrCreateClientId(clientIdFilePath: string): string {
   }
 
   if (fs.existsSync(clientIdFilePath)) {
-    const existing = fs.readFileSync(clientIdFilePath, 'utf8').trim();
+    const existing = readPrivateFileSync(clientIdFilePath).toString('utf8').trim();
     try {
       validateClientId(existing, clientIdFilePath);
     } catch (error) {

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -29,17 +29,20 @@ import {
 import { connectionLostWillOptions } from '../infrastructure/mqtt-will';
 import { logger } from '../infrastructure/logging';
 import { createWinstonLoggerPort } from '../infrastructure/winston-logger.adapter';
-import { MQTT_CLIENT_ID_FILE } from '../infrastructure/paths';
+import { DATA_DIR, MQTT_CLIENT_ID_FILE } from '../infrastructure/paths';
+import { ensurePrivateDirectory } from '../infrastructure/file-persistence';
 
 export interface AppContext {
   shutdown(): Promise<void>;
 }
 
 export async function createApp(): Promise<AppContext> {
+  ensurePrivateDirectory(DATA_DIR);
   const configRepo = new YamlConfigRepository(new FileRuntimeOverlayStore());
   const config = configRepo.load();
   const credentialStore = new FileCredentialStore();
   const dedupStore = new FileDedupStore();
+  dedupStore.assertHealthy();
   const transport = new MqttTransportAdapter(configRepo.getMqttTransportSettings());
 
   const driver = new WaveshareModbusRtuDriver({

--- a/locker-client/src/infrastructure/file-persistence.ts
+++ b/locker-client/src/infrastructure/file-persistence.ts
@@ -8,6 +8,7 @@ export interface AtomicWriteFileSystem {
   fsyncSync: typeof fs.fsyncSync;
   closeSync: typeof fs.closeSync;
   chmodSync: typeof fs.chmodSync;
+  fchmodSync: typeof fs.fchmodSync;
   renameSync: typeof fs.renameSync;
   unlinkSync: typeof fs.unlinkSync;
   mkdirSync: typeof fs.mkdirSync;
@@ -31,9 +32,37 @@ export class PersistentStateCorruptedError extends Error {
 
 export function ensurePrivateDirectory(
   directoryPath: string,
-  fileSystem: Pick<AtomicWriteFileSystem, 'mkdirSync'> = fs,
+  fileSystem: Pick<
+    AtomicWriteFileSystem,
+    'mkdirSync' | 'chmodSync' | 'openSync' | 'fchmodSync' | 'closeSync'
+  > = fs,
 ): void {
   fileSystem.mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+  if (process.platform === 'win32') {
+    fileSystem.chmodSync(directoryPath, 0o700);
+    return;
+  }
+
+  const descriptor = fileSystem.openSync(
+    directoryPath,
+    fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW,
+  );
+  try {
+    fileSystem.fchmodSync(descriptor, 0o700);
+  } finally {
+    fileSystem.closeSync(descriptor);
+  }
+}
+
+export function readPrivateFileSync(filePath: string): Buffer {
+  const noFollowFlag = process.platform === 'win32' ? 0 : fs.constants.O_NOFOLLOW;
+  const descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | noFollowFlag);
+  try {
+    fs.fchmodSync(descriptor, 0o600);
+    return fs.readFileSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }
 
 export function atomicWriteFileSync(
@@ -69,10 +98,10 @@ export function atomicWriteFileSync(
       }
       offset += written;
     }
+    fileSystem.fchmodSync(descriptor, mode);
     fileSystem.fsyncSync(descriptor);
     fileSystem.closeSync(descriptor);
     descriptor = null;
-    fileSystem.chmodSync(temporaryPath, mode);
     fileSystem.renameSync(temporaryPath, filePath);
   } catch (error) {
     if (descriptor !== null) {
@@ -86,9 +115,7 @@ export function atomicWriteFileSync(
       fileSystem.unlinkSync(temporaryPath);
     } catch (cleanupError) {
       if (!isMissingFileError(cleanupError)) {
-        throw new Error(`Failed to persist ${filePath}`, {
-          cause: cleanupError,
-        });
+        throw persistenceCleanupError(filePath, error, cleanupError);
       }
     }
     throw error;
@@ -97,25 +124,71 @@ export function atomicWriteFileSync(
   flushDirectoryBestEffort(directory, fileSystem);
 }
 
+function persistenceCleanupError(
+  filePath: string,
+  primaryError: unknown,
+  cleanupError: unknown,
+): AggregateError {
+  return new AggregateError(
+    [primaryError, cleanupError],
+    `Failed to persist ${filePath} and remove its temporary file`,
+    { cause: primaryError },
+  );
+}
+
 function flushDirectoryBestEffort(
   directory: string,
   fileSystem: Pick<AtomicWriteFileSystem, 'openSync' | 'fsyncSync' | 'closeSync'>,
 ): void {
   let descriptor: number | null = null;
+  let operationError: unknown;
   try {
     descriptor = fileSystem.openSync(directory, 'r');
     fileSystem.fsyncSync(descriptor);
-  } catch {
-    // The rename already committed; directory fsync is not supported on every filesystem.
-  } finally {
-    if (descriptor !== null) {
-      try {
-        fileSystem.closeSync(descriptor);
-      } catch {
-        // The data file was already flushed and renamed.
-      }
+  } catch (error) {
+    operationError = error;
+  }
+
+  let closeError: unknown;
+  if (descriptor !== null) {
+    try {
+      fileSystem.closeSync(descriptor);
+    } catch (error) {
+      closeError = error;
     }
   }
+
+  if (operationError !== undefined && !isUnsupportedDirectoryFsyncError(operationError)) {
+    const cause =
+      closeError === undefined
+        ? operationError
+        : new AggregateError([operationError, closeError], 'Directory flush and close failed', {
+            cause: operationError,
+          });
+    throw directoryFlushError(directory, cause);
+  }
+  if (closeError !== undefined) {
+    throw directoryFlushError(directory, closeError);
+  }
+}
+
+function directoryFlushError(directory: string, cause: unknown): Error {
+  return new Error(
+    `Persistent state rename completed, but directory flush failed for ${directory}`,
+    {
+      cause,
+    },
+  );
+}
+
+function isUnsupportedDirectoryFsyncError(error: unknown): boolean {
+  if (!(error instanceof Error) || !('code' in error)) {
+    return false;
+  }
+  if (error.code === 'EINVAL' || error.code === 'ENOTSUP' || error.code === 'EOPNOTSUPP') {
+    return true;
+  }
+  return process.platform === 'win32' && (error.code === 'EISDIR' || error.code === 'EPERM');
 }
 
 function isMissingFileError(error: unknown): boolean {

--- a/locker-client/src/infrastructure/file-persistence.ts
+++ b/locker-client/src/infrastructure/file-persistence.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export interface AtomicWriteFileSystem {
+  openSync: typeof fs.openSync;
+  writeSync: typeof fs.writeSync;
+  fsyncSync: typeof fs.fsyncSync;
+  closeSync: typeof fs.closeSync;
+  chmodSync: typeof fs.chmodSync;
+  renameSync: typeof fs.renameSync;
+  unlinkSync: typeof fs.unlinkSync;
+  mkdirSync: typeof fs.mkdirSync;
+}
+
+interface AtomicWriteOptions {
+  mode?: number;
+  fileSystem?: AtomicWriteFileSystem;
+}
+
+export class PersistentStateCorruptedError extends Error {
+  constructor(
+    public readonly stateType: string,
+    public readonly filePath: string,
+    options?: ErrorOptions,
+  ) {
+    super(`${stateType} is corrupt or incomplete: ${filePath}`, options);
+    this.name = 'PersistentStateCorruptedError';
+  }
+}
+
+export function ensurePrivateDirectory(
+  directoryPath: string,
+  fileSystem: Pick<AtomicWriteFileSystem, 'mkdirSync'> = fs,
+): void {
+  fileSystem.mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+}
+
+export function atomicWriteFileSync(
+  filePath: string,
+  contents: string | Buffer,
+  options: AtomicWriteOptions = {},
+): void {
+  const fileSystem = options.fileSystem ?? fs;
+  const mode = options.mode ?? 0o600;
+  const directory = path.dirname(filePath);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const buffer = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8');
+  let descriptor: number | null = null;
+
+  ensurePrivateDirectory(directory, fileSystem);
+
+  try {
+    descriptor = fileSystem.openSync(temporaryPath, 'wx', mode);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const written = fileSystem.writeSync(
+        descriptor,
+        buffer,
+        offset,
+        buffer.length - offset,
+        null,
+      );
+      if (written === 0) {
+        throw new Error(`Unable to complete persistent write: ${filePath}`);
+      }
+      offset += written;
+    }
+    fileSystem.fsyncSync(descriptor);
+    fileSystem.closeSync(descriptor);
+    descriptor = null;
+    fileSystem.chmodSync(temporaryPath, mode);
+    fileSystem.renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (descriptor !== null) {
+      try {
+        fileSystem.closeSync(descriptor);
+      } catch {
+        // Preserve the original write error.
+      }
+    }
+    try {
+      fileSystem.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      if (!isMissingFileError(cleanupError)) {
+        throw new Error(`Failed to persist ${filePath}`, {
+          cause: cleanupError,
+        });
+      }
+    }
+    throw error;
+  }
+
+  flushDirectoryBestEffort(directory, fileSystem);
+}
+
+function flushDirectoryBestEffort(
+  directory: string,
+  fileSystem: Pick<AtomicWriteFileSystem, 'openSync' | 'fsyncSync' | 'closeSync'>,
+): void {
+  let descriptor: number | null = null;
+  try {
+    descriptor = fileSystem.openSync(directory, 'r');
+    fileSystem.fsyncSync(descriptor);
+  } catch {
+    // The rename already committed; directory fsync is not supported on every filesystem.
+  } finally {
+    if (descriptor !== null) {
+      try {
+        fileSystem.closeSync(descriptor);
+      } catch {
+        // The data file was already flushed and renamed.
+      }
+    }
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}

--- a/locker-client/src/ports/mqtt.port.ts
+++ b/locker-client/src/ports/mqtt.port.ts
@@ -5,8 +5,15 @@ export interface OutboundPublishOptions {
 
 export interface CommandResponseBody {
   action: string;
-  result: 'success' | 'error';
   transaction_id: string;
+  result: 'success' | 'error';
+  message?: string;
+  error_code?: string;
+  applied_config_hash?: string;
+}
+
+export interface StoredCommandResponse {
+  result: 'success' | 'error';
   message?: string;
   error_code?: string;
   applied_config_hash?: string;
@@ -42,13 +49,36 @@ export interface MqttTransportSettings {
   maxReconnectAttempts: number;
 }
 
-export interface CommandRecord {
+interface CommandRecordBase {
   action: string;
-  status: 'in_progress' | 'completed';
   updatedAt: string;
-  response?: CommandResponseBody;
-  responseDeliveredAt?: string;
 }
+
+export interface InProgressCommandRecord extends CommandRecordBase {
+  status: 'in_progress';
+  response?: never;
+  responseDeliveredAt?: never;
+  legacyResponseUnavailable?: never;
+}
+
+export interface CompletedCommandRecord extends CommandRecordBase {
+  status: 'completed';
+  response: StoredCommandResponse;
+  responseDeliveredAt?: string;
+  legacyResponseUnavailable?: never;
+}
+
+export interface LegacyCompletedCommandRecord extends CommandRecordBase {
+  status: 'completed';
+  legacyResponseUnavailable: true;
+  response?: never;
+  responseDeliveredAt?: never;
+}
+
+export type CommandRecord =
+  | InProgressCommandRecord
+  | CompletedCommandRecord
+  | LegacyCompletedCommandRecord;
 
 export interface DedupStorePort {
   hasSeenMessageId(messageId: string): boolean;
@@ -56,7 +86,11 @@ export interface DedupStorePort {
   getCommandRecord(transactionId: string): CommandRecord | null;
   listCommandRecords(): Array<{ transactionId: string; record: CommandRecord }>;
   markCommandInProgress(transactionId: string, action: string): void;
-  markCommandCompleted(transactionId: string, action: string, response: CommandResponseBody): void;
+  markCommandCompleted(
+    transactionId: string,
+    action: string,
+    response: StoredCommandResponse,
+  ): void;
   markCommandResponsePending(transactionId: string): void;
   markCommandResponseDelivered(transactionId: string): void;
 }

--- a/locker-client/tests/unit/command-dispatcher.test.ts
+++ b/locker-client/tests/unit/command-dispatcher.test.ts
@@ -141,6 +141,47 @@ test('dispatcher ignores duplicate message_id before side effects', async () => 
   assert.equal(commandResponses(published).length, 1);
 });
 
+test('legacy dedup migration never repeats a completed physical command', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-legacy-dedup-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, 'dedup.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      seenMessageIds: {},
+      commandRecords: {
+        'txn-legacy-completed': {
+          action: 'open_compartment',
+          status: 'completed',
+          updatedAt: '2026-04-11T10:00:00Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  const store = new FileDedupStore(file);
+  store.assertHealthy();
+  const { bus, dispatcher, openCompartment, published } = createDispatcherHarness(
+    new FakeLockerBus([1]),
+    store,
+  );
+
+  await dispatcher.dispatch(
+    'locker/test/command',
+    JSON.stringify({
+      action: 'open_compartment',
+      transaction_id: 'txn-legacy-completed',
+      message_id: 'msg-after-migration',
+      timestamp: '2026-04-11T10:00:00Z',
+      data: { compartment_number: 1 },
+    }),
+  );
+
+  openCompartment.stopAllMonitoring();
+  assert.equal(bus.flashCalls.length, 0);
+  assert.equal(commandResponses(published).length, 0);
+});
+
 test('dispatcher rejects invalid payload with structured error', async () => {
   const { bus, dispatcher, openCompartment, published } = createDispatcherHarness();
 
@@ -208,9 +249,7 @@ test('invalid response remains persistently pending after publish failure and ca
 test('invalid duplicate does not overwrite a completed success response', async () => {
   const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
   const successResponse = {
-    action: 'open_compartment',
     result: 'success' as const,
-    transaction_id: 'txn-invalid-duplicate',
     message: 'Compartment opened.',
   };
   dedup.markCommandCompleted('txn-invalid-duplicate', 'open_compartment', successResponse);
@@ -324,9 +363,7 @@ test('failed open stores and replays its error without retrying hardware', async
 test('duplicate completed open_compartment replays its stored response', async () => {
   const { bus, dedup, dispatcher, openCompartment, published } = createDispatcherHarness();
   dedup.markCommandCompleted('txn-dup', 'open_compartment', {
-    action: 'open_compartment',
     result: 'success',
-    transaction_id: 'txn-dup',
     message: 'Compartment opened.',
   });
 
@@ -368,9 +405,7 @@ test('apply_config replays a completed response without re-running', async () =>
   dispatcher.register(createApplyConfigHandler({ applyConfig }));
 
   dedup.markCommandCompleted('txn-apply-dup', 'apply_config', {
-    action: 'apply_config',
     result: 'success',
-    transaction_id: 'txn-apply-dup',
     applied_config_hash: configHash,
     message: 'Configuration applied.',
   });
@@ -551,9 +586,7 @@ test('failed delivered duplicate replay is pending and flushes on reconnect', as
 test('flush rescans when requested while another flush is active', async () => {
   const dedup = new InMemoryDedupStore();
   dedup.markCommandCompleted('txn-first', 'open_compartment', {
-    action: 'open_compartment',
     result: 'success',
-    transaction_id: 'txn-first',
   });
   let releaseFirstPublish: (() => void) | undefined;
   const firstPublishBlocked = new Promise<void>((resolve) => {
@@ -577,9 +610,7 @@ test('flush rescans when requested while another flush is active', async () => {
   const firstFlush = dispatcher.flushPendingResponses();
   await firstPublishHasStarted;
   dedup.markCommandCompleted('txn-second', 'open_compartment', {
-    action: 'open_compartment',
     result: 'success',
-    transaction_id: 'txn-second',
   });
   const followUpFlush = dispatcher.flushPendingResponses();
   assert.equal(firstFlush, followUpFlush);

--- a/locker-client/tests/unit/dedup-store.test.ts
+++ b/locker-client/tests/unit/dedup-store.test.ts
@@ -12,6 +12,24 @@ import { InboundProtocolGuard } from '../../src/adapters/mqtt/inbound-protocol-g
 import { OutboundMqttAdapter } from '../../src/adapters/mqtt/outbound-mqtt.adapter';
 import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
 
+const supportsUnixModes = process.platform !== 'win32';
+
+test(
+  'existing dedup and response state permissions are hardened on read',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const file = createStoreFile(t);
+    fs.writeFileSync(file, JSON.stringify({ version: 2, seenMessageIds: {}, commandRecords: {} }), {
+      mode: 0o644,
+    });
+    fs.chmodSync(file, 0o644);
+
+    new FileDedupStore(file).assertHealthy();
+
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  },
+);
+
 test('completed response survives a store restart and can be sent', async (t) => {
   const file = createStoreFile(t);
   const store = new FileDedupStore(file);

--- a/locker-client/tests/unit/dedup-store.test.ts
+++ b/locker-client/tests/unit/dedup-store.test.ts
@@ -4,25 +4,37 @@ import os from 'node:os';
 import path from 'node:path';
 import { test, type TestContext } from 'node:test';
 import { CommandDispatcher } from '../../src/adapters/mqtt/command-dispatcher';
-import { FileDedupStore } from '../../src/adapters/mqtt/dedup-store';
+import {
+  DEFAULT_DELIVERED_COMMAND_RETENTION_MS,
+  FileDedupStore,
+} from '../../src/adapters/mqtt/dedup-store';
 import { InboundProtocolGuard } from '../../src/adapters/mqtt/inbound-protocol-guard';
 import { OutboundMqttAdapter } from '../../src/adapters/mqtt/outbound-mqtt.adapter';
+import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
 
 test('completed response survives a store restart and can be sent', async (t) => {
   const file = createStoreFile(t);
   const store = new FileDedupStore(file);
   store.markCommandCompleted('txn-completed', 'open_compartment', {
-    action: 'open_compartment',
     result: 'success',
-    transaction_id: 'txn-completed',
     message: 'Compartment opened.',
   });
 
   const restartedStore = new FileDedupStore(file);
   const record = restartedStore.getCommandRecord('txn-completed');
+  const persisted = JSON.parse(fs.readFileSync(file, 'utf8')) as {
+    commandRecords: Record<string, { response: Record<string, unknown> }>;
+  };
 
   assert.equal(record?.status, 'completed');
-  assert.equal(record?.response?.transaction_id, 'txn-completed');
+  assert.deepEqual(record?.response, {
+    result: 'success',
+    message: 'Compartment opened.',
+  });
+  assert.deepEqual(persisted.commandRecords['txn-completed']?.response, {
+    result: 'success',
+    message: 'Compartment opened.',
+  });
   assert.equal(record?.responseDeliveredAt, undefined);
   assert.deepEqual(
     restartedStore.listCommandRecords().map(({ transactionId }) => transactionId),
@@ -40,6 +52,13 @@ test('completed response survives a store restart and can be sent', async (t) =>
   await dispatcher.flushPendingResponses();
 
   assert.equal(published.length, 1);
+  const replayed = JSON.parse(published[0]!) as Record<string, unknown>;
+  assert.equal(replayed.action, 'open_compartment');
+  assert.equal(replayed.result, 'success');
+  assert.equal(replayed.transaction_id, 'txn-completed');
+  assert.equal(replayed.message, 'Compartment opened.');
+  assert.equal(typeof replayed.message_id, 'string');
+  assert.equal(typeof replayed.timestamp, 'string');
   assert.ok(restartedStore.getCommandRecord('txn-completed')?.responseDeliveredAt);
 });
 
@@ -53,7 +72,7 @@ test('in_progress record survives a store restart', (t) => {
   assert.equal(record?.action, 'open_compartment');
 });
 
-test('legacy dedup files remain readable without response fields', (t) => {
+test('legacy completed records without responses migrate explicitly and remain safe', (t) => {
   const file = createStoreFile(t);
   fs.writeFileSync(
     file,
@@ -72,14 +91,267 @@ test('legacy dedup files remain readable without response fields', (t) => {
     'utf8',
   );
 
-  const store = new FileDedupStore(file);
+  const store = new FileDedupStore(file, {
+    now: () => new Date('2026-04-20T00:00:00.000Z'),
+  });
 
   assert.equal(store.hasSeenMessageId('msg-legacy'), true);
   assert.deepEqual(store.getCommandRecord('txn-legacy'), {
     action: 'open_compartment',
     status: 'completed',
     updatedAt: '2026-04-11T10:00:01.000Z',
+    legacyResponseUnavailable: true,
   });
+  const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.equal(persisted.version, 2);
+  assert.equal(persisted.commandRecords['txn-legacy'].legacyResponseUnavailable, true);
+});
+
+test('legacy full responses migrate and replay with reconstructed identity', async (t) => {
+  const file = createStoreFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      seenMessageIds: {},
+      commandRecords: {
+        'txn-legacy-response': {
+          action: 'apply_config',
+          status: 'completed',
+          updatedAt: '2026-04-11T10:00:01.000Z',
+          response: {
+            action: 'apply_config',
+            result: 'success',
+            transaction_id: 'txn-legacy-response',
+            applied_config_hash: 'abc123',
+          },
+        },
+      },
+    }),
+    'utf8',
+  );
+
+  const store = new FileDedupStore(file);
+  store.assertHealthy();
+
+  assert.deepEqual(store.getCommandRecord('txn-legacy-response')?.response, {
+    result: 'success',
+    applied_config_hash: 'abc123',
+  });
+  const persisted = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.deepEqual(persisted.commandRecords['txn-legacy-response'].response, {
+    result: 'success',
+    applied_config_hash: 'abc123',
+  });
+
+  const published: string[] = [];
+  const dispatcher = new CommandDispatcher(
+    new InboundProtocolGuard(store),
+    new OutboundMqttAdapter(async (_topic, payload) => {
+      published.push(payload);
+    }, 'locker/test/response'),
+    store,
+  );
+  await dispatcher.flushPendingResponses();
+
+  const replayed = JSON.parse(published[0]!) as Record<string, unknown>;
+  assert.equal(replayed.transaction_id, 'txn-legacy-response');
+  assert.equal(replayed.action, 'apply_config');
+  assert.equal(replayed.applied_config_hash, 'abc123');
+});
+
+test('legacy responses with conflicting identity fail closed', (t) => {
+  const file = createStoreFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      seenMessageIds: {},
+      commandRecords: {
+        'txn-map-key': {
+          action: 'open_compartment',
+          status: 'completed',
+          updatedAt: '2026-04-11T10:00:01.000Z',
+          response: {
+            action: 'apply_config',
+            result: 'success',
+            transaction_id: 'txn-other',
+          },
+        },
+      },
+    }),
+    'utf8',
+  );
+
+  assert.throws(
+    () => new FileDedupStore(file).assertHealthy(),
+    (error: unknown) => error instanceof PersistentStateCorruptedError,
+  );
+});
+
+test('version 2 rejects redundant and semantically invalid command records', (t) => {
+  const invalidRecords = [
+    {
+      action: 'open_compartment',
+      status: 'completed',
+      updatedAt: '2026-04-11T10:00:01.000Z',
+      response: {
+        action: 'open_compartment',
+        result: 'success',
+        transaction_id: 'txn-invalid',
+      },
+    },
+    {
+      action: 'open_compartment',
+      status: 'completed',
+      updatedAt: '2026-04-11T10:00:01.000Z',
+    },
+    {
+      action: 'open_compartment',
+      status: 'in_progress',
+      updatedAt: '2026-04-11T10:00:01.000Z',
+      response: { result: 'success' },
+    },
+    {
+      action: 'open_compartment',
+      status: 'in_progress',
+      updatedAt: '2026-04-11T10:00:01.000Z',
+      responseDeliveredAt: '2026-04-11T10:00:02.000Z',
+    },
+  ];
+
+  for (const [index, record] of invalidRecords.entries()) {
+    const file = createStoreFile(t);
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        version: 2,
+        seenMessageIds: {},
+        commandRecords: { [`txn-invalid-${index}`]: record },
+      }),
+      'utf8',
+    );
+
+    assert.throws(
+      () => new FileDedupStore(file).assertHealthy(),
+      (error: unknown) => error instanceof PersistentStateCorruptedError,
+    );
+  }
+});
+
+test('corrupt dedup state fails closed and remains untouched', (t) => {
+  const file = createStoreFile(t);
+  const corruptContents = '{"seenMessageIds":';
+  fs.writeFileSync(file, corruptContents, 'utf8');
+
+  const store = new FileDedupStore(file);
+
+  assert.throws(
+    () => store.assertHealthy(),
+    (error: unknown) =>
+      error instanceof PersistentStateCorruptedError &&
+      error.stateType === 'MQTT deduplication and response state',
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), corruptContents);
+});
+
+test('seen message IDs are pruned by TTL and deterministic maximum size', (t) => {
+  const file = createStoreFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      seenMessageIds: {
+        expired: '2026-01-01T00:00:00.000Z',
+        oldest: '2026-04-20T00:00:00.000Z',
+        newerB: '2026-04-25T00:00:00.000Z',
+        newerA: '2026-04-25T00:00:00.000Z',
+      },
+      commandRecords: {},
+    }),
+    'utf8',
+  );
+
+  const store = new FileDedupStore(file, {
+    now: () => new Date('2026-05-01T00:00:00.000Z'),
+    seenMessageIdTtlMs: 15 * 24 * 60 * 60 * 1000,
+    maxSeenMessageIds: 2,
+  });
+  store.assertHealthy();
+
+  assert.equal(store.hasSeenMessageId('expired'), false);
+  assert.equal(store.hasSeenMessageId('oldest'), false);
+  assert.equal(store.hasSeenMessageId('newerA'), true);
+  assert.equal(store.hasSeenMessageId('newerB'), true);
+});
+
+test('pending, undelivered, and in-progress command records are never pruned', (t) => {
+  const file = createStoreFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 2,
+      seenMessageIds: {},
+      commandRecords: {
+        'txn-pending': {
+          action: 'open_compartment',
+          status: 'completed',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          response: {
+            result: 'success',
+          },
+        },
+        'txn-legacy': {
+          action: 'open_compartment',
+          status: 'completed',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          legacyResponseUnavailable: true,
+        },
+        'txn-unknown': {
+          action: 'open_compartment',
+          status: 'in_progress',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+
+  const store = new FileDedupStore(file, {
+    now: () => new Date('2026-05-01T00:00:00.000Z'),
+  });
+  store.assertHealthy();
+
+  assert.deepEqual(
+    store.listCommandRecords().map(({ transactionId }) => transactionId),
+    ['txn-pending', 'txn-legacy', 'txn-unknown'],
+  );
+});
+
+test('delivered completed records are pruned only after retention', (t) => {
+  const file = createStoreFile(t);
+  const now = new Date('2026-05-01T00:00:00.000Z');
+  const justWithinRetention = new Date(
+    now.getTime() - DEFAULT_DELIVERED_COMMAND_RETENTION_MS + 1,
+  ).toISOString();
+  const beyondRetention = new Date(
+    now.getTime() - DEFAULT_DELIVERED_COMMAND_RETENTION_MS - 1,
+  ).toISOString();
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 2,
+      seenMessageIds: {},
+      commandRecords: {
+        retained: deliveredRecord('retained', justWithinRetention),
+        pruned: deliveredRecord('pruned', beyondRetention),
+      },
+    }),
+    'utf8',
+  );
+
+  const store = new FileDedupStore(file, { now: () => now });
+  store.assertHealthy();
+
+  assert.ok(store.getCommandRecord('retained'));
+  assert.equal(store.getCommandRecord('pruned'), null);
 });
 
 test('write failures leave the cached state unchanged', (t) => {
@@ -95,9 +367,7 @@ test('write failures leave the cached state unchanged', (t) => {
   const commandFile = createStoreFile(t);
   const commandStore = new FileDedupStore(commandFile);
   commandStore.markCommandCompleted('txn-pending', 'open_compartment', {
-    action: 'open_compartment',
     result: 'success',
-    transaction_id: 'txn-pending',
   });
   const stateBeforeFailedWrite = commandStore.getCommandRecord('txn-pending');
   replaceFileWithDirectory(commandFile);
@@ -116,4 +386,16 @@ function createStoreFile(t: TestContext): string {
 function replaceFileWithDirectory(file: string): void {
   fs.rmSync(file);
   fs.mkdirSync(file);
+}
+
+function deliveredRecord(_transactionId: string, deliveredAt: string) {
+  return {
+    action: 'open_compartment',
+    status: 'completed',
+    updatedAt: deliveredAt,
+    response: {
+      result: 'success',
+    },
+    responseDeliveredAt: deliveredAt,
+  };
 }

--- a/locker-client/tests/unit/docker-entrypoint.test.ts
+++ b/locker-client/tests/unit/docker-entrypoint.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+
+const entrypoint = path.resolve(__dirname, '../../../docker-entrypoint.sh');
+const supportsFlock =
+  process.platform === 'linux' &&
+  spawnSync('flock', ['--version'], { stdio: 'ignore' }).status === 0;
+
+test(
+  'entrypoint excludes a second writer and releases the lock after a crash',
+  { skip: !supportsFlock },
+  async (t) => {
+    const root = createTemporaryDirectory(t);
+    const dataDirectory = path.join(root, 'data');
+    const readyFile = path.join(root, 'ready');
+    const environment = { ...process.env, DATA_DIR: dataDirectory };
+    const holder = spawn(
+      'sh',
+      [
+        entrypoint,
+        process.execPath,
+        '-e',
+        "require('node:fs').writeFileSync(process.argv[1], 'ready'); setInterval(() => {}, 1000)",
+        readyFile,
+      ],
+      { env: environment, stdio: 'ignore' },
+    );
+    t.after(() => {
+      if (holder.exitCode === null && holder.signalCode === null) {
+        holder.kill('SIGKILL');
+      }
+    });
+
+    await waitForFileOrExit(readyFile, holder);
+
+    const contender = spawnSync('sh', [entrypoint, process.execPath, '-e', 'process.exit(0)'], {
+      env: environment,
+      stdio: 'ignore',
+    });
+
+    assert.equal(contender.status, 75);
+    assert.equal(fs.statSync(dataDirectory).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(path.join(dataDirectory, '.locker-client.lock')).mode & 0o777, 0o600);
+
+    holder.kill('SIGKILL');
+    await waitForExit(holder);
+
+    assert.equal(fs.existsSync(path.join(dataDirectory, '.locker-client.lock')), true);
+    const successor = spawnSync('sh', [entrypoint, process.execPath, '-e', 'process.exit(0)'], {
+      env: environment,
+      stdio: 'ignore',
+    });
+    assert.equal(successor.status, 0);
+  },
+);
+
+function createTemporaryDirectory(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-entrypoint-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+async function waitForFileOrExit(file: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!fs.existsSync(file)) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`lock holder exited before becoming ready`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for lock holder`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+}

--- a/locker-client/tests/unit/file-credential.store.test.ts
+++ b/locker-client/tests/unit/file-credential.store.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+import { FileCredentialStore } from '../../src/adapters/persistence/file-credential.store';
+import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
+
+const supportsUnixModes = process.platform !== 'win32';
+
+test(
+  'new credentials are persisted with owner-only permissions',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const file = createCredentialFile(t);
+    const store = new FileCredentialStore(file);
+
+    store.saveCredentials({ username: 'locker-user', password: 'test-password' });
+
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  },
+);
+
+test(
+  'existing credentials with broad permissions are hardened on read',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const file = createCredentialFile(t);
+    fs.writeFileSync(file, JSON.stringify({ username: 'locker-user', password: 'test-password' }), {
+      mode: 0o644,
+    });
+    fs.chmodSync(file, 0o644);
+
+    const credentials = new FileCredentialStore(file).getCredentials();
+
+    assert.deepEqual(credentials, { username: 'locker-user', password: 'test-password' });
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  },
+);
+
+test('corrupt credentials fail closed and remain untouched', (t) => {
+  const file = createCredentialFile(t);
+  const corruptContents = '{"username":"locker-user"';
+  fs.writeFileSync(file, corruptContents, 'utf8');
+
+  assert.throws(
+    () => new FileCredentialStore(file).isProvisioned(),
+    (error: unknown) =>
+      error instanceof PersistentStateCorruptedError &&
+      error.stateType === 'MQTT credentials' &&
+      !error.message.includes(corruptContents),
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), corruptContents);
+});
+
+function createCredentialFile(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-credentials-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return path.join(directory, 'credentials.json');
+}

--- a/locker-client/tests/unit/file-persistence.test.ts
+++ b/locker-client/tests/unit/file-persistence.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+import {
+  atomicWriteFileSync,
+  ensurePrivateDirectory,
+  type AtomicWriteFileSystem,
+} from '../../src/infrastructure/file-persistence';
+
+const supportsUnixModes = process.platform !== 'win32';
+
+test(
+  'ensurePrivateDirectory creates a private data directory',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const root = createTemporaryDirectory(t);
+    const dataDirectory = path.join(root, 'data');
+
+    ensurePrivateDirectory(dataDirectory);
+
+    assert.equal(fs.statSync(dataDirectory).mode & 0o777, 0o700);
+  },
+);
+
+test('atomicWriteFileSync replaces an existing file and applies its mode', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  fs.writeFileSync(file, 'old state', 'utf8');
+
+  atomicWriteFileSync(file, 'new state', { mode: 0o600 });
+
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new state');
+  if (supportsUnixModes) {
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  }
+});
+
+test('atomic write failure before rename preserves the old target and removes temp files', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  fs.writeFileSync(file, 'old state', 'utf8');
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    renameSync() {
+      throw new Error('simulated rename failure');
+    },
+  };
+
+  assert.throws(
+    () => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }),
+    /simulated rename failure/,
+  );
+
+  assert.equal(fs.readFileSync(file, 'utf8'), 'old state');
+  assert.deepEqual(fs.readdirSync(directory), ['state.json']);
+});
+
+function createTemporaryDirectory(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-persistence-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}

--- a/locker-client/tests/unit/file-persistence.test.ts
+++ b/locker-client/tests/unit/file-persistence.test.ts
@@ -6,6 +6,7 @@ import { test, type TestContext } from 'node:test';
 import {
   atomicWriteFileSync,
   ensurePrivateDirectory,
+  readPrivateFileSync,
   type AtomicWriteFileSystem,
 } from '../../src/infrastructure/file-persistence';
 
@@ -23,6 +24,51 @@ test(
     assert.equal(fs.statSync(dataDirectory).mode & 0o777, 0o700);
   },
 );
+
+test(
+  'ensurePrivateDirectory hardens an existing data directory',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const root = createTemporaryDirectory(t);
+    const dataDirectory = path.join(root, 'data');
+    fs.mkdirSync(dataDirectory, { mode: 0o755 });
+    fs.chmodSync(dataDirectory, 0o755);
+
+    ensurePrivateDirectory(dataDirectory);
+
+    assert.equal(fs.statSync(dataDirectory).mode & 0o777, 0o700);
+  },
+);
+
+test('ensurePrivateDirectory refuses symbolic links', { skip: !supportsUnixModes }, (t) => {
+  const root = createTemporaryDirectory(t);
+  const target = path.join(root, 'target');
+  const link = path.join(root, 'data');
+  fs.mkdirSync(target);
+  fs.symlinkSync(target, link);
+
+  assert.throws(() => ensurePrivateDirectory(link));
+});
+
+test('readPrivateFileSync hardens and reads the opened file', { skip: !supportsUnixModes }, (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  fs.writeFileSync(file, 'private state', { mode: 0o644 });
+  fs.chmodSync(file, 0o644);
+
+  assert.equal(readPrivateFileSync(file).toString('utf8'), 'private state');
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+});
+
+test('readPrivateFileSync refuses symbolic links', { skip: !supportsUnixModes }, (t) => {
+  const directory = createTemporaryDirectory(t);
+  const target = path.join(directory, 'target.json');
+  const link = path.join(directory, 'state.json');
+  fs.writeFileSync(target, 'private state', 'utf8');
+  fs.symlinkSync(target, link);
+
+  assert.throws(() => readPrivateFileSync(link));
+});
 
 test('atomicWriteFileSync replaces an existing file and applies its mode', (t) => {
   const directory = createTemporaryDirectory(t);
@@ -56,6 +102,144 @@ test('atomic write failure before rename preserves the old target and removes te
   assert.equal(fs.readFileSync(file, 'utf8'), 'old state');
   assert.deepEqual(fs.readdirSync(directory), ['state.json']);
 });
+
+test('atomicWriteFileSync tolerates an unsupported directory fsync', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  let fsyncCalls = 0;
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    fsyncSync(descriptor) {
+      fsyncCalls += 1;
+      if (fsyncCalls === 2) {
+        throw nodeError('directory fsync unsupported', 'EINVAL');
+      }
+      fs.fsyncSync(descriptor);
+    },
+  };
+
+  assert.doesNotThrow(() => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }));
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new state');
+});
+
+test('atomicWriteFileSync propagates a directory storage error after rename', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  let fsyncCalls = 0;
+  const storageError = nodeError('simulated storage failure', 'EIO');
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    fsyncSync(descriptor) {
+      fsyncCalls += 1;
+      if (fsyncCalls === 2) {
+        throw storageError;
+      }
+      fs.fsyncSync(descriptor);
+    },
+  };
+
+  assert.throws(
+    () => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message.includes('rename completed') &&
+      error.cause === storageError,
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new state');
+});
+
+test('atomicWriteFileSync propagates a directory close error after rename', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  let closeCalls = 0;
+  const storageError = nodeError('simulated close failure', 'EIO');
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    closeSync(descriptor) {
+      closeCalls += 1;
+      if (closeCalls === 3) {
+        throw storageError;
+      }
+      fs.closeSync(descriptor);
+    },
+  };
+
+  assert.throws(
+    () => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message.includes('rename completed') &&
+      error.cause === storageError,
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new state');
+});
+
+test('atomicWriteFileSync preserves write and cleanup failures', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  const writeError = new Error('simulated rename failure');
+  const cleanupError = new Error('simulated cleanup failure');
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    renameSync() {
+      throw writeError;
+    },
+    unlinkSync() {
+      throw cleanupError;
+    },
+  };
+
+  assert.throws(
+    () => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }),
+    (error: unknown) =>
+      error instanceof AggregateError &&
+      error.cause === writeError &&
+      error.errors[0] === writeError &&
+      error.errors[1] === cleanupError,
+  );
+});
+
+test('atomicWriteFileSync fails instead of looping when a write makes no progress', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  const fileSystem: AtomicWriteFileSystem = {
+    ...fs,
+    writeSync() {
+      return 0;
+    },
+  };
+
+  assert.throws(
+    () => atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 }),
+    /Unable to complete persistent write/,
+  );
+  assert.deepEqual(fs.readdirSync(directory), []);
+});
+
+test('atomicWriteFileSync completes partial writes', (t) => {
+  const directory = createTemporaryDirectory(t);
+  const file = path.join(directory, 'state.json');
+  const fileSystem = {
+    ...fs,
+    writeSync(
+      descriptor: number,
+      buffer: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: number | null,
+    ) {
+      return fs.writeSync(descriptor, buffer, offset, Math.min(length, 2), position);
+    },
+  } as unknown as AtomicWriteFileSystem;
+
+  atomicWriteFileSync(file, 'new state', { fileSystem, mode: 0o600 });
+
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new state');
+});
+
+function nodeError(message: string, code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
+}
 
 function createTemporaryDirectory(t: TestContext): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-persistence-'));

--- a/locker-client/tests/unit/provision-device.test.ts
+++ b/locker-client/tests/unit/provision-device.test.ts
@@ -13,6 +13,8 @@ import type { CredentialStorePort } from '../../src/ports/config.port';
 import type { MessageTransportPort, MqttTransportSettings } from '../../src/ports/mqtt.port';
 import { assertMatchesSchema, readAsyncApiExample } from '../contract/jsonSchema';
 
+const supportsUnixModes = process.platform !== 'win32';
+
 class FakeMessageTransport implements MessageTransportPort {
   published: Array<{ topic: string; payload: string }> = [];
   private messageHandler: ((topic: string, payload: Buffer) => void) | null = null;
@@ -77,6 +79,15 @@ test('client ID is created atomically and reused', (t) => {
   assert.match(created, /^locker-client-[a-f0-9]{8}$/);
   assert.equal(reused, created);
   assert.deepEqual(fs.readdirSync(path.dirname(file)), [path.basename(file)]);
+});
+
+test('existing client ID permissions are hardened on read', { skip: !supportsUnixModes }, (t) => {
+  const file = createClientIdFile(t);
+  fs.writeFileSync(file, 'locker-client-existing', { mode: 0o644 });
+  fs.chmodSync(file, 0o644);
+
+  assert.equal(getOrCreateClientId(file), 'locker-client-existing');
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600);
 });
 
 test('empty client ID fails closed and remains available for operator recovery', (t) => {

--- a/locker-client/tests/unit/provision-device.test.ts
+++ b/locker-client/tests/unit/provision-device.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
-import { provisionDevice } from '../../src/application/provision-device';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+import { getOrCreateClientId, provisionDevice } from '../../src/application/provision-device';
 import {
   MqttSchemaValidationError,
   parseProvisioningResponse,
 } from '../../src/domain/mqtt-parsing';
+import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
 import type { CredentialStorePort } from '../../src/ports/config.port';
 import type { MessageTransportPort, MqttTransportSettings } from '../../src/ports/mqtt.port';
 import { assertMatchesSchema, readAsyncApiExample } from '../contract/jsonSchema';
@@ -63,6 +67,37 @@ class FakeCredentialStore implements CredentialStorePort {
     return this.savedCredentials !== null;
   }
 }
+
+test('client ID is created atomically and reused', (t) => {
+  const file = createClientIdFile(t);
+
+  const created = getOrCreateClientId(file);
+  const reused = getOrCreateClientId(file);
+
+  assert.match(created, /^locker-client-[a-f0-9]{8}$/);
+  assert.equal(reused, created);
+  assert.deepEqual(fs.readdirSync(path.dirname(file)), [path.basename(file)]);
+});
+
+test('empty client ID fails closed and remains available for operator recovery', (t) => {
+  const file = createClientIdFile(t);
+  fs.writeFileSync(file, '  \n', 'utf8');
+
+  assert.throws(
+    () => getOrCreateClientId(file),
+    (error: unknown) =>
+      error instanceof PersistentStateCorruptedError && error.stateType === 'MQTT client ID',
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), '  \n');
+});
+
+test('invalid client ID fails closed instead of silently replacing identity', (t) => {
+  const file = createClientIdFile(t);
+  fs.writeFileSync(file, 'invalid client id', 'utf8');
+
+  assert.throws(() => getOrCreateClientId(file), PersistentStateCorruptedError);
+  assert.equal(fs.readFileSync(file, 'utf8'), 'invalid client id');
+});
 
 test('parseProvisioningResponse accepts AsyncAPI success example', () => {
   const example = readAsyncApiExample('provisioning-success.json');
@@ -216,3 +251,9 @@ test('provisionDevice rejects contract-shaped error reply', async () => {
     }
   }
 });
+
+function createClientIdFile(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-client-id-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return path.join(directory, '.mqtt-client-id');
+}

--- a/locker-client/tests/unit/runtime-overlay.store.test.ts
+++ b/locker-client/tests/unit/runtime-overlay.store.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test, type TestContext } from 'node:test';
+import { FileRuntimeOverlayStore } from '../../src/adapters/config/runtime-overlay.store';
+import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
+
+test('empty runtime overlay fails closed and is not replaced', (t) => {
+  const file = createOverlayFile(t);
+  fs.writeFileSync(file, '', 'utf8');
+
+  assert.throws(
+    () => new FileRuntimeOverlayStore(file).load(),
+    (error: unknown) =>
+      error instanceof PersistentStateCorruptedError &&
+      error.stateType === 'runtime configuration overlay',
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), '');
+});
+
+test('malformed runtime overlay fails closed and is not replaced', (t) => {
+  const file = createOverlayFile(t);
+  const corruptContents = '{"compartments":';
+  fs.writeFileSync(file, corruptContents, 'utf8');
+
+  assert.throws(
+    () => new FileRuntimeOverlayStore(file).load(),
+    (error: unknown) => error instanceof PersistentStateCorruptedError,
+  );
+  assert.equal(fs.readFileSync(file, 'utf8'), corruptContents);
+});
+
+function createOverlayFile(t: TestContext): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'open-locker-overlay-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return path.join(directory, 'runtime-overlay.json');
+}

--- a/locker-client/tests/unit/runtime-overlay.store.test.ts
+++ b/locker-client/tests/unit/runtime-overlay.store.test.ts
@@ -6,6 +6,23 @@ import { test, type TestContext } from 'node:test';
 import { FileRuntimeOverlayStore } from '../../src/adapters/config/runtime-overlay.store';
 import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
 
+const supportsUnixModes = process.platform !== 'win32';
+
+test(
+  'existing runtime overlay permissions are hardened on read',
+  { skip: !supportsUnixModes },
+  (t) => {
+    const file = createOverlayFile(t);
+    fs.writeFileSync(file, JSON.stringify({ mqtt: { heartbeatInterval: 30 } }), { mode: 0o644 });
+    fs.chmodSync(file, 0o644);
+
+    assert.deepEqual(new FileRuntimeOverlayStore(file).load(), {
+      mqtt: { heartbeatInterval: 30 },
+    });
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  },
+);
+
 test('empty runtime overlay fails closed and is not replaced', (t) => {
   const file = createOverlayFile(t);
   fs.writeFileSync(file, '', 'utf8');


### PR DESCRIPTION
## Summary
- add atomic owner-only persistence with fail-closed validation for credentials, client identity, runtime overlay, and MQTT recovery state
- normalize and migrate dedup state with deterministic retention while preserving pending responses and unknown command outcomes
- enforce one container writer per data directory with `flock` and document the security and recovery decisions in ADR-0033

## Test plan
- [x] `pnpm check`
- [x] `pnpm test` (155 passed, 1 platform-specific test skipped on macOS)
- [x] `docker build -t open-locker/locker-client:issue-168 .`
- [x] `docker compose config --quiet` with a secret-free validation override
- [x] verify lock contention exits with code 75 and lock recovery succeeds after SIGKILL

## Deployment note
The image remains root-based until deployments provide an explicit Raspberry Pi serial-device GID and matching `/data` ownership. ADR-0033 documents this constraint; broad device permissions are intentionally not introduced.

Closes #168

Made with [Cursor](https://cursor.com)