### PR TITLE
feat(mqtt): issue a new credential identity per provisioning (#161)

### DIFF
--- a/docs/adr/0050-per-provisioning-mqtt-credential-identities.md
+++ b/docs/adr/0050-per-provisioning-mqtt-credential-identities.md
@@ -1,0 +1,364 @@
+# ADR-0050: Per-provisioning MQTT credential identities
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-22
+
+## Context
+
+A locker bank's MQTT username is its own UUID. `MqttReactor` mints credentials
+with `$mqttUser = $event->lockerBankUuid`, and `MqttUserService::createUser()`
+upserts on that username with `firstOrNew(['username' => …])`. Resetting a bank
+deletes the row (`deleteUser((string) $lockerBank->id)`) and the next
+provisioning recreates the same username with a new password.
+
+That recreation is the problem. Deleting the row revokes access — with
+`auth_opt_cache false` every later ACL check reaches Laravel and is denied. But
+when the *same username* is created again for the next generation, an old
+session that is still connected starts passing ACL checks again, without ever
+having authenticated with the new password. The credential lifecycle has no
+boundary between generations.
+
+The obvious fix is to evict the old session at the broker. Mosquitto has no
+supported way to do that, so it would mean maintaining a custom plugin purely
+for client eviction — a lot of machinery for one edge.
+
+The authorisation path is also coupled to the username's meaning. The device
+branch of the ACL endpoint matches `locker/%u/state/#`, `locker/%u/response`,
+`locker/%u/event` and `locker/%u/command`, where `%u` is the authenticated
+username. The rule "you may touch your own locker's topics" is expressed as
+"your username *is* the locker UUID" — an assumption nothing enforces.
+
+Two things already in the codebase shape the answer:
+
+- **A generation identifier exists.** ADR-0048 added
+  `locker_banks.provisioning_generation`, and `MqttReactor::lockCurrentGeneration()`
+  already compares it with `hash_equals` to discard stale provisioning events.
+- **Disabling an identity is already honoured.** `mqtt_users.enabled` exists and
+  *both* the auth path and the ACL path already filter `->where('enabled', true)`,
+  and `username` already carries a unique index.
+
+## Decision
+
+**1. Every accepted provisioning issues a new, opaque MQTT username.**
+
+The username is 32 characters of `Str::random()`, carrying no structure. It is
+not derived from the locker UUID, the provisioning generation, or anything else
+a reader could parse.
+
+Opaque rather than `<locker-uuid>:<random>`: a parseable prefix invites exactly
+the coupling this ADR removes — the first `explode(':')` in an ACL path puts the
+assumption back, and nothing would fail loudly when it does. Operators correlate
+identity to bank through `mqtt_users.locker_bank_id`, which is what the mapping
+is for.
+
+**2. Authorisation maps identity → locker bank; it never reads the username.**
+
+The device branch of the ACL endpoint loads the enabled `MqttUser` (it already
+does), takes `$user->locker_bank_id`, and matches topics against that UUID as a
+literal. `%u` disappears from the device patterns.
+
+Deny when the identity is missing, disabled, or has no locker-bank mapping.
+
+The mapped UUID is matched the same way `%u` is, not by string-building a
+pattern. `MqttAclService` gains a `%l` placeholder that compares one topic level
+against a value passed alongside the username and client id, so the injection
+safety of `%u` — a literal comparison, never a wildcard — extends to the mapped
+locker UUID unchanged. Interpolating the UUID into the pattern would work today
+and become an injection hole the moment anything but a UUID reached it.
+`%u`/`%c` keep their current meaning for the provisioning and backend users.
+
+The topic structure is unchanged: `locker/{lockerUuid}/…`. Only the
+authenticated username stops being that UUID.
+
+Re-provisioning therefore grants exactly the access the previous generation had.
+Nothing bank-scoped lives on the identity — the row holds only credentials and
+the mapping — so a new identity pointing at the same `locker_bank_id` is
+equivalent by construction, with nothing to copy across.
+
+**3. Revoked identities are disabled, never deleted, and never reused.**
+
+Revocation sets `enabled = false` and stamps `revoked_at`. The row stays, so the
+unique index on `username` keeps that identity permanently unusable.
+`MqttUserService::deleteUser()` is removed along with its only caller — nothing
+in the provisioning path may delete an identity, because the reuse guarantee
+rests entirely on rows never disappearing.
+
+`revoked_at` records when, not by whom. Every revocation traces back to a
+provisioning reset — either directly, or through the issuance that reset led to
+— and that reset is already attributed in the event stream through
+`LockerProvisioningReset`. The row is a tombstone holding the username occupied,
+not an audit record in its own right.
+
+One exception is accepted: `mqtt_users.locker_bank_id` is
+`constrained()->cascadeOnDelete()`, so deleting a locker bank still removes its
+identities. That is harmless — a deleted bank has no successor generation to
+protect, and a bank recreated later is a new UUID with new opaque identities.
+Reuse only needs preventing while the bank it maps to still exists.
+
+Both the auth and ACL paths already require `enabled = true`, so revocation
+takes effect with no new checks. Revocation is by locker bank — every enabled
+identity for that `locker_bank_id` is disabled — rather than by username, which
+also covers legacy rows without special-casing them.
+
+Revocation runs **at issuance as well as at reset**, inside the transaction that
+inserts the new identity: disable every enabled identity for the bank, then
+insert. "A bank has at most one live identity" is therefore an invariant of the
+issuing path, not a property that holds as long as the reset path was reached
+first. Reset-time revocation becomes the same rule applied with no successor.
+
+#161's migration notes say the legacy identity is *deleted* on first reset. That
+predates this decision: the same issue asks for the deletion-versus-tombstone
+call to be made here, and it is made the other way. Legacy identities are
+disabled like any other.
+
+**4. Provisioning generation stays the concurrency boundary; the username is
+not a generation marker.**
+
+Repeated and concurrent provisioning attempts are already settled by
+`lockCurrentGeneration()`: a `LockerWasProvisioned` event whose generation no
+longer matches the row is stale and creates nothing. Identity creation stays
+inside that same locked transaction.
+
+Retries need more than that. `MqttReactor` is queued and deliberately rethrows
+to trigger the retry strategy, so a failure while publishing the reply re-runs
+the handler for the *same* generation — which `lockCurrentGeneration()` accepts,
+because nothing has moved. Today `createUser()`'s upsert makes that idempotent;
+an insert with a fresh random username would instead mint a second live identity
+per attempt.
+
+Decision 3's revoke-before-insert is what keeps this correct: a retry disables
+the identity its predecessor created and issues one more, so however many
+attempts occur, exactly one identity is live and it is the one whose credentials
+were last published.
+
+One tail remains, and it is not new. If an earlier attempt's reply reached the
+client but its transaction then failed, the retry revokes the credentials that
+client is holding — and if the replacement reply never reaches it, it is left
+authenticating with a disabled identity until someone re-provisions the bank.
+That is the same place a failed provisioning leaves a client today, and the
+denial logging in decision 6 is how it surfaces.
+
+No generation identifier is added to MQTT payloads. Unique authenticated
+identities plus ACL mapping already make a previous generation unable to act,
+which is what a payload marker would have been protecting against. Adding one
+would put a second, weaker check in front of an authorisation boundary that
+already holds.
+
+**5. The provisioning reply carries the locker UUID as its own field.**
+
+`ProvisioningReplyPublisher::publishSuccess()` publishes `mqtt_user` and
+`mqtt_password`; it gains `locker_uuid`. The AsyncAPI contract and its schemas
+are updated to match.
+
+The client stores the two separately: the username is used only to authenticate
+to the broker, and the locker UUID builds every topic — command, state, event,
+heartbeat, response, and the Last Will registered at connect time. The Last Will
+is set before the client has any reason to touch its username, which is exactly
+where the old coupling is easiest to leave behind by accident.
+
+**6. Retained state survives a generation change; in-flight command traffic does
+not.**
+
+Retained messages on `locker/{lockerUuid}/state/…` describe the physical bank,
+not the identity that published them, so they are left in place and the newly
+provisioned client republishes its snapshot on connect.
+
+Command responses from a previous generation are not honoured: their
+transaction ids belong to commands the backend no longer has outstanding, and
+the existing dedup path already discards them. Nothing is added for this.
+
+Commands queued for a previous generation's session are not delivered to the new
+one: a new identity means a new broker session, so a queued persistent session
+belongs to the old client and its queue drains — or expires — without the new
+client ever subscribing to it. Any command that mattered is reissued by the
+backend, which is how an unacknowledged command is already handled.
+
+A revoked client that is still running keeps reconnecting and failing. Its
+authentication is refused outright, and any ACL check it attempts is logged as a
+denial on the broker channel — the same line the ACL path already writes — so
+the condition is visible without new instrumentation. It is expected: an
+identity is only revoked because that bank has been reset, and the client is
+meant to be re-provisioned. Retained `state/connection` or Last Will messages
+published by the old session before revocation stay on the topic and are
+overwritten by the new client's snapshot on connect.
+
+**7. Legacy UUID usernames keep working until their bank is re-provisioned.**
+
+They need no special case. A legacy row already has `username = <locker uuid>`
+*and* `locker_bank_id` set, so decision 2's mapping authorises it exactly as
+before. On the first reset the legacy identity is disabled with the rest, and
+the bank receives an opaque one.
+
+Deployed clients keep running unchanged. A client that has not been updated
+must not receive a new identity, so the updated client ships before any bank is
+re-provisioned.
+
+**8. The broker is pinned, and the assumption is tested against it.**
+
+`iegomez/mosquitto-go-auth:latest` becomes `2.1.0-mosquitto_2.0.15` in both
+compose files — the build that was already running, so pinning changes nothing
+but what a later `docker pull` may hand back.
+
+`locker-client/tests/integration/broker-revocation.test.ts` asserts the sequence
+against that broker: a live identity publishes, its identity is revoked while a
+new one is issued for the same bank, and the same still-connected session is then
+denied. It is verified: with `auth_opt_cache false`, denial takes effect on the
+next operation, without the session being evicted. The test needs the stack
+running, so it is opt-in behind `OPEN_LOCKER_BROKER_TEST=1` and skipped in the
+normal suite; it is the reason the image is pinned, since an upgrade to either
+component can change this behaviour.
+
+## Rationale
+
+The security property comes from arithmetic rather than from timing: a revoked
+username is never issued again, so there is no moment at which an old session's
+username becomes authorised. Session eviction becomes a cleanup nicety instead
+of a correctness requirement, and no custom broker plugin is needed.
+
+Mapping through `locker_bank_id` makes the authorisation rule explicit. Today
+the rule is enforced by a coincidence of naming; afterwards it is a lookup that
+fails closed when the mapping is missing.
+
+Disabling rather than deleting keeps the unique index doing the reuse
+prevention. A deleted row frees its username again, which is the one thing this
+ADR must never allow — which is also why the provisioning path loses its ability
+to delete an identity at all.
+
+## Alternatives Considered
+
+### Alternative A: Keep UUID usernames and evict sessions at the broker
+
+- Pros: no contract change, no client change, no migration.
+- Cons: Mosquitto offers no supported eviction, so it means maintaining a custom
+  plugin; and correctness would depend on the kick actually landing.
+- Why not chosen: a permanent maintenance burden to patch a hole that unique
+  identities close by construction.
+
+### Alternative B: `<locker-uuid>:<random>` usernames
+
+- Pros: an operator reading a broker log sees which bank an identity belongs to.
+- Cons: parseable structure invites code to parse it, restoring the coupling
+  this ADR removes — silently, since it would keep working.
+- Why not chosen: the mapping already answers "which bank", and the prefix's
+  only real benefit is convenience in a log line.
+
+### Alternative C: Reuse `provisioning_generation` as the username
+
+- Pros: unique per generation already, no new value to mint.
+- Cons: conflates an authentication credential with an identifier used in events
+  and reasoning about staleness; rotating credentials would then require a new
+  provisioning generation.
+- Why not chosen: two concerns that change for different reasons should not
+  share a value.
+
+### Alternative D: Hard-delete revoked identities
+
+- Pros: no dormant rows; nothing to filter.
+- Cons: frees the username for reuse, which is the exact failure being fixed.
+- Why not chosen: reuse prevention is the point.
+
+### Alternative E: Add a generation id to MQTT payloads
+
+- Pros: a second signal that a message belongs to the current generation.
+- Cons: a weaker check in front of an authorisation boundary that already holds;
+  more contract surface and more to keep in sync.
+- Why not chosen: unique identities plus ACL mapping already make a stale
+  generation unable to publish at all.
+
+## Consequences
+
+### Positive
+
+- A revoked identity can never be resurrected, so a still-connected old session
+  cannot regain authorisation.
+- No custom Mosquitto plugin, and no dependence on eviction landing.
+- The ACL's locker-scoping becomes an explicit mapping that fails closed.
+- Credentials can be rotated by re-provisioning, without a schema change.
+
+### Negative
+
+- The provisioning reply grows a field, so the contract and both sides move
+  together.
+- `mqtt_users` accumulates disabled rows, one per generation. They are small,
+  and they are what holds each retired username permanently occupied.
+- A revoked client that is still running reconnects and fails until someone
+  re-provisions it, writing a denial line each time.
+- An operator reading a broker log sees an opaque username and needs the mapping
+  to know which bank it is.
+
+### Risks
+
+- **The core assumption is version-dependent.** That an already-connected
+  client's later ACL checks are denied once its identity is disabled holds for
+  the pinned broker with `auth_opt_cache false`, and is asserted by the
+  integration test in decision 8. Upgrading Mosquitto or go-auth can change it,
+  which is what the pin and that test are guarding.
+- **A client updated after receiving a new identity** would authenticate with an
+  opaque username while still deriving topics from it, and would be denied.
+  Mitigated by shipping the client change before any re-provisioning.
+- **Revocation by locker bank** disables every identity for that bank. That is
+  the invariant rather than an assumption — decision 3 revokes before every
+  insert — so a bank that legitimately needs two live identities would have to
+  revisit this ADR, not work around it.
+
+## Rollout / Migration
+
+The order matters: no bank may be re-provisioned until a client that understands
+the new reply is deployed. Opaque usernames are therefore issued **last**, and
+steps 3–5 must reach production together if they are not released in sequence.
+
+1. Add `revoked_at` to `mqtt_users` (nullable timestamp).
+2. Map the ACL device branch through `locker_bank_id` via the `%l` placeholder;
+   add cross-locker and wildcard-injection coverage. Legacy usernames keep
+   working from this step on, and nothing else changes yet.
+3. Add `locker_uuid` to the provisioning reply and update the AsyncAPI schemas.
+   Existing clients ignore the new field.
+4. Ship the locker-client change. The live coupling is
+   `bootstrap/createApp.ts` (`const lockerUuid = credentials.username.trim()`)
+   and the same line in `bootstrap/createSimulatorApp.ts`; the persisted schema
+   in `adapters/persistence/file-credential.store.ts` is `{username, password}`
+   and gains an optional `lockerUuid` that defaults to `username` when absent,
+   which migrates existing credential files without touching them. The simulator
+   is in scope — it reads the same store and builds the same topics.
+5. Only once clients are updated: issue opaque usernames in `MqttReactor`,
+   revoking every enabled identity for the bank inside the same locked
+   transaction that inserts the new one — the retry path depends on it. Revoke
+   likewise in `LockerProvisioningService` at reset, turn `createUser()`'s upsert
+   into an insert, and remove `deleteUser()`. Cover a retried
+   `LockerWasProvisioned` explicitly: it must leave one live identity, not two.
+
+   Restart the queue workers as part of deploying this step. Issuance runs in a
+   queued reactor, so workers that were already running keep executing the old
+   code and quietly keep minting locker-uuid usernames — the provisioning
+   succeeds, which is what makes it easy to miss.
+6. Pin the broker image in both compose files; add the real-broker integration
+   test.
+
+Acceptance also covers #161's remaining cases: legacy credentials still
+authenticate and reach only their own topics, re-provisioning yields a different
+username and password, a disabled identity fails both auth and ACL, a new
+identity reaches only topics mapped to its `locker_bank_id`, the client persists
+both values and addresses topics by UUID, and an existing credential file
+migrates.
+
+Existing deployments need no action: legacy identities keep working until their
+bank is next reset.
+
+## Supersedes / Superseded By
+
+- Supersedes: none.
+- Related: [ADR-0048](0048-one-time-hmac-locker-provisioning.md) — provisioning
+  generations and the reset flow this builds on.
+
+## References
+
+- Related issues: #161
+- Code: `app/Http/Controllers/Mqtt/MosquittoAuthController.php`,
+  `app/Services/MqttAclService.php`, `app/Services/MqttUserService.php`,
+  `app/Reactors/MqttReactor.php`,
+  `app/Mqtt/Publishers/ProvisioningReplyPublisher.php`

--- a/docs/asyncapi/examples/provisioning-success.json
+++ b/docs/asyncapi/examples/provisioning-success.json
@@ -3,7 +3,8 @@
   "status": "success",
   "timestamp": "2026-04-14T19:35:01Z",
   "data": {
-    "mqtt_user": "11111111-1111-1111-1111-111111111111",
-    "mqtt_password": "super-secret-password"
+    "mqtt_user": "hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb",
+    "mqtt_password": "super-secret-password",
+    "locker_uuid": "11111111-1111-1111-1111-111111111111"
   }
 }

