### PR TITLE
fix(locker-client): complete runtime configuration handling (#174)

### DIFF
--- a/locker-client/docs/modbus-configuration.md
+++ b/locker-client/docs/modbus-configuration.md
@@ -43,12 +43,20 @@ the required inter-frame silence from the configured serial parameters; see
 
 ## Base config fields
 
-| Field             | Required | Default | Description                            |
-| ----------------- | -------- | ------- | -------------------------------------- |
-| `port`            | Yes      | -       | Serial port path (e.g. `/dev/ttyACM0`) |
-| `baudRate`        | No       | 9600    | Serial baud rate                       |
-| `dataBits`        | No       | 8       | Data bits (7 or 8)                     |
-| `stopBits`        | No       | 1       | Stop bits (1 or 2)                     |
-| `parity`          | No       | `none`  | Parity (`none`, `even`, or `odd`)      |
-| `timeout`         | No       | 1000    | Response timeout in milliseconds       |
-| `flashDurationMs` | No       | 200     | Relay flash duration in milliseconds   |
+| Field             | Required | Default | Accepted            | Description                            |
+| ----------------- | -------- | ------- | ------------------- | -------------------------------------- |
+| `port`            | Yes      | -       | non-empty           | Serial port path (e.g. `/dev/ttyACM0`) |
+| `baudRate`        | No       | 9600    | 1200 – 921600       | Serial baud rate                       |
+| `dataBits`        | No       | 8       | 7 or 8              | Data bits                              |
+| `stopBits`        | No       | 1       | 1 or 2              | Stop bits                              |
+| `parity`          | No       | `none`  | `none`/`even`/`odd` | Parity                                 |
+| `timeout`         | No       | 1000    | 50 – 60000 ms       | Response timeout in milliseconds       |
+| `flashDurationMs` | No       | 200     | 100 – 500 ms        | Relay flash duration in milliseconds   |
+
+A value outside its accepted range **fails at startup** rather than being
+clamped or ignored, so a mistake surfaces at the moment of deployment instead of
+becoming odd behaviour hours later. `baudRate` is bounded because it also drives
+the RTU inter-frame delay — a wrong value there would skew bus pacing silently.
+
+Absent fields fall back to the default; only a value that is present and
+unusable is rejected.

--- a/locker-client/src/adapters/config/yaml-config.repository.ts
+++ b/locker-client/src/adapters/config/yaml-config.repository.ts
@@ -53,6 +53,43 @@ function parseBaseConfig(raw: unknown): BaseLockerConfig {
   };
 }
 
