### PR TITLE
chore(ci): rename the Docker workflows to match what they build

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - "locker-backend/**"
-      - ".github/workflows/docker-ghcr.yml"
+      - ".github/workflows/backend-docker.yml"
   push:
     branches:
       - main
@@ -16,7 +16,7 @@ on:
       - "v*"
     paths:
       - "locker-backend/**"
-      - ".github/workflows/docker-ghcr.yml"
+      - ".github/workflows/backend-docker.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/client-docker.yml
+++ b/.github/workflows/client-docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - 'locker-client/**'
-      - '.github/workflows/build-locker-client.yml'
+      - '.github/workflows/client-docker.yml'
   push:
     branches:
       - main
@@ -13,7 +13,7 @@ on:
       - 'locker-client-v*'
     paths:
       - 'locker-client/**'
-      - '.github/workflows/build-locker-client.yml'
+      - '.github/workflows/client-docker.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
Two of the three renames discussed in #99:

- `docker-ghcr.yml` → `backend-docker.yml` — described where it pushed, not what it built
- `build-locker-client.yml` → `client-docker.yml` — drops the directory prefix, matching the `client-v*` tag namespace in ADR-0043

Each workflow lists its own filename in its `paths:` filters, so those move too — otherwise the workflow stops triggering on its own edits.

No behaviour change: workflow `name:` fields and job names are unchanged, so check names stay the same. Neither `dev` nor `main` has branch protection, so no required check is affected. GitHub will show the renamed files as new entries in the Actions tab while the old ones keep their run history.

The third rename (`mqtt-contract-ci.yml` → `backend-ci.yml`) is left out pending the discussion in #99.