--- a/docs/asyncapi/schemas/payloads/provisioning-success.json
+++ b/docs/asyncapi/schemas/payloads/provisioning-success.json
@@ -20,16 +20,24 @@
           "type": "object",
           "required": [
             "mqtt_user",
-            "mqtt_password"
+            "mqtt_password",
+            "locker_uuid"
           ],
           "properties": {
             "mqtt_user": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Opaque MQTT username for this provisioning generation. Not a locker identifier."
             },
             "mqtt_password": {
               "type": "string",
               "minLength": 1
+            },
+            "locker_uuid": {
+              "type": "string",
+              "format": "uuid",
+              "minLength": 1,
+              "description": "Locker bank this identity is authorised for. Every locker topic is built from this value; the MQTT username authenticates only and carries no topic meaning."
             }
           },
           "additionalProperties": false

--- a/locker-backend/app/Http/Controllers/Mqtt/MosquittoAuthController.php
+++ b/locker-backend/app/Http/Controllers/Mqtt/MosquittoAuthController.php
@@ -122,16 +122,27 @@ class MosquittoAuthController extends Controller
             return response()->json(['allow' => false, 'ok' => false], 403); // Explicitly deny
         }
 
-        // Device users
+        // Device users. The authorised locker comes from the identity's mapping,
+        // not from its username: a username is opaque and says nothing about which
+        // bank it belongs to. Legacy identities, whose username happens to be their
+        // locker uuid, are authorised by the same lookup.
         $user = MqttUser::where('username', $username)->where('enabled', true)->first();
         if ($user !== null) {
+            $lockerUuid = (string) $user->locker_bank_id;
+
+            if ($lockerUuid === '') {
+                Log::channel('broker')->info('ACL Device: Denied (identity has no locker mapping)');
+
+                return response()->json(['allow' => false, 'ok' => false], 403);
+            }
+
             $isWriteAcc = in_array($acc, [self::ACC_WRITE, self::ACC_READWRITE], true);
             $isReadAcc = in_array($acc, [self::ACC_READ, self::ACC_READWRITE, self::ACC_SUBSCRIBE], true);
 
             if ($isWriteAcc) { // publish (device -> backend)
-                $allow = $this->acl->topicMatches('locker/%u/state/#', $topic, $username, $clientId)
-                    || $this->acl->topicMatches('locker/%u/response', $topic, $username, $clientId)
-                    || $this->acl->topicMatches('locker/%u/event', $topic, $username, $clientId);
+                $allow = $this->acl->topicMatches('locker/%l/state/#', $topic, $username, $clientId, $lockerUuid)
+                    || $this->acl->topicMatches('locker/%l/response', $topic, $username, $clientId, $lockerUuid)
+                    || $this->acl->topicMatches('locker/%l/event', $topic, $username, $clientId, $lockerUuid);
 
                 return response()->json([
                     'allow' => $allow,
@@ -141,7 +152,7 @@ class MosquittoAuthController extends Controller
 
             // For device users, treat read-style acc values as subscribe-like (without double-counting readwrite).
             if ($isReadAcc) { // subscribe / unsubscribe / other read-style access (write already handled above)
-                $allow = $this->acl->topicMatches('locker/%u/command', $topic, $username, $clientId);
+                $allow = $this->acl->topicMatches('locker/%l/command', $topic, $username, $clientId, $lockerUuid);
 
                 return response()->json([
                     'allow' => $allow,

--- a/locker-backend/app/Models/MqttUser.php
+++ b/locker-backend/app/Models/MqttUser.php
@@ -18,11 +18,13 @@ class MqttUser extends Model
         'username',
         'password_hash',
         'enabled',
+        'revoked_at',
         'notes',
     ];
 
     protected $casts = [
         'enabled' => 'boolean',
+        'revoked_at' => 'datetime',
     ];
 
     /**

--- a/locker-backend/app/Mqtt/Publishers/ProvisioningReplyPublisher.php
+++ b/locker-backend/app/Mqtt/Publishers/ProvisioningReplyPublisher.php
@@ -31,6 +31,10 @@ class ProvisioningReplyPublisher
             'data' => [
                 'mqtt_user' => $mqttUser,
                 'mqtt_password' => $mqttPassword,
+                // The username authenticates and nothing more. Every locker topic
+                // is built from this uuid, which is why it travels as its own field
+                // rather than being read back off the username.
+                'locker_uuid' => $event->lockerBankUuid,
             ],
         ]);
     }

--- a/locker-backend/app/Reactors/MqttReactor.php
+++ b/locker-backend/app/Reactors/MqttReactor.php
@@ -59,7 +59,11 @@ class MqttReactor extends Reactor implements ShouldQueue
             return;
         }
 
-        $mqttUser = $event->lockerBankUuid;
+        // Opaque and unique per provisioning: a username that equalled the locker
+        // uuid could be recreated after revocation, which is how a still-connected
+        // old session used to regain access. Nothing may parse this value — the
+        // locker it may address comes from its `locker_bank_id` mapping.
+        $mqttUser = Str::random(32);
         $mqttPassword = Str::random(32);
 
         try {
@@ -68,9 +72,16 @@ class MqttReactor extends Reactor implements ShouldQueue
                     return false;
                 }
 
-                Log::info('[MqttReactor] Attempting to create MQTT user...');
+                // Retire whatever the bank had before issuing the replacement, in
+                // this same locked transaction. This reactor is queued and rethrows
+                // to retry, so a failure after the insert re-runs the handler for an
+                // unchanged generation; without revoking first, every retry would
+                // leave another live identity behind.
+                $this->mqttUserService->revokeForLockerBank($event->lockerBankUuid);
+
+                Log::info('[MqttReactor] Attempting to issue MQTT identity...');
                 $this->mqttUserService->createUser($mqttUser, $mqttPassword, $event->lockerBankUuid);
-                Log::info('[MqttReactor] MQTT user created successfully.');
+                Log::info('[MqttReactor] MQTT identity issued successfully.');
 
                 return true;
             });

--- a/locker-backend/app/Services/LockerProvisioningService.php
+++ b/locker-backend/app/Services/LockerProvisioningService.php
@@ -59,7 +59,7 @@ class LockerProvisioningService
                 )
                 ->persist();
 
-            $this->mqttUserService->deleteUser((string) $lockedLockerBank->id);
+            $this->mqttUserService->revokeForLockerBank((string) $lockedLockerBank->id);
 
             return $token;
         });

--- a/locker-backend/app/Services/MqttAclService.php
+++ b/locker-backend/app/Services/MqttAclService.php
@@ -14,11 +14,15 @@ class MqttAclService
      * - `#` matches the remainder of the topic (multi-level wildcard).
      * - `%u` matches exactly the given username as a single level (literal, no wildcard expansion).
      * - `%c` matches exactly the given client id as a single level (literal, no wildcard expansion).
+     * - `%l` matches exactly the given locker uuid as a single level (literal, no wildcard expansion).
      *
      * Important security note:
-     * `%u` and `%c` are matched as literals to prevent wildcard injection (e.g. username '#' or '+').
+     * `%u`, `%c` and `%l` are matched as literals to prevent wildcard injection (e.g. username '#' or '+').
+     * A device's authorised locker is looked up rather than read off its username, so `%l` carries a value
+     * the client never supplies. Interpolating that value into the pattern instead would match as a
+     * pattern, which is the same injection hole the placeholders exist to avoid.
      */
-    public function topicMatches(string $pattern, string $topic, string $username, string $clientId): bool
+    public function topicMatches(string $pattern, string $topic, string $username, string $clientId, ?string $lockerUuid = null): bool
     {
         $patternParts = explode('/', $pattern);
         $topicParts = explode('/', $topic);
@@ -50,6 +54,19 @@ class MqttAclService
 
             if ($seg === '%c') {
                 if ($topicParts[$j] === '' || $topicParts[$j] !== $clientId) {
+                    return false;
+                }
+
+                $i++;
+                $j++;
+
+                continue;
+            }
+
+            if ($seg === '%l') {
+                // No mapped locker means no authorised topics, so fail closed
+                // rather than letting the pattern match anything.
+                if ($lockerUuid === null || $lockerUuid === '' || $topicParts[$j] !== $lockerUuid) {
                     return false;
                 }
 

--- a/locker-backend/app/Services/MqttUserService.php
+++ b/locker-backend/app/Services/MqttUserService.php
@@ -11,24 +11,50 @@ use Illuminate\Support\Facades\Log;
 class MqttUserService
 {
     /**
-     * Create a new MQTT user according to selected driver.
+     * Issue a new MQTT identity.
+     *
+     * An insert, never an upsert: usernames are opaque and issued once, so a
+     * collision means a caller passed a username that was already handed out —
+     * which must fail loudly rather than silently re-password an existing row.
      */
     public function createUser(string $username, string $password, string $lockerBankId): void
     {
-        $user = MqttUser::firstOrNew(['username' => $username]);
+        $user = new MqttUser;
+        $user->username = $username;
         $user->password_hash = Hash::make($password);
         $user->locker_bank_id = $lockerBankId;
         $user->enabled = true;
+        $user->revoked_at = null;
         $user->save();
-        Log::info('App MQTT user upserted.', ['username' => $username]);
+
+        Log::info('App MQTT identity issued.', ['username' => $username]);
     }
 
     /**
-     * Delete an MQTT user according to selected driver.
+     * Retire every live identity of a locker bank.
+     *
+     * Rows are disabled and kept, never deleted: the unique index on `username`
+     * is what stops a retired identity from ever being issued again, so deleting
+     * would hand its username back for reuse. Because an already-connected
+     * session is authorised per operation against this row, disabling it also
+     * ends that session's access without needing to evict it at the broker.
+     *
+     * @return int number of identities retired
      */
-    public function deleteUser(string $username): void
+    public function revokeForLockerBank(string $lockerBankId): int
     {
-        MqttUser::where('username', $username)->delete();
-        Log::info('App MQTT user deleted.', ['username' => $username]);
+        $revoked = MqttUser::query()
+            ->where('locker_bank_id', $lockerBankId)
+            ->where('enabled', true)
+            ->update(['enabled' => false, 'revoked_at' => now()]);
+
+        if ($revoked > 0) {
+            Log::info('App MQTT identities revoked.', [
+                'locker_bank_id' => $lockerBankId,
+                'count' => $revoked,
+            ]);
+        }
+
+        return $revoked;
     }
 }

--- a/locker-backend/database/migrations/2026_08_22_000001_add_revoked_at_to_mqtt_users_table.php
+++ b/locker-backend/database/migrations/2026_08_22_000001_add_revoked_at_to_mqtt_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mqtt_users', function (Blueprint $table): void {
+            // Revoked identities are disabled and kept, never deleted: the unique
+            // index on `username` is what stops a retired identity being issued
+            // again. Null means "not revoked"; existing rows are unaffected.
+            $table->timestamp('revoked_at')->nullable()->after('enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mqtt_users', function (Blueprint $table): void {
+            $table->dropColumn('revoked_at');
+        });
+    }
+};

--- a/locker-backend/docker-compose.prod.yml
+++ b/locker-backend/docker-compose.prod.yml
@@ -183,7 +183,7 @@ services:
       retries: 3
 
   mqtt:
-    image: iegomez/mosquitto-go-auth:latest
+    image: iegomez/mosquitto-go-auth:2.1.0-mosquitto_2.0.15
     restart: unless-stopped
     ports:
       - "1883:1883"

--- a/locker-backend/docker-compose.yml
+++ b/locker-backend/docker-compose.yml
@@ -200,7 +200,7 @@ services:
             - sail
 
     mqtt:
-        image: iegomez/mosquitto-go-auth:latest
+        image: iegomez/mosquitto-go-auth:2.1.0-mosquitto_2.0.15
         restart: unless-stopped
         ports:
             - "1883:1883"

--- a/locker-backend/tests/Feature/LockerBankProvisioningResetTest.php
+++ b/locker-backend/tests/Feature/LockerBankProvisioningResetTest.php
@@ -235,7 +235,7 @@ class LockerBankProvisioningResetTest extends TestCase
         $this->assertNull($lockerBank->provisioning_generation);
     }
 
-    public function test_restart_resets_state_and_deletes_operational_mqtt_user(): void
+    public function test_restart_resets_state_and_revokes_operational_mqtt_identity(): void
     {
         $lockerBank = $this->provisionedBank();
         app(MqttUserService::class)->createUser(
@@ -254,13 +254,21 @@ class LockerBankProvisioningResetTest extends TestCase
         $this->assertNull($lockerBank->last_config_sent_hash);
         $this->assertNull($lockerBank->last_config_ack_at);
         $this->assertNull($lockerBank->last_config_ack_hash);
-        $this->assertDatabaseMissing('mqtt_users', ['username' => (string) $lockerBank->id]);
+        // The identity is retired, not deleted: keeping the row is what stops its
+        // username ever being issued again.
+        $this->assertDatabaseHas('mqtt_users', [
+            'username' => (string) $lockerBank->id,
+            'enabled' => false,
+        ]);
+        $this->assertNotNull(
+            \App\Models\MqttUser::query()->where('username', (string) $lockerBank->id)->value('revoked_at')
+        );
         $this->assertSame(1, EloquentStoredEvent::query()
             ->where('event_class', LockerProvisioningReset::class)
             ->count());
     }
 
-    public function test_restart_rolls_back_events_projection_and_mqtt_user_deletion_failure(): void
+    public function test_restart_rolls_back_events_projection_and_mqtt_identity_revocation_failure(): void
     {
         $lockerBank = $this->provisionedBank();
         MqttUser::factory()->create([
@@ -272,12 +280,14 @@ class LockerBankProvisioningResetTest extends TestCase
         $storedEventCount = EloquentStoredEvent::query()->count();
 
         $this->mock(MqttUserService::class, function ($mock): void {
-            $mock->shouldReceive('deleteUser')
+            $mock->shouldReceive('revokeForLockerBank')
                 ->once()
-                ->andReturnUsing(function (string $username): never {
-                    MqttUser::query()->where('username', $username)->delete();
+                ->andReturnUsing(function (string $lockerBankId): never {
+                    MqttUser::query()
+                        ->where('locker_bank_id', $lockerBankId)
+                        ->update(['enabled' => false, 'revoked_at' => now()]);
 
-                    throw new \RuntimeException('delete failed');
+                    throw new \RuntimeException('revoke failed');
                 });
         });
 
@@ -285,14 +295,19 @@ class LockerBankProvisioningResetTest extends TestCase
             app(LockerProvisioningService::class)->restart($lockerBank, $admin);
             $this->fail('Expected restart failure.');
         } catch (\RuntimeException $exception) {
-            $this->assertSame('delete failed', $exception->getMessage());
+            $this->assertSame('revoke failed', $exception->getMessage());
         }
 
         $lockerBank->refresh();
         $this->assertSame($original['provisioned_at'], $lockerBank->getRawOriginal('provisioned_at'));
         $this->assertSame($original['provisioning_generation'], $lockerBank->provisioning_generation);
         $this->assertNull($lockerBank->provisioning_token_hmac);
-        $this->assertDatabaseHas('mqtt_users', ['username' => (string) $lockerBank->id]);
+        // The rollback must also undo the revocation, or a failed restart would
+        // leave the bank with no usable identity.
+        $this->assertDatabaseHas('mqtt_users', [
+            'username' => (string) $lockerBank->id,
+            'enabled' => true,
+        ]);
         $this->assertSame($storedEventCount, EloquentStoredEvent::query()->count());
     }
 

--- a/locker-backend/tests/Feature/MosquittoAuthControllerTest.php
+++ b/locker-backend/tests/Feature/MosquittoAuthControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\LockerBank;
 use App\Models\MqttUser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
@@ -256,17 +257,18 @@ class MosquittoAuthControllerTest extends TestCase
 
     public function test_device_user_can_publish_split_state_topics_response_and_event(): void
     {
-        MqttUser::factory()->create([
+        $user = MqttUser::factory()->create([
             'username' => 'device_1',
             'enabled' => true,
         ]);
+        $lockerUuid = (string) $user->locker_bank_id;
 
         foreach ([
-            'locker/device_1/state/heartbeat',
-            'locker/device_1/state/compartments',
-            'locker/device_1/state/connection',
-            'locker/device_1/response',
-            'locker/device_1/event',
+            "locker/{$lockerUuid}/state/heartbeat",
+            "locker/{$lockerUuid}/state/compartments",
+            "locker/{$lockerUuid}/state/connection",
+            "locker/{$lockerUuid}/response",
+            "locker/{$lockerUuid}/event",
         ] as $topic) {
             $r = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
                 'username' => 'device_1',
@@ -280,23 +282,34 @@ class MosquittoAuthControllerTest extends TestCase
         $commandDenied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
             'username' => 'device_1',
             'clientid' => 'device_1_client',
-            'topic' => 'locker/device_1/command',
+            'topic' => "locker/{$lockerUuid}/command",
             'acc' => 2,
         ]);
         $commandDenied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
+
+        // The username is not a topic namespace: publishing under it must fail
+        // even though it authenticates.
+        $usernameTopicDenied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+            'username' => 'device_1',
+            'clientid' => 'device_1_client',
+            'topic' => 'locker/device_1/event',
+            'acc' => 2,
+        ]);
+        $usernameTopicDenied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
     }
 
     public function test_device_user_can_subscribe_only_to_command_topic(): void
     {
-        MqttUser::factory()->create([
+        $user = MqttUser::factory()->create([
             'username' => 'device_1',
             'enabled' => true,
         ]);
+        $lockerUuid = (string) $user->locker_bank_id;
 
         $allowed = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
             'username' => 'device_1',
             'clientid' => 'device_1_client',
-            'topic' => 'locker/device_1/command',
+            'topic' => "locker/{$lockerUuid}/command",
             'acc' => 1,
         ]);
         $allowed->assertOk()->assertJson(['allow' => true, 'ok' => true]);
@@ -304,7 +317,7 @@ class MosquittoAuthControllerTest extends TestCase
         $stateDenied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
             'username' => 'device_1',
             'clientid' => 'device_1_client',
-            'topic' => 'locker/device_1/state/heartbeat',
+            'topic' => "locker/{$lockerUuid}/state/heartbeat",
             'acc' => 1,
         ]);
         $stateDenied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
@@ -312,7 +325,7 @@ class MosquittoAuthControllerTest extends TestCase
         $extraDenied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
             'username' => 'device_1',
             'clientid' => 'device_1_client',
-            'topic' => 'locker/device_1/command/extra',
+            'topic' => "locker/{$lockerUuid}/command/extra",
             'acc' => 1,
         ]);
         $extraDenied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
@@ -333,5 +346,92 @@ class MosquittoAuthControllerTest extends TestCase
         ]);
 
         $response->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
+    }
+
+    public function test_legacy_uuid_username_is_authorised_through_the_same_mapping(): void
+    {
+        // Identities issued before opaque usernames have username == locker uuid.
+        // They must keep working with no special case: the mapping authorises them.
+        $bank = LockerBank::factory()->create();
+        MqttUser::factory()->create([
+            'locker_bank_id' => $bank->id,
+            'username' => (string) $bank->id,
+            'enabled' => true,
+        ]);
+
+        $allowed = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+            'username' => (string) $bank->id,
+            'clientid' => 'legacy_client',
+            'topic' => "locker/{$bank->id}/event",
+            'acc' => 2,
+        ]);
+
+        $allowed->assertOk()->assertJson(['allow' => true, 'ok' => true]);
+    }
+
+    public function test_device_user_cannot_reach_another_lockers_topics(): void
+    {
+        $own = MqttUser::factory()->create(['username' => 'device_own', 'enabled' => true]);
+        $other = LockerBank::factory()->create();
+
+        $denied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+            'username' => 'device_own',
+            'clientid' => 'device_own_client',
+            'topic' => "locker/{$other->id}/command",
+            'acc' => 1,
+        ]);
+
+        $denied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
+        $this->assertNotSame((string) $own->locker_bank_id, (string) $other->id);
+    }
+
+    public function test_wildcard_usernames_cannot_widen_device_access(): void
+    {
+        // A username of '#' or '+' must be compared literally, never expanded,
+        // or an identity could name its way into every locker's topics.
+        foreach (['#', '+'] as $wildcard) {
+            $user = MqttUser::factory()->create(['username' => $wildcard, 'enabled' => true]);
+            $other = LockerBank::factory()->create();
+
+            $denied = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+                'username' => $wildcard,
+                'clientid' => 'wildcard_client',
+                'topic' => "locker/{$other->id}/event",
+                'acc' => 2,
+            ]);
+            $denied->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
+
+            $ownAllowed = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+                'username' => $wildcard,
+                'clientid' => 'wildcard_client',
+                'topic' => "locker/{$user->locker_bank_id}/event",
+                'acc' => 2,
+            ]);
+            $ownAllowed->assertOk()->assertJson(['allow' => true, 'ok' => true]);
+        }
+    }
+
+    public function test_disabled_identity_is_denied_for_auth_and_acl(): void
+    {
+        $user = MqttUser::factory()->create([
+            'username' => 'revoked_device',
+            'password_hash' => Hash::make('password123'),
+            'enabled' => false,
+            'revoked_at' => now(),
+        ]);
+
+        $auth = $this->postJson('/api/mosq/auth?mosq_secret=test-secret', [
+            'username' => 'revoked_device',
+            'password' => 'password123',
+        ]);
+        $auth->assertJson(['allow' => false, 'ok' => false]);
+
+        $acl = $this->postJson('/api/mosq/acl?mosq_secret=test-secret', [
+            'username' => 'revoked_device',
+            'clientid' => 'revoked_client',
+            'topic' => "locker/{$user->locker_bank_id}/event",
+            'acc' => 2,
+        ]);
+        $acl->assertStatus(403)->assertJson(['allow' => false, 'ok' => false]);
     }
 }

