### PR TITLE
perf(mobile): cut Android internal build time where the profile says it goes (#204)

### DIFF
--- a/.github/workflows/mobile-app-build.yml
+++ b/.github/workflows/mobile-app-build.yml
@@ -28,6 +28,9 @@ concurrency:
 
 env:
   APP_ID_BASE: de.merona.openlocker
+  # Pinned rather than `@latest`: the build tool should not change underneath a
+  # release without a commit saying so. Bump deliberately.
+  EAS_CLI_VERSION: '21.8.0'
   EAS_BUILD_NO_EXPO_GO_WARNING: 'true'
 
 jobs:
@@ -54,6 +57,22 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      # The local EAS build runs Gradle under the runner's own GRADLE_USER_HOME,
+      # so this covers the wrapper distribution, the dependency cache and the
+      # Gradle build cache (task outputs keyed by input hash — the part that
+      # makes a warm run skip work rather than just skip downloads).
+      # Native dependency changes must not reuse stale outputs, so the key
+      # carries the lockfile and both Expo/EAS config files.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('mobile-app/pnpm-lock.yaml', 'mobile-app/app.config.ts', 'mobile-app/eas.json') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -61,7 +80,7 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          pnpm dlx eas-cli@latest build \
+          pnpm dlx eas-cli@${EAS_CLI_VERSION} build \
             --local --non-interactive \
             --profile production --platform android \
             --output ./build/openlocker-android.apk
@@ -98,7 +117,7 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          pnpm dlx eas-cli@latest build \
+          pnpm dlx eas-cli@${EAS_CLI_VERSION} build \
             --local --non-interactive \
             --profile production --platform ios \
             --output ./build/openlocker-ios.ipa
@@ -120,7 +139,7 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APP_VARIANT: production   # so app.config.ts resolves the production bundle id (no .dev suffix)
         run: |
-          pnpm dlx eas-cli@latest submit \
+          pnpm dlx eas-cli@${EAS_CLI_VERSION} submit \
             --non-interactive \
             --profile production --platform ios \
             --path ./build/openlocker-ios.ipa

--- a/docs/adr/0035-android-internal-build-abi-and-cache-strategy.md
+++ b/docs/adr/0035-android-internal-build-abi-and-cache-strategy.md
@@ -1,0 +1,110 @@
+# ADR-0035: Ship internal Android builds for physical-device ABIs only
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-12
+
+## Context
+
+The Android job in `mobile-app-build.yml` takes about 23 minutes, against roughly nine
+for iOS. Issue #204 assumed the difference was Gradle and EAS cache misses. Profiling the
+last successful run (`28397897877`) shows that assumption is wrong, and by a wide margin.
+
+Every step outside `eas build --local` — checkout, pnpm, `setup-java`, `pnpm install` —
+totals **16 seconds**. Of the 23m30s job, ~1.9m is pre-Gradle work (project compression,
+prebuild, eager bundle) and ~21.6m is Gradle. Gradle's own task-timing table attributes
+that time to three things:
+
+1. **Native C++ builds across four ABIs.** `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`
+   are each compiled from source for `expo-modules-core`, `react-native-reanimated`,
+   `react-native-worklets`, `react-native-screens` and `:app`. The four longest
+   wall-clock gaps in the entire run were per-ABI Reanimated builds (103s, 83s, 74s,
+   73s). The two emulator-only ABIs account for roughly **6–7 minutes**.
+2. **`lintVitalAnalyzeRelease` on every module** — safe-area-context 47s, expo 26.5s,
+   gesture-handler 23.2s, svg 20.6s, netinfo 19.9s. Roughly **2.5–3 minutes** spent
+   producing a lint report that no one reads, on an internal test build.
+3. **Kotlin/Java compilation** of the React Native libraries —
+   `react-native-screens:compileReleaseKotlin` alone is 59.5s.
+
+Downloads and toolchain installs — the Gradle distribution zip, NDK 27.1, CMake 3.22.1,
+a 44s cold daemon start — come to **3–4 minutes**. That is the entire share of the build
+that a dependency cache can address. Notably, there is no R8/minification step in the
+build at all, so shrinking configuration is not a lever here.
+
+The build also resolved `eas-cli@latest` on every run, at three call sites. A release
+tool that changes without a commit is a reproducibility problem independent of speed.
+
+## Decision
+
+Optimise for what the profile actually shows, in this order.
+
+**Build only the ABIs that ship to physical devices.** The production Android profile
+passes `-PreactNativeArchitectures=armeabi-v7a,arm64-v8a`. `x86` and `x86_64` exist for
+emulators; internal builds are distributed to real test devices, and Play Store delivery
+to physical hardware never uses them. This is the single largest saving and the only one
+that changes the artifact.
+
+**Skip lint on release builds** via `-x :app:lintVitalRelease`. Lint belongs in
+`mobile-app-ci.yml`, which runs on every push and is where a developer would actually
+read the result — not in the artifact-producing job.
+
+**Enable the Gradle build cache** (`--build-cache`) and persist `~/.gradle/caches` and
+`~/.gradle/wrapper` between runs with `actions/cache`. This covers dependency downloads
+*and* task outputs keyed by input hash, so a warm run skips recompiling unchanged native
+and Kotlin code rather than merely skipping downloads. The cache key carries
+`pnpm-lock.yaml`, `app.config.ts` and `eas.json`, so a native dependency change cannot
+restore stale outputs.
+
+**Pin the EAS CLI** to an explicit version in a workflow-level `EAS_CLI_VERSION`.
+
+Deliberately *not* done: caching the generated `android/` prebuild directory, which issue
+#204 proposed. Expo regenerates it from config on every build, and a restored copy is the
+most likely source of a build that succeeds while being subtly wrong. The Gradle build
+cache gets the same benefit with input-hash correctness.
+
+Signing behaviour is unchanged: credentials are still fetched from EAS at build time via
+`EXPO_TOKEN`, as decided in ADR-0028.
+
+## Alternatives Considered
+
+**Cache dependencies only, as issue #204 specified.** Safe and artifact-neutral, but the
+profile caps it at 3–4 minutes of 23. It would have shipped as a completed ticket that
+left the actual cost untouched.
+
+**Move to EAS cloud builds** instead of `--local`. Removes the runner from the critical
+path but reintroduces the build-minute cost that ADR-0028 chose local builds to avoid.
+
+**Build a single ABI (`arm64-v8a`).** Faster still, but `armeabi-v7a` is cheap relative
+to the emulator ABIs and dropping it would exclude older 32-bit test hardware.
+
+**Keep all four ABIs and accept the time.** Defensible while nobody waits on the Android
+job — it is triggered by push to `main` and by manual dispatch, not by PR review. Rejected
+because the emulator ABIs are pure waste for a device-distributed artifact.
+
+## Consequences
+
+The production Android APK no longer installs on x86/x86_64 Android emulators. Anyone
+testing on an emulator must build locally (`pnpm android`) or use an arm64 emulator image,
+which is the default on Apple Silicon. If emulator-installable internal artifacts become a
+requirement, the fix is a separate build profile that keeps all four ABIs, not reverting
+this one.
+
+Release lint no longer runs during the build; `mobile-app-ci.yml` remains the lint gate.
+
+Warm runs depend on cache restoration. A cold run — first build after a dependency change,
+or after the 7-day GitHub cache eviction — still pays the download and full-compile cost,
+so the improvement is a floor-to-ceiling range rather than a fixed number.
+
+The pinned EAS CLI version must now be bumped deliberately. That is the intent, but it
+adds a maintenance step that will otherwise drift.
+
+## References
+
+- Issue #204 — Cache Android dependencies in local EAS builds
+- ADR-0028 — Mobile internal test builds in CI (`0028-mobile-internal-test-builds-ci.md`)
+- Profiled run: GitHub Actions run `28397897877`, `mobile-app-build.yml`
+- `mobile-app/eas.json`, `.github/workflows/mobile-app-build.yml`

--- a/mobile-app/docs/internal-builds.md
+++ b/mobile-app/docs/internal-builds.md
@@ -97,9 +97,15 @@ This writes (all **gitignored**, never commit): `credentials.json`,
 
 ## Installing a build (for testers)
 
-### Android (anyone — device or emulator)
+### Android (physical devices, and arm64 emulators only)
 
 The Android job uploads an installable `.apk` as a GitHub Actions artifact.
+
+The APK is built for `armeabi-v7a` and `arm64-v8a` only — the emulator-only `x86`
+and `x86_64` ABIs cost about a third of the build time and never reach a real
+test device (see [ADR-0035](../../docs/adr/0035-android-internal-build-abi-and-cache-strategy.md)).
+On Apple Silicon the default emulator image is arm64 and installs fine. On an
+x86 emulator, build locally with `pnpm android` instead.
 
 1. Open the workflow run: GitHub → **Actions** → **Mobile App Build** → the run.
 2. Scroll to **Artifacts** → download **`openlocker-android`** (a zip).
@@ -110,8 +116,9 @@ The Android job uploads an installable `.apk` as a GitHub Actions artifact.
      ```bash
      adb install openlocker-android.apk
      ```
-   - **Emulator:** start the emulator, then `adb install openlocker-android.apk`
-     (or drag-and-drop the `.apk` onto the emulator window).
+   - **Emulator (arm64 image only):** start the emulator, then
+     `adb install openlocker-android.apk` (or drag-and-drop the `.apk` onto the
+     emulator window). An x86/x86_64 emulator rejects this APK — build locally.
 
    Download the artifact from the CLI instead of the browser:
 

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -23,7 +23,8 @@
       "channel": "production",
       "autoIncrement": true,
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleRelease --build-cache -PreactNativeArchitectures=armeabi-v7a,arm64-v8a -x :app:lintVitalRelease"
       },
       "env": {
         "APP_VARIANT": "production"


### PR DESCRIPTION
Closes #204.

Stacked on #207 — base branch is `chore/199-code-quality`.

## The profile first

Issue #204 assumed Gradle/EAS cache misses were behind the ~23-minute Android job. Profiling the last successful run (`28397897877`) says otherwise.

Everything outside `eas build --local` — checkout, pnpm, `setup-java`, `pnpm install` — totals **16 seconds**. Of 23m30s: ~1.9m pre-Gradle (compress, prebuild, eager bundle), ~21.6m Gradle. From Gradle's own task-timing table:

| Cost | Share | Notes |
| --- | --- | --- |
| Per-ABI native C++ builds | ~6–7 min for `x86` + `x86_64` alone | The four longest wall-clock gaps in the run were per-ABI Reanimated builds (103s, 83s, 74s, 73s) |
| `lintVitalAnalyzeRelease` across modules | ~2.5–3 min | safe-area-context 47s, expo 26.5s, gesture-handler 23.2s, svg 20.6s, netinfo 19.9s |
| Kotlin/Java compiles | — | `react-native-screens:compileReleaseKotlin` 59.5s, svg javac 40.4s |
| **Downloads / toolchain installs** | **3–4 min** | Gradle distribution zip, NDK 27.1, CMake 3.22.1, 44s cold daemon — the entire share a dependency cache can touch |

There is no R8/minification step in the build at all, so shrinking config is not a lever here.

## What this changes

- **Build only device ABIs** — `-PreactNativeArchitectures=armeabi-v7a,arm64-v8a`. The emulator-only ABIs are pure waste for an artifact distributed to physical test devices. Largest single saving, and the only change that alters the artifact.
- **Skip release lint** — `-x :app:lintVitalRelease`. Lint stays in `mobile-app-ci.yml`, which runs per push and is where anyone would actually read it.
- **Gradle build cache** — `--build-cache` plus `actions/cache` over `~/.gradle/caches` and `~/.gradle/wrapper`, so a warm run skips recompiling unchanged native and Kotlin code, not just re-downloading. Key carries `pnpm-lock.yaml` + `app.config.ts` + `eas.json`.
- **Pin the EAS CLI** — `EAS_CLI_VERSION: 21.8.0` replaces `eas-cli@latest` at three call sites. A release tool that changes without a commit is a reproducibility problem regardless of speed.

**Deliberately not done:** caching the generated `android/` prebuild directory, which the ticket proposed. Expo regenerates it from config every build, and a restored copy is the likeliest way to get a build that succeeds while being subtly wrong. The Gradle build cache gives the same benefit with input-hash correctness.

## Consequences

The APK no longer installs on x86/x86_64 emulators. `mobile-app/docs/internal-builds.md` now says so — arm64 emulator images (the Apple Silicon default) still work, otherwise build locally with `pnpm android`. If emulator-installable artifacts become a requirement, the answer is a separate profile that keeps all four ABIs, not reverting this.

Signing is untouched: credentials still come from EAS at build time via `EXPO_TOKEN`.

## Verification status

`eas.json` validates against the pinned CLI (`eas config --platform android --profile production` resolves the profile cleanly). The timing claims are **projections from the profile, not measured results** — the workflow only triggers on push to `main` and manual dispatch, so cold and warm dispatch runs on this branch are the actual measurement. I will post the before/after numbers here once they land.

Decision record: `docs/adr/0035-android-internal-build-abi-and-cache-strategy.md`.