### PR TITLE
chore: address review findings from the stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,10 @@ docker/mosquitto/config/password.conf
 hardware/models/spacer1.stl
 hardware/models/spacer2.stl
 hardware/models/fillets3d.scad
+
+# Simulator scenarios hold real provisioning tokens, and the credential cache
+# holds the MQTT password issued on a bank's one-and-only provisioning. The
+# cache is written beside the scenario file, wherever the operator points it,
+# so these are ignored repo-wide rather than only under locker-client/.
+simulator-scenario.yml
+.simulator-credentials.json

--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@ Nächste Schritte
   - [x] Action triggert Aggregate-Event `CompartmentOpeningRequested`
   - [x] Reactor: Publish an `locker/{locker_bank_uuid}/command` (QoS 1)
   - [ ] Projector/Read-Model-Update (optional)
-  - [x] Tests (Feature + E2E via `mqtt:client-simulator`/Artisan)
+  - [x] Tests (Feature + E2E via the locker-client fleet simulator)
 - [ ] Heartbeat-Workflow implementieren (siehe `docs/mqtt_integration_plan.md`)
   - [ ] Listener für `locker/{uuid}/state` (Heartbeat/Telemetrie)
   - [x] Events/Projector: `HeartbeatReceived` → `last_seen`/`online_status`

--- a/docs/adr/0031-contract-aligned-locker-fleet-simulator.md
+++ b/docs/adr/0031-contract-aligned-locker-fleet-simulator.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adr/0040-separate-command-acknowledgement-from-door-open-detection.md
+++ b/docs/adr/0040-separate-command-acknowledgement-from-door-open-detection.md
@@ -278,6 +278,15 @@ is a known trade-off (see Risks).
 
 ### Risks
 
+- **The `events` queue must stay single-worker.** `DoorDetectionReactor` and
+  `CommandResponseReactor` both keep a derivation idempotent by reading whether
+  the derived event exists and then emitting it. That pair is not atomic, so two
+  consumers handling one redelivery would each find nothing and each emit. In an
+  event-sourced store the duplicate is permanent history and every replay counts
+  the open twice. Recorded in both compose files beside the worker command;
+  making the guard safe — an advisory lock, or a unique index over the
+  transaction id per event class — would remove the constraint.
+
 - **Timeout coupling.** Raising `heartbeat_interval_seconds` for an unrelated
   reason (a flaky network) silently lengthens door-detection waits. Mitigation:
   documented here; if it bites, introduce Alternative D as its own column.