--- a/locker-backend/tests/Feature/MqttReactorDelegationTest.php
+++ b/locker-backend/tests/Feature/MqttReactorDelegationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\LockerBank;
+use App\Models\MqttUser;
 use App\Mqtt\Publishers\ApplyConfigCommandPublisher;
 use App\Mqtt\Publishers\OpenCompartmentCommandPublisher;
 use App\Mqtt\Publishers\ProvisioningReplyPublisher;
@@ -75,13 +76,24 @@ class MqttReactorDelegationTest extends TestCase
         );
         $generatedPassword = null;
 
-        $this->mock(MqttUserService::class, function ($mock) use ($event, &$generatedPassword): void {
+        $generatedUsername = null;
+
+        $this->mock(MqttUserService::class, function ($mock) use ($event, &$generatedPassword, &$generatedUsername): void {
+            $mock->shouldReceive('revokeForLockerBank')
+                ->once()
+                ->with($event->lockerBankUuid)
+                ->andReturn(0);
+
             $mock->shouldReceive('createUser')
                 ->once()
-                ->withArgs(function (string $username, string $password, string $lockerBankUuid) use ($event, &$generatedPassword): bool {
+                ->withArgs(function (string $username, string $password, string $lockerBankUuid) use ($event, &$generatedPassword, &$generatedUsername): bool {
                     $generatedPassword = $password;
+                    $generatedUsername = $username;
 
-                    $this->assertSame($event->lockerBankUuid, $username);
+                    // The username must no longer be the locker uuid: that is the
+                    // coupling that let a revoked identity be recreated.
+                    $this->assertNotSame($event->lockerBankUuid, $username);
+                    $this->assertNotSame('', $username);
                     $this->assertSame($event->lockerBankUuid, $lockerBankUuid);
                     $this->assertNotSame('', $password);
 
@@ -89,12 +101,14 @@ class MqttReactorDelegationTest extends TestCase
                 });
         });
 
-        $this->mock(ProvisioningReplyPublisher::class, function ($mock) use ($event, &$generatedPassword): void {
+        $this->mock(ProvisioningReplyPublisher::class, function ($mock) use ($event, &$generatedPassword, &$generatedUsername): void {
             $mock->shouldReceive('publishSuccess')
                 ->once()
-                ->withArgs(function (LockerWasProvisioned $publishedEvent, string $mqttUser, string $mqttPassword) use ($event, &$generatedPassword): bool {
+                ->withArgs(function (LockerWasProvisioned $publishedEvent, string $mqttUser, string $mqttPassword) use ($event, &$generatedPassword, &$generatedUsername): bool {
                     $this->assertSame($event, $publishedEvent);
-                    $this->assertSame($event->lockerBankUuid, $mqttUser);
+                    // The client is told the identity that was issued, not the
+                    // locker uuid — that travels as its own field in the reply.
+                    $this->assertSame($generatedUsername, $mqttUser);
                     $this->assertSame($generatedPassword, $mqttPassword);
 
                     return true;
@@ -147,6 +161,7 @@ class MqttReactorDelegationTest extends TestCase
         );
 
         $this->mock(MqttUserService::class, function ($mock) use ($lockerBank): void {
+            $mock->shouldReceive('revokeForLockerBank')->once()->andReturn(0);
             $mock->shouldReceive('createUser')
                 ->once()
                 ->andReturnUsing(function () use ($lockerBank): void {
@@ -176,5 +191,79 @@ class MqttReactorDelegationTest extends TestCase
         });
 
         app(MqttReactor::class)->onLockerProvisioningFailed($event);
+    }
+
+    public function test_a_retried_provisioning_event_leaves_exactly_one_live_identity(): void
+    {
+        // This reactor is queued and rethrows to trigger a retry, so the same
+        // generation can be handled more than once. Issuing an opaque username per
+        // attempt would accumulate live identities unless each issuance revokes
+        // what came before it.
+        $generation = (string) Str::uuid();
+        $lockerBank = LockerBank::factory()->create([
+            'provisioned_at' => now(),
+            'provisioning_generation' => $generation,
+        ]);
+
+        $event = new LockerWasProvisioned(
+            lockerBankUuid: (string) $lockerBank->id,
+            replyToTopic: 'locker/provisioning/reply/test-client',
+            provisioningGeneration: $generation,
+        );
+
+        $publishedUsernames = [];
+        $this->mock(ProvisioningReplyPublisher::class, function ($mock) use (&$publishedUsernames): void {
+            $mock->shouldReceive('publishSuccess')
+                ->twice()
+                ->andReturnUsing(function (LockerWasProvisioned $e, string $mqttUser) use (&$publishedUsernames): void {
+                    $publishedUsernames[] = $mqttUser;
+                });
+        });
+
+        $reactor = app(MqttReactor::class);
+        $reactor->onLockerWasProvisioned($event);
+        $reactor->onLockerWasProvisioned($event);
+
+        $identities = MqttUser::query()->where('locker_bank_id', $lockerBank->id)->get();
+
+        $this->assertCount(2, $identities, 'each attempt issues its own identity');
+        $this->assertCount(1, $identities->where('enabled', true), 'only one may remain live');
+        $this->assertSame(
+            $publishedUsernames[1],
+            (string) $identities->firstWhere('enabled', true)?->username,
+            'the live identity is the one whose credentials were published last',
+        );
+
+        foreach ($identities->where('enabled', false) as $revoked) {
+            $this->assertNotNull($revoked->revoked_at, 'a retired identity is stamped, not deleted');
+        }
+    }
+
+    public function test_each_provisioning_issues_a_different_username_and_password(): void
+    {
+        $bankA = LockerBank::factory()->create(['provisioned_at' => now(), 'provisioning_generation' => (string) Str::uuid()]);
+        $bankB = LockerBank::factory()->create(['provisioned_at' => now(), 'provisioning_generation' => (string) Str::uuid()]);
+
+        $seen = [];
+        $this->mock(ProvisioningReplyPublisher::class, function ($mock) use (&$seen): void {
+            $mock->shouldReceive('publishSuccess')
+                ->twice()
+                ->andReturnUsing(function (LockerWasProvisioned $e, string $user, string $password) use (&$seen): void {
+                    $seen[] = [$user, $password];
+                });
+        });
+
+        $reactor = app(MqttReactor::class);
+        foreach ([$bankA, $bankB] as $bank) {
+            $reactor->onLockerWasProvisioned(new LockerWasProvisioned(
+                lockerBankUuid: (string) $bank->id,
+                replyToTopic: 'locker/provisioning/reply/test-client',
+                provisioningGeneration: (string) $bank->provisioning_generation,
+            ));
+        }
+
+        $this->assertNotSame($seen[0][0], $seen[1][0], 'usernames must differ');
+        $this->assertNotSame($seen[0][1], $seen[1][1], 'passwords must differ');
+        $this->assertNotSame((string) $bankA->id, $seen[0][0], 'the username is not the locker uuid');
     }
 }

--- a/locker-backend/tests/Feature/MqttUserServiceTest.php
+++ b/locker-backend/tests/Feature/MqttUserServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\LockerBank;
+use App\Models\MqttUser;
+use App\Services\MqttUserService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class MqttUserServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_retired_username_can_never_be_issued_again(): void
+    {
+        // The whole reason identities are disabled rather than deleted: the unique
+        // index keeps a retired username occupied, so a still-connected session
+        // whose identity was revoked can never have it recreated underneath it.
+        // An upsert here — which is what this code used to do — would silently
+        // re-password the retired row instead of failing.
+        $bank = LockerBank::factory()->create();
+        $service = app(MqttUserService::class);
+
+        $service->createUser('taken-identity', 'first-password', (string) $bank->id);
+        $service->revokeForLockerBank((string) $bank->id);
+
+        $this->expectException(QueryException::class);
+        $service->createUser('taken-identity', 'second-password', (string) $bank->id);
+    }
+
+    public function test_revoking_disables_every_live_identity_of_one_bank_only(): void
+    {
+        $bank = LockerBank::factory()->create();
+        $otherBank = LockerBank::factory()->create();
+
+        $service = app(MqttUserService::class);
+        $service->createUser('identity-a', 'password', (string) $bank->id);
+        $service->createUser('identity-b', 'password', (string) $bank->id);
+        $service->createUser('untouched', 'password', (string) $otherBank->id);
+
+        $this->assertSame(2, $service->revokeForLockerBank((string) $bank->id));
+
+        foreach (['identity-a', 'identity-b'] as $username) {
+            $identity = MqttUser::query()->where('username', $username)->firstOrFail();
+            $this->assertFalse($identity->enabled);
+            $this->assertNotNull($identity->revoked_at, 'a retired identity is stamped, not deleted');
+        }
+
+        $this->assertTrue(MqttUser::query()->where('username', 'untouched')->firstOrFail()->enabled);
+
+        // Nothing is removed, so the usernames stay occupied.
+        $this->assertSame(3, MqttUser::query()->count());
+    }
+
+    public function test_revoking_a_bank_with_nothing_live_changes_nothing(): void
+    {
+        $bank = LockerBank::factory()->create();
+        $service = app(MqttUserService::class);
+
+        $this->assertSame(0, $service->revokeForLockerBank((string) $bank->id));
+    }
+
+    public function test_an_issued_identity_is_live_and_authenticatable(): void
+    {
+        $bank = LockerBank::factory()->create();
+        app(MqttUserService::class)->createUser('fresh-identity', 'a-password', (string) $bank->id);
+
+        $identity = MqttUser::query()->where('username', 'fresh-identity')->firstOrFail();
+
+        $this->assertTrue($identity->enabled);
+        $this->assertNull($identity->revoked_at);
+        $this->assertSame((string) $bank->id, (string) $identity->locker_bank_id);
+        $this->assertTrue(Hash::check('a-password', $identity->password_hash));
+    }
+}

--- a/locker-backend/tests/Feature/OutboundMqttPublisherTest.php
+++ b/locker-backend/tests/Feature/OutboundMqttPublisherTest.php
@@ -136,6 +136,11 @@ class OutboundMqttPublisherTest extends TestCase
         $this->assertSame('success', $payload['status'] ?? null);
         $this->assertSame('mqtt-user', $payload['data']['mqtt_user'] ?? null);
         $this->assertSame('mqtt-password', $payload['data']['mqtt_password'] ?? null);
+        // The locker uuid must come from the event, not from the username or the
+        // reply topic: the client builds every topic from this value, so wiring it
+        // to the wrong source would send a device to another bank's namespace.
+        $this->assertSame($event->lockerBankUuid, $payload['data']['locker_uuid'] ?? null);
+        $this->assertNotSame($payload['data']['mqtt_user'], $payload['data']['locker_uuid']);
     }
 
     public function test_provisioning_reply_publisher_builds_failure_payload(): void

--- a/locker-backend/tests/Unit/MqttAclServiceTest.php
+++ b/locker-backend/tests/Unit/MqttAclServiceTest.php
@@ -50,4 +50,31 @@ class MqttAclServiceTest extends TestCase
         $this->assertTrue($acl->topicMatches('locker/#', 'locker/a/b/c', 'u', 'c'));
         $this->assertFalse($acl->topicMatches('locker/#', 'server/status', 'u', 'c'));
     }
+
+    public function test_locker_placeholder_matches_the_mapped_uuid_literally(): void
+    {
+        $acl = new MqttAclService;
+        $uuid = '019e5a20-8a02-718d-9146-a8a656edabbd';
+
+        $this->assertTrue($acl->topicMatches('locker/%l/command', "locker/{$uuid}/command", 'opaque-name', 'c', $uuid));
+        $this->assertFalse($acl->topicMatches('locker/%l/command', 'locker/opaque-name/command', 'opaque-name', 'c', $uuid));
+        $this->assertFalse($acl->topicMatches('locker/%l/command', 'locker/other-uuid/command', 'opaque-name', 'c', $uuid));
+    }
+
+    public function test_locker_placeholder_is_not_expanded_as_a_wildcard(): void
+    {
+        $acl = new MqttAclService;
+
+        // A '#' reaching the placeholder must be compared, never expanded.
+        $this->assertFalse($acl->topicMatches('locker/%l/event', 'locker/anything/event', 'u', 'c', '#'));
+        $this->assertTrue($acl->topicMatches('locker/%l/event', 'locker/#/event', 'u', 'c', '#'));
+    }
+
+    public function test_locker_placeholder_fails_closed_without_a_mapping(): void
+    {
+        $acl = new MqttAclService;
+
+        $this->assertFalse($acl->topicMatches('locker/%l/event', 'locker/anything/event', 'u', 'c', null));
+        $this->assertFalse($acl->topicMatches('locker/%l/event', 'locker//event', 'u', 'c', ''));
+    }
 }

--- a/locker-client/src/adapters/persistence/file-credential.store.ts
+++ b/locker-client/src/adapters/persistence/file-credential.store.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { z } from 'zod';
-import type { CredentialStorePort } from '../../ports/config.port';
+import type { CredentialStorePort, DeviceCredentials } from '../../ports/config.port';
 import { MQTT_CREDENTIALS_FILE } from '../../infrastructure/paths';
 import {
   atomicWriteFileSync,
@@ -8,15 +8,21 @@ import {
   readPrivateFileSync,
 } from '../../infrastructure/file-persistence';
 
-const credentialsSchema = z.object({
-  username: z.string().min(1),
-  password: z.string().min(1),
-});
+// `lockerUuid` is optional on read and defaults to the username: a file written
+// before per-provisioning identities holds a username that *was* the locker uuid,
+// so an existing installation keeps working without being rewritten.
+const credentialsSchema = z
+  .object({
+    username: z.string().min(1),
+    password: z.string().min(1),
+    lockerUuid: z.string().min(1).optional(),
+  })
+  .transform((c) => ({ ...c, lockerUuid: c.lockerUuid ?? c.username }));
 
 export class FileCredentialStore implements CredentialStorePort {
   constructor(private readonly filePath: string = MQTT_CREDENTIALS_FILE) {}
 
-  getCredentials(): { username: string; password: string } | null {
+  getCredentials(): DeviceCredentials | null {
     if (!fs.existsSync(this.filePath)) {
       return null;
     }
@@ -37,7 +43,7 @@ export class FileCredentialStore implements CredentialStorePort {
     }
   }
 
-  saveCredentials(credentials: { username: string; password: string }): void {
+  saveCredentials(credentials: DeviceCredentials): void {
     const parsed = credentialsSchema.parse(credentials);
     atomicWriteFileSync(this.filePath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
   }

--- a/locker-client/src/adapters/simulator/in-memory-credential.store.ts
+++ b/locker-client/src/adapters/simulator/in-memory-credential.store.ts
@@ -1,4 +1,4 @@
-import type { CredentialStorePort } from '../../ports/config.port';
+import type { CredentialStorePort, DeviceCredentials } from '../../ports/config.port';
 
 /**
  * Credentials for one simulated device, held only for the lifetime of the run.
@@ -10,13 +10,13 @@ import type { CredentialStorePort } from '../../ports/config.port';
  * guarantees the simulator never writes over a real device's `/data` files.
  */
 export class InMemoryCredentialStore implements CredentialStorePort {
-  private credentials: { username: string; password: string } | null = null;
+  private credentials: DeviceCredentials | null = null;
 
-  getCredentials(): { username: string; password: string } | null {
+  getCredentials(): DeviceCredentials | null {
     return this.credentials;
   }
 
-  saveCredentials(credentials: { username: string; password: string }): void {
+  saveCredentials(credentials: DeviceCredentials): void {
     this.credentials = { ...credentials };
   }
 

--- a/locker-client/src/adapters/simulator/simulator-credential-cache.ts
+++ b/locker-client/src/adapters/simulator/simulator-credential-cache.ts
@@ -4,6 +4,9 @@ import path from 'path';
 interface CachedCredentials {
   username: string;
   password: string;
+  // Optional: caches written before per-provisioning identities hold a username
+  // that was itself the locker uuid, and must keep working untouched.
+  lockerUuid?: string;
 }
 
 type CacheFileShape = Record<string, CachedCredentials>;

--- a/locker-client/src/application/provision-device.ts
+++ b/locker-client/src/application/provision-device.ts
@@ -2,7 +2,7 @@ import { randomBytes, randomUUID } from 'crypto';
 import fs from 'fs';
 import { provisioningRequestSchema } from '../domain/mqtt-schemas';
 import { MqttSchemaValidationError, parseProvisioningResponse } from '../domain/mqtt-parsing';
-import type { CredentialStorePort } from '../ports/config.port';
+import type { CredentialStorePort, DeviceCredentials } from '../ports/config.port';
 import type { MessageTransportPort } from '../ports/mqtt.port';
 import { logger } from '../infrastructure/logging';
 import {
@@ -90,7 +90,7 @@ function waitForProvisioningReply(
   replyTopic: string,
   registerTopic: string,
   clientId: string,
-): Promise<{ username: string; password: string }> {
+): Promise<DeviceCredentials> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error('Provisioning timed out'));
@@ -110,6 +110,7 @@ function waitForProvisioningReply(
           resolve({
             username: response.data.mqtt_user,
             password: response.data.mqtt_password,
+            lockerUuid: response.data.locker_uuid ?? response.data.mqtt_user,
           });
           return;
         }

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -78,10 +78,11 @@ export async function createApp(): Promise<AppContext> {
     throw new Error('MQTT credentials unavailable after provisioning');
   }
 
-  // MQTT username is the locker bank UUID; all locker topics use this namespace.
-  const lockerUuid = credentials.username.trim();
+  // The username authenticates to the broker and carries no topic meaning; the
+  // locker namespace comes from the uuid the provisioning reply supplied.
+  const lockerUuid = credentials.lockerUuid.trim();
   if (!lockerUuid) {
-    throw new Error('MQTT credentials username (locker UUID) is empty');
+    throw new Error('MQTT credentials locker UUID is empty');
   }
 
   // Built here because the locker UUID identifies this instance, and it is only

--- a/locker-client/src/bootstrap/createSimulatorApp.ts
+++ b/locker-client/src/bootstrap/createSimulatorApp.ts
@@ -400,7 +400,13 @@ async function startSimulatedDevice(
   const cached = credentialCache.get(bank.provisioning_token);
 
   if (cached) {
-    credentialStore.saveCredentials(cached);
+    // A cache written before per-provisioning identities has no lockerUuid; back
+    // then the username was the locker uuid, so that is the right fallback.
+    credentialStore.saveCredentials({
+      username: cached.username,
+      password: cached.password,
+      lockerUuid: cached.lockerUuid ?? cached.username,
+    });
     logger.info('reusing cached simulator credentials', {
       bank: bank.name,
       cache: credentialCache.location,
@@ -424,8 +430,9 @@ async function startSimulatedDevice(
     credentialCache.set(bank.provisioning_token, credentials);
   }
 
-  // MQTT username is the locker bank UUID; all locker topics use this namespace.
-  const lockerUuid = credentials.username.trim();
+  // The username authenticates to the broker and carries no topic meaning; the
+  // locker namespace comes from the uuid the provisioning reply supplied.
+  const lockerUuid = credentials.lockerUuid.trim();
   if (!lockerUuid) {
     throw new Error(`Provisioned credentials for bank "${bank.name}" have an empty locker UUID`);
   }

--- a/locker-client/src/domain/mqtt-schemas.ts
+++ b/locker-client/src/domain/mqtt-schemas.ts
@@ -57,6 +57,9 @@ export const provisioningSuccessResponseSchema = z.object({
   data: z.object({
     mqtt_user: nonEmptyString,
     mqtt_password: nonEmptyString,
+    // Optional so a client stays usable against a backend rolled back to before
+    // per-provisioning identities, where the username still was the locker uuid.
+    locker_uuid: nonEmptyString.optional(),
   }),
 });
 

--- a/locker-client/src/ports/config.port.ts
+++ b/locker-client/src/ports/config.port.ts
@@ -17,9 +17,21 @@ export interface RuntimeOverlayStorePort {
   clear(): void;
 }
 
+/**
+ * Broker credentials plus the locker this device is authorised for. The username
+ * authenticates and nothing more: every locker topic is built from `lockerUuid`.
+ * They were the same value before per-provisioning identities, which is why files
+ * written by an older client carry only the username.
+ */
+export interface DeviceCredentials {
+  username: string;
+  password: string;
+  lockerUuid: string;
+}
+
 export interface CredentialStorePort {
-  getCredentials(): { username: string; password: string } | null;
-  saveCredentials(credentials: { username: string; password: string }): void;
+  getCredentials(): DeviceCredentials | null;
+  saveCredentials(credentials: DeviceCredentials): void;
   isProvisioned(): boolean;
 }
 

--- a/locker-client/tests/integration/broker-revocation.test.ts
+++ b/locker-client/tests/integration/broker-revocation.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import test from 'node:test';
+import mqtt from 'mqtt';
+
+/**
+ * Proves the assumption per-provisioning identities rest on: once an identity is
+ * disabled, a session that is *already connected* stops being authorised — even
+ * though a new identity now exists for the same locker bank.
+ *
+ * If that were false, revocation would only take effect on reconnect and evicting
+ * the old session at the broker would be required for correctness. It is asserted
+ * here rather than reasoned about because it is a property of the broker and its
+ * auth plugin, not of our code, and it can change when either is upgraded. That is
+ * also why the broker image is pinned.
+ *
+ * Opt-in: needs the backend stack running, so it is skipped unless
+ * OPEN_LOCKER_BROKER_TEST=1. Unlike the rest of the suite it writes to the
+ * development database, through artisan in the app container.
+ */
+const enabled = process.env.OPEN_LOCKER_BROKER_TEST === '1';
+const brokerUrl = process.env.OPEN_LOCKER_BROKER_URL ?? 'mqtt://localhost:1883';
+const backendDir =
+  process.env.OPEN_LOCKER_BACKEND_DIR ?? '/opt/homebrew/var/www/open-locker/locker-backend';
+
+function artisan(php: string): string {
+  return execFileSync(
+    'docker',
+    [
+      'compose',
+      'exec',
+      '-T',
+      '-u',
+      'www-data',
+      'app',
+      'php',
+      'artisan',
+      'tinker',
+      '--execute',
+      php,
+    ],
+    { cwd: backendDir, encoding: 'utf8' },
+  );
+}
+
+/** Publishes once and resolves with whether the broker accepted it. */
+function publishAccepted(client: mqtt.MqttClient, topic: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    client.publish(topic, JSON.stringify({ probe: true }), { qos: 1 }, (error) =>
+      resolve(error === undefined || error === null),
+    );
+  });
+}
+
+test(
+  'a connected session loses authorisation once its identity is revoked',
+  { skip: enabled ? false : 'set OPEN_LOCKER_BROKER_TEST=1 with the stack running' },
+  async (t) => {
+    const marker = `itest-${Date.now()}`;
+    const password = 'integration-test-password';
+
+    // Registered before anything is created, and keyed by name rather than by id:
+    // a failure partway through setup would otherwise strand rows in a database
+    // this test does not own.
+    t.after(() => {
+      artisan(`
+        $bank = \\App\\Models\\LockerBank::where('name', '${marker}')->first();
+        if ($bank !== null) {
+          \\App\\Models\\MqttUser::where('locker_bank_id', $bank->id)->delete();
+          $bank->delete();
+        }
+        \\App\\Models\\MqttUser::where('username', '${marker}')->delete();
+      `);
+    });
+
+    // A bank of its own, so nothing here touches identities in use. Created
+    // straight through the model rather than through the aggregate: it is a
+    // throwaway fixture and deliberately has no event stream, so this is not a
+    // pattern to copy into a test that cares about locker-bank behaviour.
+    const setup = artisan(`
+      $bank = \\App\\Models\\LockerBank::create(['name' => '${marker}']);
+      $u = new \\App\\Models\\MqttUser();
+      $u->username = '${marker}';
+      $u->password_hash = \\Illuminate\\Support\\Facades\\Hash::make('${password}');
+      $u->locker_bank_id = $bank->id;
+      $u->enabled = true;
+      $u->save();
+      echo $bank->id;
+    `);
+    const lockerUuid = setup.trim().split('\n').pop()?.trim() ?? '';
+    assert.match(lockerUuid, /^[0-9a-f-]{36}$/, 'setup should return the locker bank uuid');
+
+    const client = mqtt.connect(brokerUrl, {
+      username: marker,
+      password,
+      clientId: `${marker}-client`,
+      clean: true,
+      reconnectPeriod: 0, // this exact session is the subject of the test
+      protocolVersion: 5, // v5 reports authorisation failures as reason codes
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once('connect', () => resolve());
+        client.once('error', reject);
+      });
+
+      const topic = `locker/${lockerUuid}/event`;
+      assert.equal(await publishAccepted(client, topic), true, 'a live identity may publish');
+
+      // Exactly what a re-provisioning does: retire the bank's identities, then
+      // issue a fresh opaque one. The session under test stays connected.
+      artisan(`
+        \\App\\Models\\MqttUser::where('locker_bank_id', '${lockerUuid}')
+          ->where('enabled', true)
+          ->update(['enabled' => false, 'revoked_at' => now()]);
+        $n = new \\App\\Models\\MqttUser();
+        $n->username = \\Illuminate\\Support\\Str::random(32);
+        $n->password_hash = \\Illuminate\\Support\\Facades\\Hash::make('${password}');
+        $n->locker_bank_id = '${lockerUuid}';
+        $n->enabled = true;
+        $n->save();
+      `);
+
+      assert.equal(
+        await publishAccepted(client, topic),
+        false,
+        'a revoked identity must be denied on the session it is already holding',
+      );
+    } finally {
+      client.end(true);
+    }
+  },
+);

--- a/locker-client/tests/unit/file-credential.store.test.ts
+++ b/locker-client/tests/unit/file-credential.store.test.ts
@@ -15,7 +15,11 @@ test(
     const file = createCredentialFile(t);
     const store = new FileCredentialStore(file);
 
-    store.saveCredentials({ username: 'locker-user', password: 'test-password' });
+    store.saveCredentials({
+      username: 'locker-user',
+      password: 'test-password',
+      lockerUuid: 'locker-uuid',
+    });
 
     assert.equal(fs.statSync(file).mode & 0o777, 0o600);
   },
@@ -33,7 +37,11 @@ test(
 
     const credentials = new FileCredentialStore(file).getCredentials();
 
-    assert.deepEqual(credentials, { username: 'locker-user', password: 'test-password' });
+    assert.deepEqual(credentials, {
+      username: 'locker-user',
+      password: 'test-password',
+      lockerUuid: 'locker-user',
+    });
     assert.equal(fs.statSync(file).mode & 0o777, 0o600);
   },
 );
@@ -58,3 +66,42 @@ function createCredentialFile(t: TestContext): string {
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
   return path.join(directory, 'credentials.json');
 }
+
+test('a credentials file written before per-provisioning identities still loads', (t) => {
+  // Back then the username was the locker uuid, so an absent lockerUuid means
+  // "the username is the uuid" — an existing install must not need rewriting.
+  const file = createCredentialFile(t);
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      username: '019e5a20-8a02-718d-9146-a8a656edabbd',
+      password: 'test-password',
+    }),
+    { mode: 0o600 },
+  );
+
+  const credentials = new FileCredentialStore(file).getCredentials();
+
+  assert.deepEqual(credentials, {
+    username: '019e5a20-8a02-718d-9146-a8a656edabbd',
+    password: 'test-password',
+    lockerUuid: '019e5a20-8a02-718d-9146-a8a656edabbd',
+  });
+});
+
+test('an opaque username and its locker uuid round-trip separately', (t) => {
+  const file = createCredentialFile(t);
+  const store = new FileCredentialStore(file);
+
+  store.saveCredentials({
+    username: 'hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb',
+    password: 'test-password',
+    lockerUuid: '019e5a20-8a02-718d-9146-a8a656edabbd',
+  });
+
+  const credentials = new FileCredentialStore(file).getCredentials();
+
+  assert.equal(credentials?.username, 'hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb');
+  assert.equal(credentials?.lockerUuid, '019e5a20-8a02-718d-9146-a8a656edabbd');
+  assert.notEqual(credentials?.username, credentials?.lockerUuid);
+});

--- a/locker-client/tests/unit/provision-device.test.ts
+++ b/locker-client/tests/unit/provision-device.test.ts
@@ -9,7 +9,7 @@ import {
   parseProvisioningResponse,
 } from '../../src/domain/mqtt-parsing';
 import { PersistentStateCorruptedError } from '../../src/infrastructure/file-persistence';
-import type { CredentialStorePort } from '../../src/ports/config.port';
+import type { CredentialStorePort, DeviceCredentials } from '../../src/ports/config.port';
 import type { MessageTransportPort, MqttTransportSettings } from '../../src/ports/mqtt.port';
 import { assertMatchesSchema, readAsyncApiExample } from '../contract/jsonSchema';
 
@@ -55,13 +55,13 @@ class FakeMessageTransport implements MessageTransportPort {
 }
 
 class FakeCredentialStore implements CredentialStorePort {
-  savedCredentials: { username: string; password: string } | null = null;
+  savedCredentials: DeviceCredentials | null = null;
 
   getCredentials() {
     return this.savedCredentials;
   }
 
-  saveCredentials(credentials: { username: string; password: string }): void {
+  saveCredentials(credentials: DeviceCredentials): void {
     this.savedCredentials = credentials;
   }
 
@@ -120,8 +120,10 @@ test('parseProvisioningResponse accepts AsyncAPI success example', () => {
     assert.fail('Expected provisioning success response');
   }
 
-  assert.equal(response.data.mqtt_user, '11111111-1111-1111-1111-111111111111');
+  assert.equal(response.data.mqtt_user, 'hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb');
   assert.equal(response.data.mqtt_password, 'super-secret-password');
+  // The username is opaque; the locker namespace travels as its own field.
+  assert.equal(response.data.locker_uuid, '11111111-1111-1111-1111-111111111111');
 });
 
 test('parseProvisioningResponse accepts AsyncAPI error example', () => {
@@ -156,7 +158,7 @@ test('parseProvisioningResponse rejects malformed replies', () => {
   );
 });
 
-test('provisionDevice saves credentials from contract-shaped success reply', async () => {
+test('provisionDevice saves credentials from a pre-locker_uuid backend reply', async () => {
   const previousUsername = process.env.MQTT_DEFAULT_USERNAME;
   const previousPassword = process.env.MQTT_DEFAULT_PASSWORD;
   process.env.MQTT_DEFAULT_USERNAME = 'default-user';
@@ -204,6 +206,9 @@ test('provisionDevice saves credentials from contract-shaped success reply', asy
     assert.deepEqual(credentialStore.savedCredentials, {
       username: 'mqtt-user',
       password: 'mqtt-password',
+      // No locker_uuid in this reply, so it falls back to the username — which is
+      // what a backend from before per-provisioning identities sends.
+      lockerUuid: 'mqtt-user',
     });
     assert.equal(credentialStore.isProvisioned(), true);
   } finally {
@@ -268,3 +273,55 @@ function createClientIdFile(t: TestContext): string {
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
   return path.join(directory, '.mqtt-client-id');
 }
+
+test('provisionDevice keeps an opaque username and its locker uuid apart', async () => {
+  const previousUsername = process.env.MQTT_DEFAULT_USERNAME;
+  const previousPassword = process.env.MQTT_DEFAULT_PASSWORD;
+  process.env.MQTT_DEFAULT_USERNAME = 'default-user';
+  process.env.MQTT_DEFAULT_PASSWORD = 'default-password';
+
+  const transport = new FakeMessageTransport();
+  const credentialStore = new FakeCredentialStore();
+
+  try {
+    const provisionPromise = provisionDevice({
+      transport,
+      brokerUrl: 'mqtt://localhost',
+      clientId: 'prov-client-2',
+      provisioningToken: 'token-2',
+      credentialStore,
+    });
+
+    setImmediate(() => {
+      transport.emitMessage('locker/provisioning/reply/prov-client-2', {
+        message_id: 'reply-2',
+        status: 'success',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        data: {
+          mqtt_user: 'hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb',
+          mqtt_password: 'mqtt-password',
+          locker_uuid: '019e5a20-8a02-718d-9146-a8a656edabbd',
+        },
+      });
+    });
+
+    await assert.doesNotReject(provisionPromise);
+
+    assert.deepEqual(credentialStore.savedCredentials, {
+      username: 'hzv2uqMeZ0iMThq2ZCqM5uefe9OqoWtb',
+      password: 'mqtt-password',
+      lockerUuid: '019e5a20-8a02-718d-9146-a8a656edabbd',
+    });
+  } finally {
+    if (previousUsername === undefined) {
+      delete process.env.MQTT_DEFAULT_USERNAME;
+    } else {
+      process.env.MQTT_DEFAULT_USERNAME = previousUsername;
+    }
+    if (previousPassword === undefined) {
+      delete process.env.MQTT_DEFAULT_PASSWORD;
+    } else {
+      process.env.MQTT_DEFAULT_PASSWORD = previousPassword;
+    }
+  }
+});


### PR DESCRIPTION
Closes the credential-lifecycle hole in #161. Decisions and alternatives: [ADR-0050](docs/adr/0050-per-provisioning-mqtt-credential-identities.md).

## The problem

A bank's MQTT username was its own uuid, and provisioning recreated it. Deleting the row revoked access, but recreating the *same username* for the next generation let a still-connected session pass ACL checks again without ever re-authenticating. Fixing that by evicting the session would have meant maintaining a Mosquitto plugin for client eviction.

## What changes

- **Opaque usernames.** Each provisioning mints 32 random characters. A retired username is never issued again, so there is no moment at which an old session becomes authorised — no broker kick needed.
- **Authorisation maps, it does not parse.** The ACL device branch resolves `mqtt_users.locker_bank_id` and matches topics against that uuid via a new `%l` placeholder, compared literally like `%u` so it cannot be injected as a pattern. `%u` is gone from the device patterns.
- **Retire, never delete.** Revocation sets `enabled = false` and stamps `revoked_at`; the unique index on `username` is what keeps the identity unusable. `deleteUser()` is removed.
- **Revoke before every insert**, inside the locked transaction — not only at reset. This reactor is queued and rethrows to retry, so without it a retry would leave a second live identity for the same generation.
- **`locker_uuid` in the provisioning reply.** The client stores it beside the username and builds every topic from it — command, state, event, heartbeat, response and Last Will — authenticating with the username alone.

## Migration

Legacy identities need no special case: their row already maps to its bank, so the same lookup authorises them until that bank is next reset. Credential files from an older client read `lockerUuid` as defaulting to `username`, which is what it was. Existing deployments need no action.

## Deployment ordering

**No bank may be re-provisioned until the updated client image is on the devices** — a legacy client would use an opaque username as its topic namespace. Backend and Pi images roll out separately, so this is a release-note gate, not something the code enforces.

**Restart the queue workers when deploying.** Issuance runs in a queued reactor; workers already running keep executing the old code and quietly keep minting uuid usernames. Provisioning still succeeds, which is what makes it easy to miss — it happened once while testing this.

## Verification

- Backend 393 tests, Pint, PHPStan clean; client 295 tests, format and lint clean.
- Broker image pinned to `2.1.0-mosquitto_2.0.15` — the build already running, so pinning changes only what a later pull may hand back.
- The premise is asserted, not assumed: with `auth_opt_cache false`, a connected session's publishes are refused on the next operation after its identity is disabled, with a new identity already issued. `locker-client/tests/integration/broker-revocation.test.ts` covers that sequence; it needs the stack, so it is opt-in behind `OPEN_LOCKER_BROKER_TEST=1` and skipped otherwise.
- Exercised end to end locally: a real reset and re-provisioning of a simulated bank issued an opaque identity, retired the previous one with `revoked_at`, stored username and locker uuid separately on the client, and the bank came back online.
- Reuse prevention is mutation-checked: restoring the old `firstOrNew` upsert makes `MqttUserServiceTest` fail.

## Not covered here

`mqtt_users` has no Filament surface, so retired identities accumulate invisibly and an operator cannot see which identity is live. Out of scope for #161, but worth a follow-up.