+/**
+ * Bounds a numeric setting read from the operator-managed config file.
+ *
+ * The MQTT path is already strict — `apply_config` is schema-validated before
+ * it reaches the client. The file is not, and it is the one edited by hand on a
+ * device with no feedback loop, so a typo there deserves the louder failure of
+ * the two. `heartbeatInterval: 0` would otherwise reach `setInterval` and
+ * publish as fast as the loop allows.
+ *
+ * Absent stays absent: the caller's default applies. Only a value that is
+ * present and unusable throws.
+ */
+function requireBoundedSetting(
+  value: number | undefined,
+  name: string,
+  min: number,
+  max: number,
+  alsoAllow?: number,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${name} must be a number`);
+  }
+
+  if (alsoAllow !== undefined && value === alsoAllow) {
+    return;
+  }
+
+  if (value < min || value > max) {
+    const allowed = alsoAllow === undefined ? '' : ` (or ${alsoAllow})`;
+    throw new Error(`${name} must be between ${min} and ${max}${allowed}`);
+  }
+}
+
 export class YamlConfigRepository implements ConfigRepositoryPort {
   private config: EffectiveLockerConfig | null = null;
 
@@ -79,8 +116,28 @@ export class YamlConfigRepository implements ConfigRepositoryPort {
 
     normalizeFlashDurationMs(base.modbus.flashDurationMs);
 
+    // Timer and transport values, bounded at load so a bad file fails at
+    // startup rather than becoming odd behaviour hours later.
+    requireBoundedSetting(base.mqtt.keepaliveSeconds, 'mqtt.keepaliveSeconds', 5, 3600, 0);
+    requireBoundedSetting(base.mqtt.reconnectPeriodMs, 'mqtt.reconnectPeriodMs', 500, 300_000, 0);
+    requireBoundedSetting(base.mqtt.connectTimeoutMs, 'mqtt.connectTimeoutMs', 1_000, 120_000);
+    requireBoundedSetting(
+      base.mqtt.maxReconnectAttempts,
+      'mqtt.maxReconnectAttempts',
+      1,
+      Number.MAX_SAFE_INTEGER,
+      0,
+    );
+
     const overlay = this.overlayStore.load();
-    this.config = mergeRuntimeConfig(base, overlay);
+    const effective = mergeRuntimeConfig(base, overlay);
+
+    // The heartbeat interval reaches the effective config only through the
+    // runtime overlay — `apply_config` validates it on the way in, but the
+    // overlay is a file on disk and can be edited or corrupted after the fact.
+    requireBoundedSetting(effective.mqtt?.heartbeatInterval, 'mqtt.heartbeatInterval', 1, 300);
+
+    this.config = effective;
     return this.config;
   }
 

--- a/locker-client/src/adapters/config/yaml-config.repository.ts
+++ b/locker-client/src/adapters/config/yaml-config.repository.ts
@@ -71,6 +71,7 @@ function requireBoundedSetting(
   min: number,
   max: number,
   alsoAllow?: number,
+  requireInteger = false,
 ): void {
   if (value === undefined) {
     return;
@@ -80,6 +81,10 @@ function requireBoundedSetting(
     throw new Error(`${name} must be a number`);
   }
 
+  if (requireInteger && !Number.isInteger(value)) {
+    throw new Error(`${name} must be a whole number`);
+  }
+
   if (alsoAllow !== undefined && value === alsoAllow) {
     return;
   }
@@ -87,6 +92,24 @@ function requireBoundedSetting(
   if (value < min || value > max) {
     const allowed = alsoAllow === undefined ? '' : ` (or ${alsoAllow})`;
     throw new Error(`${name} must be between ${min} and ${max}${allowed}`);
+  }
+}
+
+/**
+ * Rejects a setting the driver only accepts from a fixed set. Absent stays
+ * absent, so the caller's default applies.
+ */
+function requireEnumSetting<T extends number | string>(
+  value: T | undefined,
+  name: string,
+  allowed: readonly T[],
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!allowed.includes(value)) {
+    throw new Error(`${name} must be one of ${allowed.join(', ')}`);
   }
 }
 
@@ -118,6 +141,15 @@ export class YamlConfigRepository implements ConfigRepositoryPort {
 
     // Timer and transport values, bounded at load so a bad file fails at
     // startup rather than becoming odd behaviour hours later.
+    // Serial framing. `baudRate` is not just handed to the driver: it drives the
+    // RTU inter-frame delay, so a bogus value degrades the pacing silently
+    // rather than failing loudly.
+    requireBoundedSetting(base.modbus.baudRate, 'modbus.baudRate', 1_200, 921_600);
+    requireBoundedSetting(base.modbus.timeout, 'modbus.timeout', 50, 60_000);
+    requireEnumSetting(base.modbus.dataBits, 'modbus.dataBits', [7, 8]);
+    requireEnumSetting(base.modbus.stopBits, 'modbus.stopBits', [1, 2]);
+    requireEnumSetting(base.modbus.parity, 'modbus.parity', ['none', 'even', 'odd']);
+
     requireBoundedSetting(base.mqtt.keepaliveSeconds, 'mqtt.keepaliveSeconds', 5, 3600, 0);
     requireBoundedSetting(base.mqtt.reconnectPeriodMs, 'mqtt.reconnectPeriodMs', 500, 300_000, 0);
     requireBoundedSetting(base.mqtt.connectTimeoutMs, 'mqtt.connectTimeoutMs', 1_000, 120_000);
@@ -135,7 +167,21 @@ export class YamlConfigRepository implements ConfigRepositoryPort {
     // The heartbeat interval reaches the effective config only through the
     // runtime overlay — `apply_config` validates it on the way in, but the
     // overlay is a file on disk and can be edited or corrupted after the fact.
-    requireBoundedSetting(effective.mqtt?.heartbeatInterval, 'mqtt.heartbeatInterval', 1, 300);
+    //
+    // No upper bound: the inbound schema is `positive()` and the admin panel
+    // sets only a minimum, so a ceiling here would reject a value the panel
+    // legitimately offers — the command would be accepted, written, and then
+    // fail on the reload it triggered.
+    requireBoundedSetting(
+      effective.mqtt?.heartbeatInterval,
+      'mqtt.heartbeatInterval',
+      1,
+      Number.MAX_SAFE_INTEGER,
+      undefined,
+      // The inbound schema is `int()`; the file should not be looser than the
+      // contract in the other direction either.
+      true,
+    );
 
     this.config = effective;
     return this.config;

--- a/locker-client/src/adapters/modbus/waveshare-modbus-bus-actor.ts
+++ b/locker-client/src/adapters/modbus/waveshare-modbus-bus-actor.ts
@@ -35,7 +35,12 @@ export class WaveshareModbusBusActor implements LockerBusPort {
   constructor(
     private readonly driver: WaveshareModbusDriver,
     reconnectOptions?: { maxAttempts?: number; delayMs?: number },
-    private readonly configuredSlaveIds: number[] = [1],
+    /**
+     * Accepts a getter so the boards are read when asked for, not captured once.
+     * A runtime `apply_config` can add or remove a board, and a snapshot taken
+     * at construction would still describe the fleet as it was at boot.
+     */
+    private readonly configuredSlaveIds: number[] | (() => number[]) = [1],
     private readonly tracing: TracingPort = noopTracing,
     private readonly log: LoggerPort = noopLogger,
   ) {
@@ -64,7 +69,9 @@ export class WaveshareModbusBusActor implements LockerBusPort {
   }
 
   getConfiguredSlaveIds(): number[] {
-    return [...this.configuredSlaveIds];
+    return typeof this.configuredSlaveIds === 'function'
+      ? [...this.configuredSlaveIds()]
+      : [...this.configuredSlaveIds];
   }
 
   async ensureConnected(): Promise<boolean> {

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -109,7 +109,7 @@ export async function createApp(): Promise<AppContext> {
   const bus = new WaveshareModbusBusActor(
     driver,
     { maxAttempts: DEFAULT_MODBUS_MAX_RECONNECT_ATTEMPTS, delayMs: 5000 },
-    configRepo.getConfiguredSlaveIds(),
+    () => configRepo.getConfiguredSlaveIds(),
     tracing,
     appLogger,
   );

--- a/locker-client/tests/unit/waveshare-modbus-bus-actor.test.ts
+++ b/locker-client/tests/unit/waveshare-modbus-bus-actor.test.ts
@@ -385,3 +385,20 @@ test('an unreachable bus is logged when ensureConnected gives up', async () => {
     'expected reconnect exhaustion to be logged at error level',
   );
 });
+
+test('configured slave ids are read live, so a runtime config change is visible', () => {
+  let boards = [1];
+  const driver = new FakeWaveshareModbusDriver();
+  const bus = new WaveshareModbusBusActor(driver, { maxAttempts: 0 }, () => boards);
+
+  assert.deepEqual(bus.getConfiguredSlaveIds(), [1]);
+
+  // apply_config adds a second relay board at runtime.
+  boards = [1, 2];
+
+  assert.deepEqual(
+    bus.getConfiguredSlaveIds(),
+    [1, 2],
+    'a board added after construction must be visible to the bus',
+  );
+});

--- a/locker-client/tests/unit/yaml-config.repository.test.ts
+++ b/locker-client/tests/unit/yaml-config.repository.test.ts
@@ -111,6 +111,19 @@ test('sentinel values that mean "disabled" stay allowed', () => {
   assert.equal(config.modbus.port, '/dev/ttyTEST');
 });
 
+test('a heartbeat the admin panel can legally set is accepted', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST']);
+
+  const overlay = new MemoryOverlayStore();
+  // Above the ceiling an earlier revision invented; the inbound schema is
+  // `positive()` and the panel sets only a minimum, so this must load.
+  overlay.save({ mqtt: { heartbeatInterval: 600 }, updatedAt: '2026-08-20T00:00:00Z' });
+
+  const config = new YamlConfigRepository(overlay, configFile).load();
+
+  assert.equal(config.mqtt?.heartbeatInterval, 600);
+});
+
 test('a corrupted overlay heartbeat is caught rather than reaching setInterval', () => {
   writeConfig(['modbus:', '  port: /dev/ttyTEST']);
 
@@ -120,5 +133,53 @@ test('a corrupted overlay heartbeat is caught rather than reaching setInterval',
   assert.throws(
     () => new YamlConfigRepository(overlay, configFile).load(),
     /heartbeatInterval must be between/,
+  );
+});
+
+test('a nonsensical baud rate fails at load rather than skewing RTU pacing', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  baudRate: 12']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /baudRate must be between/,
+  );
+});
+
+test('a non-numeric baud rate is rejected', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  baudRate: fast']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /baudRate must be a number/,
+  );
+});
+
+test('serial framing values outside the driver set are rejected', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  dataBits: 9']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /dataBits must be one of 7, 8/,
+  );
+});
+
+test('an unusable serial timeout is rejected', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  timeout: 0']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /timeout must be between/,
+  );
+});
+
+test('a fractional heartbeat is rejected, matching the inbound schema', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST']);
+
+  const overlay = new MemoryOverlayStore();
+  overlay.save({ mqtt: { heartbeatInterval: 1.5 }, updatedAt: '2026-08-20T00:00:00Z' });
+
+  assert.throws(
+    () => new YamlConfigRepository(overlay, configFile).load(),
+    /heartbeatInterval must be a whole number/,
   );
 });

--- a/locker-client/tests/unit/yaml-config.repository.test.ts
+++ b/locker-client/tests/unit/yaml-config.repository.test.ts
@@ -73,3 +73,52 @@ test('YamlConfigRepository returns empty slave ids for explicit empty runtime ma
   assert.deepEqual(repository.getConfiguredSlaveIds(), []);
   assert.deepEqual(repository.load().compartments, []);
 });
+
+function writeConfig(lines: string[]): void {
+  fs.writeFileSync(configFile, lines.join('\n'), 'utf8');
+}
+
+test('a transport setting outside its bounds fails at load, not hours later', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', 'mqtt:', '  connectTimeoutMs: 0']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /connectTimeoutMs must be between/,
+  );
+});
+
+test('a non-numeric transport setting is rejected', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', 'mqtt:', '  keepaliveSeconds: soon']);
+
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /keepaliveSeconds must be a number/,
+  );
+});
+
+test('sentinel values that mean "disabled" stay allowed', () => {
+  writeConfig([
+    'modbus:',
+    '  port: /dev/ttyTEST',
+    'mqtt:',
+    '  keepaliveSeconds: 0',
+    '  reconnectPeriodMs: 0',
+    '  maxReconnectAttempts: 0',
+  ]);
+
+  const config = new YamlConfigRepository(new MemoryOverlayStore(), configFile).load();
+
+  assert.equal(config.modbus.port, '/dev/ttyTEST');
+});
+
+test('a corrupted overlay heartbeat is caught rather than reaching setInterval', () => {
+  writeConfig(['modbus:', '  port: /dev/ttyTEST']);
+
+  const overlay = new MemoryOverlayStore();
+  overlay.save({ mqtt: { heartbeatInterval: 0 }, updatedAt: '2026-08-20T00:00:00Z' });
+
+  assert.throws(
+    () => new YamlConfigRepository(overlay, configFile).load(),
+    /heartbeatInterval must be between/,
+  );
+});


### PR DESCRIPTION
Closes #174.

Most of what the ticket describes was already handled by work since it was written on 14 July. Rather than assume that, each clause was checked — and where possible exercised against a live broker — before deciding what was left.

## Already resolved, verified rather than assumed

| Ticket clause | State | How it was checked |
|---|---|---|
| Reload refreshes derived values | works | Live: `apply_config` adding a compartment on a **new board** (slaveId 2) was accepted, and the retained snapshot came back `#1 #2 #3 #4` — polling followed the new mapping |
| Validate `apply_config` input | works | Live: duplicate relay target → `response apply_config error INVALID_CONFIG`. Schema also bounds `heartbeat_interval_seconds`, compartment numbers, slave ids and addresses |
| Config file presence and `modbus.port` | works | Throws at load |
| Flash duration bounds | works | Finite, min and max, enforced at load — the one setting that can cook a relay coil, so it was guarded first |
| Rollback on failed reload | works | Existing passing test: `apply config restores previous overlay when runtime reload fails` |
| Environment overrides | nothing to change | Env covers deployment (provisioning token, broker URL, credentials, paths, log level); the config file covers hardware and timing. The two sets are disjoint, and the code matches the documented deployment contract, so there is no precedence to resolve |

## What was actually missing

**1. Slave ids were captured, not read.** `WaveshareModbusBusActor` took its board list as a constructor argument and `reloadRuntimeConfig()` never refreshed it, so a board added by `apply_config` stayed invisible to the bus.

Latent rather than live: the only consumer is `runStartupFailsafe`, which runs at boot before any reload can arrive, and polling reads the config directly. But it is a trap for whoever adds the next caller. The list is now read when asked for.

**2. The validation asymmetry.** Commands arriving over MQTT are strictly checked. The operator-managed config file had almost none of that — only the flash duration, which is bounded because it can cook a relay coil. So `heartbeatInterval: 0` reached `setInterval` and published as fast as the loop allowed; `keepaliveSeconds`, `reconnectPeriodMs`, `connectTimeoutMs`, `maxReconnectAttempts` and every serial setting passed through unchecked, including non-numeric values.

The remote path being the strict one while the hand-edited one is not is backwards: the file is edited on a device with no feedback loop. Those values are now bounded at load, so a bad file fails at startup instead of becoming odd behaviour hours later. Sentinel zeros that mean "disabled" stay allowed.

**Serial values** are part of the same clause and are now covered: `baudRate` (1200–921600), `timeout` (50–60000 ms), and `dataBits` / `stopBits` / `parity` checked against the sets the driver's own types accept. `baudRate` matters most because it is not only handed to the driver — it feeds `calculateModbusRtuInterFrameDelayMs`, so a bogus value skews RTU bus pacing silently instead of failing, which is the opposite of what ADR-0035 exists to guarantee.

**The heartbeat bound says only what the contract says.** It is validated after the merge rather than on the base config, because the yaml key is deliberately ignored and the value only arrives through the runtime overlay — `apply_config` validates it inbound, but the overlay is a file on disk that can be edited or corrupted afterwards.

An earlier revision of this branch capped it at 300s. That was a number chosen for plausibility, and nothing upstream agreed with it: the inbound schema is `z.number().int().positive()` and the Filament field sets only `minValue(1)`. An admin could legally save 600, have it accepted and written, and then have the reload it triggered fail — recreating the asymmetry this PR set out to remove, inverted. A crash between the overlay write and the reload would also have left a file that threw on every boot, a crash loop on a device with no MQTT connection to correct it from.

The ceiling is now gone rather than widened: positive, whole, nothing more. The comment in the code explains why there is no maximum, since adding one back is the tempting move.

Nothing here touches flash duration.

## Verification

281 tests, 280 pass, 1 skipped; lint, format and typecheck clean. Ten new tests cover live slave ids, out-of-range and non-numeric transport and serial settings, framing values outside the driver's sets, sentinel zeros, a corrupted overlay heartbeat, a fractional heartbeat, and a heartbeat above the removed ceiling that must now load.

`locker-client/docs/modbus-configuration.md` gains the accepted range for every field — they were documented nowhere — and states that an out-of-range value fails at startup rather than being clamped, which matters for an existing deployment upgrading into stricter validation.

The reload and validation behaviour above was exercised against real Mosquitto and the backend using the fleet simulator, not only in unit tests.