--- a/docs/asyncapi/schemas/messages/state.json
+++ b/docs/asyncapi/schemas/messages/state.json
@@ -12,7 +12,8 @@
       "$ref": "../common/message-id.json"
     },
     "traceparent": {
-      "$ref": "../common/traceparent.json"
+      "$ref": "../common/traceparent.json",
+      "description": "Reserved for symmetry with the other envelopes. State topics are deliberately excluded from tracing on both sides — heartbeats and retained snapshots would dominate the trace backend — so this field is not sent on state messages today."
     },
     "timestamp": {
       "$ref": "../common/timestamp.json"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -196,6 +196,12 @@ count and two services; that is the complete round trip.
 | `OTEL_TRACES_SAMPLER_TRACEIDRATIO_RATIO`| Sampling ratio when using `traceidratio`.                            |
 | `OTEL_WORKER_MODE_FLUSH_AFTER_EACH_ITERATION` | **Set this to `true`.** See below.                             |
 
+> Sampling defaults to `always_on`, which is right for development and for
+> tracing a single open flow end to end — the reason this exists. It is the wrong
+> default for a fleet: every span from every bank, kept. Before pointing a
+> deployment at a collector, set `OTEL_TRACES_SAMPLER_TYPE=traceidratio` with a
+> ratio, or accept the volume deliberately rather than by omission.
+
 > Queue workers batch their spans and only flush periodically, so a job that
 > throws exports nothing — a failed reactor leaves a trace that simply stops
 > after the job was queued, with no error anywhere. The Compose overlay sets

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -28,7 +28,11 @@ cd locker-client
 cp simulator-scenario.yml.example simulator-scenario.yml
 ```
 
-Edit the copy — it is git-ignored, so your tokens stay out of the repo:
+Edit the copy — it is git-ignored, so your tokens stay out of the repo.
+The ignore rules cover exactly two names, `simulator-scenario.yml` and
+`.simulator-credentials.json`. A scenario kept under any other name, or a
+cache moved with `SIMULATOR_CREDENTIALS_FILE`, is **not** ignored and holds a
+real provisioning token — keep those outside the repository.
 
 ```yaml
 broker_url: mqtt://localhost:1883

--- a/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/UserAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/CompartmentResource/RelationManagers/UserAccessesRelationManager.php
@@ -37,7 +37,7 @@ class UserAccessesRelationManager extends RelationManager
             ->recordTitleAttribute('id')
             ->modifyQueryUsing(function (Builder $query): Builder {
                 /** @var Builder<CompartmentAccess> $query */
-                return $query->active();
+                return $query->active()->with(['user', 'grantedByUser']);
             })
             ->columns([
                 Tables\Columns\TextColumn::make('user.email')

--- a/locker-backend/app/Filament/Resources/UserResource/RelationManagers/CompartmentAccessesRelationManager.php
+++ b/locker-backend/app/Filament/Resources/UserResource/RelationManagers/CompartmentAccessesRelationManager.php
@@ -38,6 +38,17 @@ class CompartmentAccessesRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('id')
+            // Every column below reaches through `compartment`, and two reach a
+            // hop further into its latest open request. The actor columns reach
+            // sideways instead, resolved inside a per-row closure rather than a
+            // dotted column name — easy to miss for that reason, and just as
+            // much a query per row.
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with([
+                'compartment.lockerBank',
+                'compartment.latestOpenRequest',
+                'grantedByUser',
+                'revokedByUser',
+            ]))
             ->columns([
                 Tables\Columns\TextColumn::make('compartment.number')
                     ->label(__('Compartment'))

--- a/locker-backend/app/Projectors/CompartmentOpenRequestProjector.php
+++ b/locker-backend/app/Projectors/CompartmentOpenRequestProjector.php
@@ -132,14 +132,40 @@ class CompartmentOpenRequestProjector extends Projector
         ]);
     }
 
+    /**
+     * A command failure must not overwrite a door that was seen to move.
+     *
+     * The two race in one specific way: a command whose relay fired but whose
+     * response never published leaves an in-progress record on the client, and
+     * restart recovery answers it with an error — by which time detection may
+     * already have recorded the physical outcome. Letting that late failure win
+     * would discard an observed fact in favour of a stale one, which is the
+     * conflation this projection exists to prevent. The timestamp and error are
+     * still recorded, exactly as a late acknowledgement is.
+     */
     public function onCompartmentOpeningFailed(CompartmentOpeningFailed $event): void
     {
-        $this->applyToRequest($event->transactionId, [
-            'status' => CompartmentOpenRequestStatus::Failed,
+        $request = CompartmentOpenRequest::query()->where('command_id', $event->transactionId);
+
+        // What was reported is always recorded — the failure genuinely arrived,
+        // and a `failed_at` with no reason beside it leaves an admin reading the
+        // event stream to find out why. Only `status` is withheld, because that
+        // is the judgement about which fact wins.
+        (clone $request)->update([
             'failed_at' => $this->timestampOrNow($event->timestamp),
             'error_code' => $event->errorCode,
             'error_message' => $event->message,
         ]);
+
+        (clone $request)
+            ->whereNotIn('status', [
+                CompartmentOpenRequestStatus::Opened->value,
+                CompartmentOpenRequestStatus::AlreadyOpen->value,
+                CompartmentOpenRequestStatus::DoorJammed->value,
+            ])
+            ->update([
+                'status' => CompartmentOpenRequestStatus::Failed,
+            ]);
     }
 
     /**
@@ -170,7 +196,8 @@ class CompartmentOpenRequestProjector extends Projector
     /**
      * The app pins dates to CarbonImmutable (AppServiceProvider), but
      * Carbon::parse() hands back a mutable instance, so the two branches
-     * disagreed on type. Parse through the Date facade to honour the pin.
+     * disagreed on type. Parsing on CarbonImmutable directly keeps both
+     * branches immutable.
      */
     private function timestampOrNow(?string $timestamp): CarbonImmutable
     {

--- a/locker-backend/app/Reactors/CommandResponseReactor.php
+++ b/locker-backend/app/Reactors/CommandResponseReactor.php
@@ -15,6 +15,12 @@ use Illuminate\Support\Facades\Log;
 use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 
+/**
+ * Guards against re-deriving domain events from a redelivered command response
+ * with a read followed by a write, which is not atomic. That holds only while
+ * one worker consumes the `events` queue — see DoorDetectionReactor, which
+ * shares both the queue and the constraint.
+ */
 class CommandResponseReactor extends Reactor implements ShouldQueue
 {
     public string $queue = 'events';

--- a/locker-backend/app/Reactors/DoorDetectionReactor.php
+++ b/locker-backend/app/Reactors/DoorDetectionReactor.php
@@ -23,6 +23,13 @@ use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
  * The client reports the physical door separately from the command response, so
  * this is where "the door actually opened" enters the domain. Idempotent: a
  * redelivered device event does not produce a second derived event.
+ *
+ * That idempotence holds only while one worker consumes this queue. The guard
+ * is a read followed by a write, not an atomic operation, so two consumers
+ * handling the same redelivery would both find nothing recorded and both emit.
+ * Duplicated events here are permanent history — every replay would count the
+ * open twice — so the `events` queue must stay single-worker until the guard
+ * takes a lock or the store enforces uniqueness.
  */
 class DoorDetectionReactor extends Reactor implements ShouldQueue
 {

--- a/locker-backend/app/Services/CommandResponseInboxService.php
+++ b/locker-backend/app/Services/CommandResponseInboxService.php
@@ -26,10 +26,16 @@ class CommandResponseInboxService
     {
         $now = Carbon::now();
 
-        // message_id and traceparent identify the delivery, not the response. Hashing
-        // them would make every genuine replay — which always carries a fresh
-        // message_id — look like a payload that changed.
-        $semanticPayload = Arr::except($payload, ['message_id', MqttTraceContext::FIELD]);
+        // Fields that identify the delivery rather than the response: a genuine
+        // replay always carries a fresh message_id, usually a fresh timestamp,
+        // and its own trace context. Hashing any of them would make every
+        // legitimate replay look like a payload that changed, which is the
+        // opposite of what `payload_changed` is meant to tell an operator.
+        $semanticPayload = Arr::except($payload, [
+            'message_id',
+            'timestamp',
+            MqttTraceContext::FIELD,
+        ]);
         $payloadHash = hash('sha256', json_encode($semanticPayload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
 
         $action = isset($payload['action']) && is_string($payload['action']) ? $payload['action'] : null;
@@ -83,8 +89,8 @@ class CommandResponseInboxService
                 'locker_uuid' => $lockerUuid,
                 'transaction_id' => $transactionId,
                 'topic' => $topic,
-                // Same outcome, different bytes (a re-sent response usually carries a
-                // fresh timestamp), so it is context on the info line rather than an alert.
+                // Same outcome, genuinely different content — delivery fields are
+                // excluded from the hash, so this is not merely a re-sent copy.
                 'payload_changed' => $existing !== null && $existing->payload_hash !== $payloadHash,
             ]);
         }

--- a/locker-backend/app/Services/CompartmentService.php
+++ b/locker-backend/app/Services/CompartmentService.php
@@ -10,9 +10,13 @@ use App\Models\Compartment;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
 
 class CompartmentService
 {
+    /** Matches the `content_note` column and both entry-point validations. */
+    public const CONTENT_NOTE_MAX_LENGTH = 80;
+
     public function __construct(
         private readonly CompartmentAccessService $accessService,
     ) {}
@@ -49,6 +53,17 @@ class CompartmentService
     public function updateContentNote(User $actor, Compartment $compartment, ?string $note): Compartment
     {
         $this->ensureCanEditNote($actor, $compartment);
+
+        // The Filament form and the API request each cap this at 80, matching the
+        // column. Enforced here as well because what gets past this point becomes
+        // a stored event: a caller that skipped validation would record permanent
+        // history the read model cannot hold, failing only when the projector
+        // writes it.
+        if ($note !== null && mb_strlen($note) > self::CONTENT_NOTE_MAX_LENGTH) {
+            throw new InvalidArgumentException(
+                sprintf('Content note may not exceed %d characters.', self::CONTENT_NOTE_MAX_LENGTH),
+            );
+        }
 
         CompartmentContentNoteAggregate::retrieve((string) $compartment->id)
             ->updateNote(

--- a/locker-backend/docker-compose.prod.yml
+++ b/locker-backend/docker-compose.prod.yml
@@ -100,6 +100,11 @@ services:
       <<: *laravel_env_prod
       AUTORUN_ENABLED: "false"
       MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_event_worker"
+    # Single worker on purpose. DoorDetectionReactor and CommandResponseReactor
+    # both guard against duplicate derived events with a read-then-write, which
+    # is not atomic — a second consumer would let a redelivered event be
+    # recorded twice, and duplicated events are permanent history. Do not scale
+    # this service without making those guards safe first.
     command: "php artisan queue:work --queue=events --tries=3 --timeout=90"
     depends_on:
       <<: *worker_depends_on_prod

--- a/locker-backend/docker-compose.yml
+++ b/locker-backend/docker-compose.yml
@@ -107,6 +107,11 @@ services:
             <<: *laravel_env_dev
             AUTORUN_ENABLED: "false"
             MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_event_worker"
+        # Single worker on purpose. DoorDetectionReactor and CommandResponseReactor
+        # both guard against duplicate derived events with a read-then-write,
+        # which is not atomic — a second consumer would let a redelivered event
+        # be recorded twice, and duplicated events are permanent history. Do not
+        # scale this service without making those guards safe first.
         command: "php artisan queue:work --queue=events --tries=3 --timeout=90"
         depends_on:
             <<: *worker_depends_on_dev

--- a/locker-backend/tests/Feature/CommandResponseDedupTest.php
+++ b/locker-backend/tests/Feature/CommandResponseDedupTest.php
@@ -344,6 +344,46 @@ class CommandResponseDedupTest extends TestCase
             ->once();
     }
 
+    public function test_a_replay_with_a_fresh_timestamp_is_not_reported_as_changed(): void
+    {
+        Log::spy();
+
+        $handler = app(CommandResponseHandler::class);
+
+        $lockerUuid = '11111111-1111-1111-1111-111111111111';
+        $transactionId = '33333333-3333-3333-3333-333333333333';
+        $topic = "locker/{$lockerUuid}/response";
+
+        $payload = [
+            'type' => 'command_response',
+            'action' => 'open_compartment',
+            'result' => 'success',
+            'transaction_id' => $transactionId,
+            'message' => 'ok',
+        ];
+
+        $handler->handleMessage($topic, (string) json_encode($payload + [
+            'message_id' => 'cccccccc-0000-0000-0000-cccccccccccc',
+            'timestamp' => now()->toIso8601String(),
+        ]));
+
+        // A real replay is re-sent later, so it carries a fresh timestamp as well
+        // as a fresh message_id. Neither says anything about the response itself.
+        $this->travel(30)->seconds();
+
+        $handler->handleMessage($topic, (string) json_encode($payload + [
+            'message_id' => 'dddddddd-0000-0000-0000-dddddddddddd',
+            'timestamp' => now()->toIso8601String(),
+        ]));
+
+        $this->assertDatabaseCount('command_transactions', 1);
+
+        Log::shouldHaveReceived('info')
+            ->withArgs(fn (string $message, array $context = []) => $message === 'Duplicate command response received (deduped).'
+                && ($context['payload_changed'] ?? null) === false)
+            ->once();
+    }
+
     public function test_conflicting_replay_is_discarded_and_logged(): void
     {
         Log::spy();

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\CompartmentResource\Pages\ListCompartments;
+use App\Models\Compartment;
+use App\Models\LockerBank;
+use App\Models\User;
+use Filament\Tables\Table;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * The compartment list navigates by locker bank rather than by paging: banks
+ * arrive collapsed and the admin opens one. Nothing else asserts that shape, so
+ * re-enabling pagination or dropping the grouping to "fix" a slow page would
+ * otherwise be a silent change rather than a deliberate one.
+ */
+class CompartmentListGroupingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function tableFor(User $admin): Table
+    {
+        return Livewire::actingAs($admin)
+            ->test(ListCompartments::class)
+            ->instance()
+            ->getTable();
+    }
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        return $admin;
+    }
+
+    public function test_the_list_is_grouped_by_locker_bank_by_default(): void
+    {
+        $table = $this->tableFor($this->admin());
+
+        // Asserting the default alone is not enough: getDefaultGroup() synthesises
+        // a Group when the id is absent from groups(), so deleting the grouping
+        // entirely would still satisfy it.
+        $this->assertArrayHasKey('lockerBank.name', $table->getGroups());
+        $this->assertSame('lockerBank.name', $table->getDefaultGroup()?->getId());
+    }
+
+    public function test_the_bank_group_is_collapsible_so_the_accordion_has_something_to_toggle(): void
+    {
+        $group = $this->tableFor($this->admin())->getGroups()['lockerBank.name'] ?? null;
+
+        // Group::$isCollapsible defaults to false, and Filament gates both the
+        // toggle handler and the fi-collapsed binding on it. Without it the
+        // headers never get .fi-collapsible, the accordion script matches
+        // nothing, and the page degrades to the flat list #167 removed.
+        $this->assertNotNull($group);
+        $this->assertTrue($group->isCollapsible());
+    }
+
+    public function test_groups_start_collapsed_so_the_page_opens_as_a_short_list_of_banks(): void
+    {
+        $this->assertTrue($this->tableFor($this->admin())->areGroupsCollapsedByDefault());
+    }
+
+    public function test_pagination_is_off_so_a_bank_is_never_split_across_pages(): void
+    {
+        $this->assertFalse($this->tableFor($this->admin())->isPaginated());
+    }
+
+    public function test_every_compartment_of_every_bank_is_listed_without_paging(): void
+    {
+        $admin = $this->admin();
+
+        $compartments = collect();
+        foreach (LockerBank::factory()->count(2)->create() as $bankIndex => $bank) {
+            for ($i = 1; $i <= 3; $i++) {
+                $compartments->push(Compartment::factory()->create([
+                    'locker_bank_id' => $bank->id,
+                    'number' => ($bankIndex * 10) + $i,
+                ]));
+            }
+        }
+
+        Livewire::actingAs($admin)
+            ->test(ListCompartments::class)
+            ->assertCanSeeTableRecords($compartments);
+    }
+}

--- a/locker-backend/tests/Feature/CompartmentNoteAdminUiTest.php
+++ b/locker-backend/tests/Feature/CompartmentNoteAdminUiTest.php
@@ -159,4 +159,22 @@ class CompartmentNoteAdminUiTest extends TestCase
 
         $this->assertSame('Checked by manager', $compartment->refresh()->content_note);
     }
+
+    public function test_a_note_beyond_the_column_length_is_refused_before_it_becomes_history(): void
+    {
+        $admin = User::factory()->create();
+        $admin->makeAdmin();
+
+        $compartment = Compartment::factory()->create();
+
+        // Both entry points cap this at 80. A caller that skipped validation would
+        // otherwise record a permanent event the read model cannot hold.
+        $this->expectException(\InvalidArgumentException::class);
+
+        app(CompartmentService::class)->updateContentNote(
+            actor: $admin,
+            compartment: $compartment,
+            note: str_repeat('a', 81),
+        );
+    }
 }

--- a/locker-backend/tests/Feature/DoorDetectionTest.php
+++ b/locker-backend/tests/Feature/DoorDetectionTest.php
@@ -14,6 +14,7 @@ use App\Notifications\Security\CompartmentOpenDeviationNotification;
 use App\StorableEvents\CompartmentDoorAlreadyOpen;
 use App\StorableEvents\CompartmentDoorOpenDetected;
 use App\StorableEvents\CompartmentOpenAcknowledged;
+use App\StorableEvents\CompartmentOpeningFailed;
 use App\StorableEvents\CompartmentOpeningRequested;
 use App\StorableEvents\CompartmentOpenNotDetected;
 use App\StorableEvents\CompartmentUncommandedOpenDetected;
@@ -183,6 +184,62 @@ class DoorDetectionTest extends TestCase
         $this->assertSame(CompartmentOpenRequestStatus::Opened, $request?->status);
         $this->assertSame(501, $request?->open_detection_ms);
         $this->assertNotNull($request?->acknowledged_at, 'the pulse timestamp is still recorded');
+    }
+
+    public function test_a_late_failure_does_not_overwrite_a_detected_open(): void
+    {
+        $transactionId = 'txn-late-failure';
+        $this->givenAnOpenCommandWasSent($transactionId);
+
+        $this->receiveDeviceEvent('compartment_open_detected', [
+            'compartment_number' => 7,
+            'transaction_id' => $transactionId,
+            'outcome' => 'opened',
+            'detection_ms' => 412,
+        ]);
+
+        // The client fired the relay but never published its response; restart
+        // recovery answers the transaction with an error afterwards. The door
+        // was seen to move, so that late failure must not become the outcome.
+        event(new CompartmentOpeningFailed(
+            lockerBankUuid: $this->lockerBank->id,
+            compartmentUuid: (string) $this->compartment->id,
+            compartmentNumber: 7,
+            transactionId: $transactionId,
+            errorCode: 'UNKNOWN_ERROR',
+            message: 'Command outcome is unknown after locker-client restart.',
+            timestamp: now()->toIso8601String(),
+        ));
+
+        $request = CompartmentOpenRequest::query()->find($transactionId);
+        $this->assertSame(CompartmentOpenRequestStatus::Opened, $request?->status);
+        $this->assertSame(412, $request?->open_detection_ms);
+        $this->assertSame(
+            'UNKNOWN_ERROR',
+            $request?->error_code,
+            'what the client reported is recorded even though it did not win',
+        );
+        $this->assertNotNull($request?->failed_at, 'the failure timestamp is still recorded');
+    }
+
+    public function test_a_late_failure_still_lands_when_nothing_physical_was_observed(): void
+    {
+        $transactionId = 'txn-plain-failure';
+        $this->givenAnOpenCommandWasSent($transactionId);
+
+        event(new CompartmentOpeningFailed(
+            lockerBankUuid: $this->lockerBank->id,
+            compartmentUuid: (string) $this->compartment->id,
+            compartmentNumber: 7,
+            transactionId: $transactionId,
+            errorCode: 'MODBUS_ERROR',
+            message: 'Bus unreachable.',
+            timestamp: now()->toIso8601String(),
+        ));
+
+        $request = CompartmentOpenRequest::query()->find($transactionId);
+        $this->assertSame(CompartmentOpenRequestStatus::Failed, $request?->status);
+        $this->assertSame('MODBUS_ERROR', $request?->error_code);
     }
 
     public function test_a_late_acknowledgement_does_not_overwrite_a_jam(): void

--- a/locker-client/simulator-scenario.yml.example
+++ b/locker-client/simulator-scenario.yml.example
@@ -1,6 +1,6 @@
-    # Open-Locker Fleet Simulator Scenario — see ADR-0031
+# Open-Locker Fleet Simulator Scenario — see ADR-0031
 #
-#   cp simulator-scenario.yml.example config/simulator-scenario.yml
+#   cp simulator-scenario.yml.example simulator-scenario.yml
 #   pnpm sim
 #
 # The simulator emulates one or many locker banks in a single process. Each bank

--- a/locker-client/src/adapters/simulator/production-guard.ts
+++ b/locker-client/src/adapters/simulator/production-guard.ts
@@ -1,0 +1,35 @@
+import { logger } from '../../infrastructure/logging';
+
+/**
+ * The simulator publishes fake state under a real locker UUID. Doing that
+ * against production would corrupt live read models, so refuse by default.
+ *
+ * Both variables are read, not the first one that happens to be set. A
+ * Laravel-shaped `.env` supplies `APP_ENV` while the Node runtime supplies
+ * `NODE_ENV`, so `APP_ENV=local` alongside `NODE_ENV=production` is an ordinary
+ * arrangement here — and coalescing on the first defined value would let it
+ * through a guard that promises to check both.
+ */
+export function assertNotProduction(allowProduction: boolean): void {
+  const environments = [process.env.APP_ENV, process.env.NODE_ENV]
+    .map((value) => (value ?? '').trim().toLowerCase())
+    .filter((value) => value !== '');
+
+  const environment = environments.find((value) => value === 'production' || value === 'prod');
+
+  if (environment === undefined) {
+    return;
+  }
+
+  if (allowProduction) {
+    logger.warn('Simulator starting against a production environment by explicit override', {
+      environment,
+    });
+    return;
+  }
+
+  throw new Error(
+    `Refusing to start the simulator with APP_ENV/NODE_ENV="${environment}". ` +
+      'Pass --allow-production if this is genuinely intended.',
+  );
+}

--- a/locker-client/src/adapters/tracing/create-tracing.ts
+++ b/locker-client/src/adapters/tracing/create-tracing.ts
@@ -1,4 +1,5 @@
 import { noopTracing, type LogShippingPort, type TracingPort } from '../../ports/tracing.port';
+import type { LoggerPort } from '../../ports/logging.port';
 
 export const DEFAULT_SERVICE_NAME = 'open-locker-client';
 
@@ -6,6 +7,8 @@ export interface CreateTracingOptions {
   /** Locker UUID, used as `service.instance.id`. */
   lockerUuid: string;
   env?: NodeJS.ProcessEnv;
+  /** Where the SDK's own export failures are reported. */
+  log?: LoggerPort;
 }
 
 /**
@@ -34,5 +37,6 @@ export async function createTracing(
     serviceInstanceId: options.lockerUuid,
     serviceVersion: env.OTEL_SERVICE_VERSION?.trim() || undefined,
     endpoint,
+    log: options.log,
   });
 }

--- a/locker-client/src/adapters/tracing/otel-tracing.adapter.ts
+++ b/locker-client/src/adapters/tracing/otel-tracing.adapter.ts
@@ -13,6 +13,8 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import {
   context,
+  diag,
+  DiagLogLevel,
   SpanKind,
   SpanStatusCode,
   trace,
@@ -21,6 +23,7 @@ import {
   type Span,
   type Tracer,
 } from '@opentelemetry/api';
+import { noopLogger, type LoggerPort } from '../../ports/logging.port';
 import type {
   ActiveSpan,
   LogShippingPort,
@@ -39,6 +42,8 @@ export interface OtelTracingOptions {
   serviceVersion?: string;
   /** OTLP/HTTP base endpoint, e.g. http://otel-collector:4318 */
   endpoint: string;
+  /** Where the SDK's own diagnostics go. Defaults to discarding them. */
+  log?: LoggerPort;
   /**
    * Replaces the OTLP exporter pipeline. Tests use it to keep spans in memory;
    * production leaves it unset.
@@ -67,6 +72,82 @@ const spanKinds: Record<TraceSpanKind, SpanKind> = {
   internal: SpanKind.INTERNAL,
 };
 
+/** How long an identical exporter complaint stays suppressed. */
+const DIAGNOSTIC_REPEAT_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Cap on distinct complaints remembered. Reached only by messages that embed
+ * identifiers, which normalisation should already have collapsed — the cap is
+ * there so an unforeseen shape cannot grow without bound on a Pi that runs for
+ * months.
+ */
+const DIAGNOSTIC_KEY_LIMIT = 256;
+
+/**
+ * Collapses the parts of a diagnostic that differ per occurrence.
+ *
+ * The SDK embeds trace and span ids in some warnings ("Cannot execute the
+ * operation on ended Span {traceId: …}"), which would make every occurrence a
+ * distinct key and defeat the throttle entirely.
+ */
+function throttleKey(message: string): string {
+  return message.replace(/\b[0-9a-f]{16,32}\b/gi, '<id>').slice(0, 200);
+}
+
+/**
+ * Routes OpenTelemetry's own diagnostics through the app logger, once per
+ * distinct message per window.
+ *
+ * A collector that is configured but unreachable — a flaky site link, a
+ * collector that moved — retries indefinitely, and each failure prints. On a Pi
+ * that accumulates for as long as the endpoint stays down, which makes the
+ * telemetry noisier than the flow it exists to observe. Losing the repeats
+ * costs nothing: the hundredth identical failure says what the first did.
+ *
+ * The first occurrence is always reported, so a broken exporter is still
+ * visible rather than silently swallowed.
+ *
+ * Note that `diag.setLogger` is process-global while this runs from a per-device
+ * constructor: a simulated fleet re-registers it once per bank, each replacing
+ * the previous throttle window. Harmless — the last registration wins and the
+ * behaviour is identical — but it is why the override warning is suppressed.
+ */
+function quietenExporterDiagnostics(log: LoggerPort): void {
+  const lastReportedAt = new Map<string, number>();
+
+  const reportOnce = (message: string): void => {
+    const key = throttleKey(message);
+    const previous = lastReportedAt.get(key);
+    const now = Date.now();
+
+    if (previous !== undefined && now - previous < DIAGNOSTIC_REPEAT_WINDOW_MS) {
+      return;
+    }
+
+    if (lastReportedAt.size >= DIAGNOSTIC_KEY_LIMIT) {
+      const oldest = lastReportedAt.keys().next().value;
+
+      if (oldest !== undefined) {
+        lastReportedAt.delete(oldest);
+      }
+    }
+
+    lastReportedAt.set(key, now);
+    log.warn('OpenTelemetry exporter reported a failure', { message });
+  };
+
+  diag.setLogger(
+    {
+      error: (message) => reportOnce(message),
+      warn: (message) => reportOnce(message),
+      info: () => undefined,
+      debug: () => undefined,
+      verbose: () => undefined,
+    },
+    { logLevel: DiagLogLevel.WARN, suppressOverrideMessage: true },
+  );
+}
+
 /**
  * OpenTelemetry implementation of {@link TracingPort}.
  *
@@ -81,6 +162,8 @@ export class OtelTracingAdapter implements TracingPort, LogShippingPort {
   private readonly propagator = new W3CTraceContextPropagator();
 
   constructor(options: OtelTracingOptions) {
+    quietenExporterDiagnostics(options.log ?? noopLogger);
+
     const resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: options.serviceName,
       [SERVICE_INSTANCE_ID]: options.serviceInstanceId,

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -87,11 +87,11 @@ export async function createApp(): Promise<AppContext> {
   // Built here because the locker UUID identifies this instance, and it is only
   // known once provisioning has completed. Returns a no-op unless a collector
   // endpoint is configured, in which case the SDK is never even loaded.
-  const tracing = await createTracing({ lockerUuid });
+  const appLogger = createWinstonLoggerPort();
+
+  const tracing = await createTracing({ lockerUuid, log: appLogger });
   setLogTraceContextProvider(() => tracing.currentCorrelation());
   shipLogsTo(tracing);
-
-  const appLogger = createWinstonLoggerPort();
 
   const driver = new WaveshareModbusRtuDriver(
     {

--- a/locker-client/src/bootstrap/createSimulatorApp.ts
+++ b/locker-client/src/bootstrap/createSimulatorApp.ts
@@ -439,7 +439,10 @@ async function startSimulatedDevice(
 
   // Each simulated bank reports as its own instance, so a fleet run looks to the
   // trace backend exactly like a fleet of Pis.
-  const tracing = await createTracing({ lockerUuid });
+  // Passing the logger matters here: the simulator is how the tracing path gets
+  // exercised without hardware, so a misconfigured collector during a run should
+  // say so rather than be discarded.
+  const tracing = await createTracing({ lockerUuid, log: logger });
   setLogTraceContextProvider(() => tracing.currentCorrelation());
   shipLogsTo(tracing);
 

--- a/locker-client/src/domain/errors.ts
+++ b/locker-client/src/domain/errors.ts
@@ -43,6 +43,14 @@ export class ModbusTransportError extends LockerError {
  * The library throws plain `Error`s, so its message text is the only signal
  * available. Matching it is fragile, which is why it is confined to this one
  * function: everything we raise ourselves carries an explicit code instead.
+ *
+ * The patterns name specific transport failures deliberately. A bare `modbus`
+ * match caught nearly every hardware-adjacent message in this codebase,
+ * including our own configuration and programming faults, and reported them to
+ * the backend as MODBUS_ERROR — a bug dressed as a broken bus. Unrecognised
+ * errors are better reported as unknown than misattributed to the hardware.
+ *
+ * Reconnectability is decided separately, by `isReconnectableModbusError`.
  */
 function isModbusLibraryError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -55,8 +63,7 @@ function isModbusLibraryError(error: unknown): boolean {
     message.includes('port not open') ||
     message.includes('econnrefused') ||
     message.includes('timed out') ||
-    message.includes('crc error') ||
-    message.includes('modbus')
+    message.includes('crc error')
   );
 }
 

--- a/locker-client/src/main-simulator.ts
+++ b/locker-client/src/main-simulator.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import readline from 'readline';
 import { loadScenario, ScenarioValidationError } from './adapters/simulator/scenario';
 import { SimulatorCredentialCache } from './adapters/simulator/simulator-credential-cache';
+import { assertNotProduction } from './adapters/simulator/production-guard';
 import {
   createSimulatorApp,
   type SimulatedDevice,
@@ -109,31 +110,6 @@ function printUsage(): void {
       '  quit                        Shut down',
       '',
     ].join('\n'),
-  );
-}
-
-/**
- * The simulator publishes fake state under a real locker UUID. Doing that
- * against production would corrupt live read models, so refuse by default
- *.
- */
-function assertNotProduction(allowProduction: boolean): void {
-  const environment = (process.env.APP_ENV ?? process.env.NODE_ENV ?? '').trim().toLowerCase();
-
-  if (environment !== 'production' && environment !== 'prod') {
-    return;
-  }
-
-  if (allowProduction) {
-    logger.warn('Simulator starting against a production environment by explicit override', {
-      environment,
-    });
-    return;
-  }
-
-  throw new Error(
-    `Refusing to start the simulator with APP_ENV/NODE_ENV="${environment}". ` +
-      'Pass --allow-production if this is genuinely intended.',
   );
 }
 

--- a/locker-client/tests/simulator/composition-parity.test.ts
+++ b/locker-client/tests/simulator/composition-parity.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+
+/**
+ * The simulator is only a faithful stand-in while it dispatches the same
+ * commands as the real client. A handler added to one root and forgotten in the
+ * other makes the simulator quietly answer `UNKNOWN_ACTION` for something
+ * production handles — the drift ADR-0031 exists to prevent.
+ *
+ * Checked textually rather than by instantiating both roots: `createApp` needs a
+ * config file, a serial device and a broker, none of which belong in a unit
+ * test. The two roots also diverge on purpose elsewhere — the simulator has no
+ * `recoverInterruptedCommands` or flush wiring, because its dedup store is
+ * in-memory — so this asserts the one property that must match, not general
+ * equivalence.
+ */
+/**
+ * Walks up from this file to the directory holding package.json.
+ *
+ * Neither `__dirname` nor `process.cwd()` works on its own: compiled tests run
+ * from `dist/`, where the TypeScript sources do not exist, and cwd is only the
+ * package root when the runner is invoked from there.
+ */
+function packageRoot(): string {
+  let dir = __dirname;
+
+  while (!fs.existsSync(path.join(dir, 'package.json'))) {
+    const parent = path.dirname(dir);
+
+    if (parent === dir) {
+      throw new Error('Could not locate the locker-client package root');
+    }
+
+    dir = parent;
+  }
+
+  return dir;
+}
+
+function registeredHandlers(file: string): string[] {
+  const source = fs.readFileSync(path.join(packageRoot(), 'src', 'bootstrap', file), 'utf8');
+
+  return [...source.matchAll(/dispatcher\.register\(\s*(create\w+Handler)/g)]
+    .map((match) => match[1])
+    .toSorted();
+}
+
+test('both composition roots register the same command handlers', () => {
+  const production = registeredHandlers('createApp.ts');
+  const simulator = registeredHandlers('createSimulatorApp.ts');
+
+  assert.ok(production.length > 0, 'the production root must register handlers');
+  assert.deepEqual(
+    simulator,
+    production,
+    'a handler registered in one composition root but not the other means the simulator no longer mirrors the client',
+  );
+});

--- a/locker-client/tests/simulator/production-guard.test.ts
+++ b/locker-client/tests/simulator/production-guard.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { assertNotProduction } from '../../src/adapters/simulator/production-guard';
+
+const original = { APP_ENV: process.env.APP_ENV, NODE_ENV: process.env.NODE_ENV };
+
+function setEnv(appEnv?: string, nodeEnv?: string): void {
+  if (appEnv === undefined) {
+    delete process.env.APP_ENV;
+  } else {
+    process.env.APP_ENV = appEnv;
+  }
+
+  if (nodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = nodeEnv;
+  }
+}
+
+afterEach(() => setEnv(original.APP_ENV, original.NODE_ENV));
+
+test('a production NODE_ENV is caught even when APP_ENV is set to something else', () => {
+  // The arrangement this repo actually produces: a Laravel-shaped .env supplies
+  // APP_ENV while the Node runtime supplies NODE_ENV. Coalescing on the first
+  // defined value would let this straight through.
+  setEnv('local', 'production');
+
+  assert.throws(() => assertNotProduction(false), /production/);
+});
+
+test('an empty APP_ENV does not mask a production NODE_ENV', () => {
+  setEnv('', 'production');
+
+  assert.throws(() => assertNotProduction(false), /production/);
+});
+
+test('a production APP_ENV is caught when NODE_ENV is absent', () => {
+  setEnv('production', undefined);
+
+  assert.throws(() => assertNotProduction(false), /production/);
+});
+
+test('the short form is caught too', () => {
+  setEnv('prod', undefined);
+
+  assert.throws(() => assertNotProduction(false), /prod/);
+});
+
+test('a development pair starts without complaint', () => {
+  setEnv('local', 'development');
+
+  assert.doesNotThrow(() => assertNotProduction(false));
+});
+
+test('neither variable set is allowed', () => {
+  setEnv(undefined, undefined);
+
+  assert.doesNotThrow(() => assertNotProduction(false));
+});
+
+test('an explicit override permits production rather than throwing', () => {
+  setEnv('local', 'production');
+
+  assert.doesNotThrow(() => assertNotProduction(true));
+});

--- a/locker-client/tests/unit/error-mapping.test.ts
+++ b/locker-client/tests/unit/error-mapping.test.ts
@@ -55,3 +55,23 @@ test('only transport faults that reconnecting can clear are reconnectable', () =
   assert.equal(isReconnectableModbusError(new Error('connect ECONNREFUSED')), true);
   assert.equal(isReconnectableModbusError(new Error('something unrelated')), false);
 });
+
+test('a fault that merely mentions modbus is not reported as a hardware error', () => {
+  // A bare `modbus` match caught nearly every hardware-adjacent message here,
+  // including our own configuration and programming faults, and sent them to the
+  // backend as MODBUS_ERROR — a bug dressed as a broken bus.
+  assert.equal(
+    mapErrorToMqttCode(new Error('Invalid modbus register mapping for compartment 3')),
+    MqttErrorCode.UNKNOWN_ERROR,
+  );
+  assert.equal(
+    mapErrorToMqttCode(new Error('modbus config missing slaveId')),
+    MqttErrorCode.UNKNOWN_ERROR,
+  );
+});
+
+test('the specific library transport failures are still reported as MODBUS_ERROR', () => {
+  for (const message of ['Port Not Open', 'connect ECONNREFUSED', 'Timed out', 'CRC error']) {
+    assert.equal(mapErrorToMqttCode(new Error(message)), MqttErrorCode.MODBUS_ERROR, message);
+  }
+});

--- a/locker-client/tests/unit/otel-tracing.test.ts
+++ b/locker-client/tests/unit/otel-tracing.test.ts
@@ -144,3 +144,70 @@ test('a failing operation is recorded on the span but still throws', async () =>
   assert.ok(span);
   assert.equal(span.status.code, 2, 'expected the span to be marked as an error');
 });
+
+test('repeated exporter failures are reported once per window, not per retry', async () => {
+  const { diag } = await import('@opentelemetry/api');
+  const warned: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+  const log = {
+    warn: (message: string, meta?: Record<string, unknown>) => warned.push({ message, meta }),
+    error: () => undefined,
+  };
+
+  const adapter = new OtelTracingAdapter({
+    serviceName: 'test',
+    serviceInstanceId: 'test-instance',
+    endpoint: 'http://localhost:4318',
+    log,
+  });
+
+  // What an unreachable collector produces: the same complaint, forever.
+  for (let i = 0; i < 25; i++) {
+    diag.error('Export failure: connect ECONNREFUSED 127.0.0.1:4318');
+  }
+
+  // Other adapters built earlier in this process also register globals, and the
+  // SDK complains about that — count only the failure this test provoked.
+  const refused = () =>
+    warned.filter((entry) => String(entry.meta?.message).includes('ECONNREFUSED'));
+
+  assert.equal(refused().length, 1, 'a broken exporter is reported, but only once');
+
+  // A different failure is still its own signal.
+  diag.error('Export failure: 413 payload too large');
+  assert.equal(
+    warned.filter((entry) => String(entry.meta?.message).includes('413')).length,
+    1,
+    'a distinct failure is not swallowed by the throttle',
+  );
+
+  await adapter.shutdown();
+});
+
+test('a diagnostic carrying span ids still throttles despite the ids differing', async () => {
+  const { diag } = await import('@opentelemetry/api');
+  const warned: Array<{ meta?: Record<string, unknown> }> = [];
+
+  const adapter = new OtelTracingAdapter({
+    serviceName: 'test',
+    serviceInstanceId: 'test-instance',
+    endpoint: 'http://localhost:4318',
+    log: {
+      warn: (_m: string, meta?: Record<string, unknown>) => warned.push({ meta }),
+      error: () => undefined,
+    },
+  });
+
+  // The SDK embeds trace and span ids in some warnings, so every occurrence is a
+  // different string. Without normalisation each one is a new key: never
+  // throttled, and a permanent map entry on a Pi that runs for months.
+  for (let i = 0; i < 20; i++) {
+    diag.warn(
+      `Cannot execute the operation on ended Span {traceId: ${i.toString(16).padStart(32, '0')}}`,
+    );
+  }
+
+  const ended = warned.filter((entry) => String(entry.meta?.message).includes('ended Span'));
+  assert.equal(ended.length, 1, 'ids are normalised out of the throttle key');
+
+  await adapter.shutdown();
+});

--- a/website/src/content/docs/de/dokumentation/reference.md
+++ b/website/src/content/docs/de/dokumentation/reference.md
@@ -17,9 +17,9 @@ sidebar:
 - **Kanonischer Protokollvertrag** (AsyncAPI + JSON-Schemas):
   [`docs/asyncapi/`](https://github.com/Open-Locker/Open-Locker/tree/main/docs/asyncapi)
 - Topic-Struktur und Message-/Transaction-IDs:
-  [ADR-0002](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0002-mqtt-message-id-transaction-id.md)
+  [ADR-0002](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0002-mqtt-message-id-and-transaction-id-separation.md)
 - Typisierte Outbound-Publisher im Backend:
-  [ADR-0008](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0008-typed-mqtt-publisher-services.md)
+  [ADR-0008](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0008-typed-outbound-mqtt-publisher-services.md)
 - Broker-Authentifizierung: `mosquitto-go-auth` gegen `/api/mosq/*`
 
 ## Hardware

--- a/website/src/content/docs/dokumentation/reference.md
+++ b/website/src/content/docs/dokumentation/reference.md
@@ -17,9 +17,9 @@ sidebar:
 - **Canonical protocol contract** (AsyncAPI + JSON schemas):
   [`docs/asyncapi/`](https://github.com/Open-Locker/Open-Locker/tree/main/docs/asyncapi)
 - Topic structure and message/transaction IDs:
-  [ADR-0002](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0002-mqtt-message-id-transaction-id.md)
+  [ADR-0002](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0002-mqtt-message-id-and-transaction-id-separation.md)
 - Typed outbound publishers in the backend:
-  [ADR-0008](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0008-typed-mqtt-publisher-services.md)
+  [ADR-0008](https://github.com/Open-Locker/Open-Locker/blob/main/docs/adr/0008-typed-outbound-mqtt-publisher-services.md)
 - Broker authentication: `mosquitto-go-auth` against `/api/mosq/*`
 
 ## Hardware


### PR DESCRIPTION
Collects the fixes for findings raised by the independent reviews across the stack.

They land here rather than on their original branches on purpose. A fix on a mid-stack branch has to be merged up through every descendant to reach the tip, which re-triggers CI on each PR above it and gives every hop a chance to conflict. Landing them once at the tip costs one CI run and one review, and each finding is checked against the tip first so anything already resolved upstack costs nothing at all.

**One commit per originating PR**, so `git log` reads back to the review comment that produced it — except #184, whose findings arrived in two review passes.

Deferrals raised here are tracked as **#139** (reactor idempotency, `after_commit`), **#222** (JSONB lookups on `stored_events`), **#223** (panel-wide eager loading) and **#225** (postgres in CI).

## Findings addressed

| Issue | From PR | Finding | Commit | What was done |
|---|---|---|---|---|
| #167 | #183 | The grouped, unpaginated compartment list had no test | `dabd5ad5` | Five tests pin grouping by locker bank, the group being collapsible, collapsed-by-default, pagination off, and every compartment reachable without paging |
| #82 | #184 | Simulator credential cache could land outside the ignore rules | `fd8d4454` | Both patterns moved to the root `.gitignore` — the cache follows the scenario file wherever the operator points it, so a scenario outside `locker-client/` left a live MQTT password unignored |
| #82 | #184 | ADR still `Proposed` while its implementation lands | `fd8d4454` | ADR-0031 set to `Accepted` |
| #82 | #184 | `TODO.md` cited the deleted `mqtt:client-simulator` | `fd8d4454` | Now names the fleet simulator. The ADR's references stay — it documents the retirement |
| #82 | #184 | Production guard checked one variable, not both | `70ddf64c` | `APP_ENV ?? NODE_ENV` meant any defined `APP_ENV` masked `NODE_ENV`, so `APP_ENV=local NODE_ENV=production` started against production, as did `APP_ENV=""`. Both are read now; 7 tests, two of which fail against the old expression |
| #82 | #184 | Composition roots duplicate without a drift alarm | `70ddf64c` | Parity test asserting both roots register the same handlers. Scoped to registration only — the roots diverge on purpose over recovery and flush wiring |
| #82 | #184 | Ignore rules cover exact filenames only | `70ddf64c` | `docs/simulator.md` now states that a renamed scenario, or a cache moved with `SIMULATOR_CREDENTIALS_FILE`, is not ignored and holds a real token |
| #94 | #185 | A late command failure overwrote a door that was seen to open | `ff0a4080` | `onCompartmentOpeningFailed` withholds only `status`, and only from the three terminal physical states. What the client reported is still recorded, mirroring the acknowledgement handler. Two tests: a late failure after a detected open leaves the outcome intact, and an ordinary failure still lands |
| #94 | #185 | The single-worker constraint behind the idempotency guards was unstated | `ff0a4080` | Recorded in both reactors, beside the worker command in both compose files, and in ADR-0040's Risks with the two exits named. Tracked for a real fix in #139 |
| #65 | #189 | Exporter failures were invisible, and would have flooded once reported | `062a1ea6` | OTel diagnostics route through the app logger, first occurrence always reported and repeats collapsed for five minutes. Trace and span ids are normalised out of the throttle key, and the map is capped — otherwise every per-span warning is a new key and a permanent entry. Both composition roots pass their logger |
| #65 | #189 | `state.json` advertised a `traceparent` that is never sent | `062a1ea6` | Kept for envelope symmetry, now described as reserved: state topics are excluded from tracing on both sides |
| #65 | #189 | 100% sampling default | `062a1ea6` | `docs/observability.md` records that `always_on` suits tracing one flow and not a fleet |
| #190 | #191 | N+1 in the one access table the PR did not align | `60c8d8a3` | Loads `compartment.lockerBank`, `compartment.latestOpenRequest`, `grantedByUser` and `revokedByUser`. The actor columns were resolved inside `->state()` closures rather than dotted names, which is why they were easy to miss. `UserAccessesRelationManager` fixed alongside it |
| #173 | #192 | `message.includes('modbus')` matched almost anything | `8972316a` | Catch-all dropped, four specific transport failures kept. A configuration fault was being reported to the backend as a broken bus |
| #188 | #193 | `payload_changed` was true for every ordinary replay | `8867ef89` | `timestamp` joins `message_id` and `traceparent` as a delivery field. The existing test reused one timestamp, which is why it went unnoticed |
| #136 | #198 | The 80-character note limit lived only at the two entry points | `7bc4636f` | Enforced in `CompartmentService` before the aggregate, so an unvalidated caller cannot record permanent history the read model refuses |
| #214 | #215 | Four dead ADR links on the public documentation site | `e2f63bbf` | Both language versions now name files that exist. Pre-existing — both ADRs sit below the renumbering's cutoff |

## Deliberately not changed

| Issue | From PR | Finding | Why |
|---|---|---|---|
| #167 | #183 | `paginated(false)` renders every compartment into the DOM | Accepted for the expected fleet size. Collapsed groups still render their rows, so page weight grows with total compartments — invisible at tens, relevant in the low thousands. Revisit if a deployment ever approaches that |
| #167 | #183 | Description claimed note-text search was lost | Corrected on #183 directly, since it was PR text rather than code. `content_note` was never searchable; `lockerBank.name` was, and the group headers replace it |
| #82 | #184 | A corrupt credential cache resets silently | Not worth touching provisioning code mid-merge, but the blast radius is **fleet-wide, not per-bank**: it is one file keyed by provisioning token, so a truncated read loses every bank's credentials and the next `set()` writes `{...read(), [token]: …}`, making that loss permanent. Recovery is one provisioning reset *per bank* plus pasting each new token back into the scenario file — not a single admin click |
| #82 | #184 | `mode: 0o600` applies only on creation | Left as is. This class is **normally** the only writer, so an inherited loose mode is not reachable in ordinary use — but `SIMULATOR_CREDENTIALS_FILE` can point at a file the operator created, in which case the mode is whatever their umask gave it |
| #94 | #185 | Two unindexed JSONB predicates per door event on `stored_events` | Deferred with measurement in mind — the choice between a GIN index and a correlation table should follow real data, not a guess. Tracked in **#222** so it survives this merge |
| #94 | #185 | ADR numbers in code comments, and an ADR number collision | Already resolved upstack by the renumbering in #214/#215 — no ADR references remain in `locker-backend/app` or `locker-client/src`, and all 49 ADRs have unique numbers |
| #173 | #192 | The hardware badge never ages out | Left. A bank whose device stopped reporting keeps a green `reachable` badge, with staleness only in the tooltip. Fixing it means choosing a threshold, which is a product decision rather than merge preparation |
| #173 | #192 | `modbus_connected` is written outside the event stream | Left. It follows the existing `last_heartbeat_at` handling, so it is not a deviation — but whether hardware connectivity is telemetry or domain state deserves a deliberate answer rather than an inheritance |
| #188 | #193 | Queued reactors dispatch inside the new transaction | Deferred to **#139** scope item 2. All four connections set `after_commit => false`, so a worker can act before COMMIT or after a ROLLBACK. The fix is one flag but it changes dispatch timing for every queued job in the application |
| #148 | #194 | The active-membership predicate is duplicated across two models | Left. `Group::activeMembers()` and `User::activeGroups()` are byte-identical; the PR reduced the copies from three to two. Worth a shared scope eventually, since "active" is authorization-adjacent |
| #141 | #196 | A typo'd `ADMIN_EMAIL` stops the container starting | Left deliberately. Absent is tolerated and malformed is fatal — asymmetric, but failing loudly on a misconfigured admin bootstrap is defensible |
| #199 | #207 | The blanket `ignoreErrors` pattern could absorb unrelated findings | Checked by removing it: 32 suppressed errors, all the Eloquent generics friction it was written for. Theoretical rather than live, so no change |
| #187 | #197 | The advisory lock has no passing test | Tracked in **#225**. `LastAdminLockContentionTest` skips unless the driver is pgsql, the suite runs sqlite, and no workflow provides postgres — so the mechanism production depends on is undemonstrated |
| #82 | #184 | 477-line composition root mirroring a 321-line one | Not extracted. The simulator's value is being the production path with two substitutions; a shared-wiring helper is what grows an `if (simulator)` branch and lets them diverge behind a common signature. The parity test above addresses the drift risk instead |

## Note on the first test

The initial version of the grouping test passed even with the entire `groups()` block deleted: `getDefaultGroup()` synthesises a `Group` when the id is absent from `groups()`, so asserting on it alone proves nothing. That matters because `Group::$isCollapsible` defaults to `false` and Filament gates both the collapse handler and the `fi-collapsed` binding on it — without it the headers never get `.fi-collapsible`, the accordion script matches nothing, and the page silently degrades to the flat list #167 removed.

The committed version asserts the group is present in `getGroups()` and is collapsible. Verified in both directions: five pass as written, removing `groups()` fails two, flipping `paginated(false)` fails a third.



