### PR TITLE
fix(locker-client): recover the Modbus bus after a prolonged outage (#172)

### DIFF
--- a/docs/adr/0006-best-effort-startup-failsafe-for-unreachable-modbus-boards.md
+++ b/docs/adr/0006-best-effort-startup-failsafe-for-unreachable-modbus-boards.md
@@ -79,6 +79,15 @@ could continue.
   reset until connectivity is restored
 - polling is less noisy during startup because it begins on a reachable board
 
+## Supersedes / Superseded By
+
+- Superseded in part by
+  [ADR-0051](0051-modbus-reconnect-declares-an-unreachable-bus.md): the rule below
+  that startup fails when every configured board fails the failsafe no longer
+  applies when the Modbus bus itself is unreachable, which is recoverable and is
+  handled by reconnect instead. It still applies when the bus is reachable and the
+  boards are silent. Everything else here stands.
+
 ## References
 
 - `docs/adr/0004-waveshare-hardware-flash-and-supported-boards.md`

--- a/docs/adr/0051-modbus-reconnect-declares-an-unreachable-bus.md
+++ b/docs/adr/0051-modbus-reconnect-declares-an-unreachable-bus.md
@@ -1,0 +1,288 @@
+# ADR-0051: Modbus reconnect declares an unreachable bus and keeps recovering
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-22
+
+## Context
+
+`ReconnectCoordinator` allows five attempts, and `attempts` is reset only by a
+successful connect. After five consecutive failures — roughly twenty-five seconds
+with a USB adapter unplugged — the counter stays at five, and every later attempt
+short-circuits on `attempts >= maxAttempts` and throws immediately. Nothing ever
+lowers it again.
+
+So a Pi that loses its adapter for half a minute stays unable to reach its
+hardware until the container is restarted, however long the adapter has been back.
+Restarting is the only recovery, and nobody is standing next to the locker.
+
+Three smaller faults sit alongside it:
+
+- **Startup gets one attempt.** `connect()` calls `connectInternal()` directly
+  rather than through the coordinator, so a port that is not ready at boot is
+  never retried, while the same failure a minute later is.
+- **Reconnectable errors are recognised by message text.**
+  `isReconnectableModbusError()` falls back to `message.includes('Port Not Open')`
+  or `'ECONNREFUSED'`. An unplugged adapter surfaces as `ENOENT`, `EIO` or
+  `ENXIO`, none of which match, so the most recoverable failure of all is
+  classified as permanent and no reconnect is attempted. #173 removed the
+  mirror-image fault — a substring that matched too much — from the same layer.
+- **The state machine cannot express "dead".** `ConnectionState` is
+  `disconnected | connecting | connected`, and `connectInternal()` sets
+  `connecting` before dialling. When the attempt fails the state stays
+  `connecting`, so a permanently unreachable bus is indistinguishable from one
+  that is mid-attempt.
+
+What already works is the reporting path: the heartbeat carries
+`modbus_connected` (`state === 'connected'`), the backend stores it, and the admin
+panel renders a "Hardware" badge of reachable / unreachable / unknown. An operator
+can already see a dead bus. It is the client's own notion of its state, and its
+ability to recover, that are wrong.
+
+ADR-0014 faced the same question for the MQTT link and chose unlimited automatic
+reconnects, with a finite cap available as "an optional safety cap for lab use".
+The two transports in the same process currently disagree about whether
+permanent surrender is acceptable on hardware in the field.
+
+## Decision
+
+**1. The attempt budget is per outage, not per process.**
+
+A budget that cannot be replenished is a latch, and nothing in the system is
+meant to latch. Attempts reset on a successful connect, as now, and additionally
+once a cooldown has passed since the last failed cycle. A new cycle then starts on
+the next operation that needs the bus.
+
+The cooldown defaults to **60 seconds** and is exposed as
+`modbus.reconnectCooldownSeconds` in `locker-config.yml`, validated through
+`requireBoundedSetting` between 5 and 3600 — the same bounds and default as
+`mqtt.keepaliveSeconds`, which is the closest existing analogue. Sixty seconds is a
+compromise, not a measurement: long enough that a dead adapter is not dialled
+continuously, short enough that a blip costs one poll interval.
+
+The periodic compartment poll already drives bus traffic, so recovery needs no
+timer of its own: the next poll after the cooldown starts a fresh cycle, and a
+bus that has come back is used again without anyone intervening.
+
+**2. Exhausting a cycle declares the bus unreachable, out loud.**
+
+`ConnectionState` gains `unreachable`. It is set when a cycle is spent, and it
+means "we tried, we failed, and we have stopped trying *for now*" — as opposed to
+`connecting`, which claims an attempt is in progress.
+
+Nothing changes on the wire. `modbus_connected` is one boolean derived from
+`state === 'connected'`, and it is already `false` while a dial is in progress, so
+the admin panel shows the same "unreachable" badge before and after this change.
+The new state is for the client's own correctness: it is what lets a spent cycle be
+distinguished from an attempt in flight, in the logs and in the code that decides
+whether to start another cycle.
+
+The actor owns the state and the coordinator owns the budget, so the transition is
+made in **both** failure paths: `ensureConnected()`'s catch, and
+`runWithReconnectRetry()`'s. The second is the one that matters — `ensureConnected()`
+is reached only from the command path, while the compartment poll reaches the bus
+through `readDoorSensors()`. Wiring only the first would leave a bus that dies
+between commands never reporting `unreachable` at all, and would undercut decision
+1, whose recovery trigger is that same poll.
+
+**3. Recovery is automatic and silent about its attempts.**
+
+Entering `unreachable` is logged at error once per cycle, not per attempt. A bus
+that is down for an hour must not produce an hour of identical error lines — that
+is how real failures get missed. Individual retry attempts stay at warn, as now.
+
+**4. Startup retries within one bounded cycle.**
+
+`connect()` goes through the coordinator, so a port that is not ready at boot gets
+the same cycle of attempts as any later drop. It gets exactly one cycle: when that
+is spent, startup continues with the bus marked `unreachable` rather than blocking.
+
+`reloadRuntimeConfig()` dials the same way when the driver is closed, and is
+included for the same reason: a config reload arriving while the adapter is briefly
+away should not be the one path that still gets a single attempt.
+
+ADR-0006 already decided that unreachable boards must not prevent the client from
+starting; retrying forever at boot would quietly reverse that.
+
+This narrows ADR-0006 in one place. That ADR fails startup when every configured
+board fails the failsafe, and `runStartupFailsafe` throws accordingly. That stays
+right when the bus is reachable and the boards are silent — a wiring or
+configuration fault, which a human must fix and which should be loud. It is wrong
+when the bus itself is unreachable: that is recoverable, and it is what this ADR
+exists for. The failsafe therefore skips its sweep and logs once when the bus is
+`unreachable`, instead of throwing.
+
+Today that throw reaches `main().catch(process.exit(1))`, so a missing adapter at
+boot restarts the process. That is a restart loop rather than a permanent latch —
+it does recover when the adapter returns — but it churns the MQTT session, flaps
+the bank in the admin panel, and fills the log with the same failure.
+
+**5. Reconnectable failures are recognised by error code.**
+
+Classification uses the codes the serial layer actually reports — `ENOENT`,
+`ENXIO`, `EIO`, `EBADF`, `ECONNREFUSED` — read from the error and from a nested
+`cause`, since a code that cannot be reached classifies as unknown. `Port Not Open`
+stays a message match: it is the library's own wording and carries no code.
+
+`EACCES` is deliberately absent. A device the container user may not open — a
+missing `dialout` group — produces it every time, so treating it as recoverable
+would cycle against it indefinitely. That is precisely the loop this decision
+warns about, and a permissions fault is better left loud than quietly retried.
+
+There is no catch-all. An unrecognised error stays non-reconnectable: dialling
+again in response to a fault we do not understand is how a wedged bus turns into a
+loop.
+
+## Rationale
+
+The failure this ADR fixes is not that reconnect gave up. It is that giving up was
+permanent while the cause was temporary. Separating the two — a bounded cycle that
+declares failure, and an unbounded willingness to try again later — keeps the
+useful half of each behaviour.
+
+The declaration is a state rather than a log line because the code needs it, not
+because the wire does: whether to begin another cycle is a decision, and deriving
+it from log output is not an option. What the operator sees is unchanged, and
+deliberately so — `modbus_connected` already says "not reachable", and the reason
+it is not reachable has no consumer yet.
+
+Classifying by code rather than by message follows the same reasoning as #173,
+where a substring match reported unrelated faults as broken hardware: a message is
+written for a human and can be reworded by a dependency without notice, while a
+code is part of the interface.
+
+## Alternatives Considered
+
+### Alternative A: Retry forever, as the MQTT link does
+
+- Pros: matches ADR-0014; simplest possible policy; a bus that returns is always
+  picked up.
+- Cons: never declares failure, so "unreachable" would have to be inferred from a
+  log; a genuinely dead adapter looks the same as a slow one, permanently.
+- Why not chosen: the issue asks for recoverable cycles, not unlimited ones, and
+  the operator-facing badge is worth more than the small simplification.
+
+### Alternative B: Keep the permanent budget and restart the process on exhaustion
+
+- Pros: no coordinator change; the autoheal sidecar already restarts unhealthy
+  containers (ADR-0028).
+- Cons: turns a recoverable hardware blip into a full client restart, dropping the
+  MQTT session and re-running startup; and it treats a peripheral fault as a
+  process fault.
+- Why not chosen: the client is healthy — its adapter is not.
+
+### Alternative C: Publish a dedicated "bus unreachable" event
+
+- Pros: explicit, and carries a reason string.
+- Cons: new contract surface for something `modbus_connected` already conveys, and
+  a second source of truth for the same condition.
+- Why not chosen: the heartbeat already says it, and the admin already renders it.
+
+### Alternative D: Keep classifying by message text, add the missing strings
+
+- Pros: smallest possible change.
+- Cons: the list is unbounded and silently version-dependent; the same approach
+  produced the fault #173 removed.
+- Why not chosen: codes are the stable half of the interface.
+
+### Alternative E: Extend the heartbeat with a bus state or reason
+
+Keep `modbus_connected` and add a nullable field saying *why* — attempting,
+unreachable, never configured.
+
+- Pros: an operator could tell "trying" from "given up" without reading logs, which
+  is the one thing the badge cannot express.
+- Cons: a contract change plus backend and admin work, to answer a question nobody
+  has asked yet; and the client would need a reason vocabulary it does not have.
+- Why not chosen: the badge already distinguishes reachable from not, which is what
+  an operator acts on. Worth revisiting the first time someone asks why a bank has
+  been unreachable for an hour — the state added here is what such a field would be
+  derived from.
+
+## Consequences
+
+### Positive
+
+- A bus that returns after any outage is used again, with no restart and no
+  intervention.
+- A dead bus is stated rather than implied, and reaches the admin panel through a
+  path that already exists.
+- Boot no longer depends on the adapter being ready at exactly the right moment.
+- An unplugged adapter is finally classified as recoverable, which is what makes
+  the rest of this work at all.
+
+### Negative
+
+- One more `ConnectionState` value for callers to consider; `unreachable` is not
+  `connected`, so anything testing for equality is unaffected, but anything
+  enumerating states must handle it.
+- A bus that is genuinely dead retries quietly forever at cooldown intervals. That
+  is the cost of never latching; the state and the once-per-cycle error line are
+  what keep it visible.
+
+### Risks
+
+- **Cooldown too short** turns recovery into a slow retry loop against dead
+  hardware; too long delays recovery after a brief blip. Hence the bounded config
+  key: a deployment that finds 60 seconds wrong can change it without a new image.
+- **Startup semantics** are the fragile part: a bounded cycle at boot preserves
+  ADR-0006, but making that cycle long enough to be useful lengthens startup for
+  a device whose adapter is missing.
+- **Error codes are assumed, not observed.** The chosen list reflects what the
+  serial layer is documented to report for a removed device; it has not been
+  confirmed against a real adapter being unplugged. That confirmation belongs to
+  the Raspberry Pi soak test (#169), and until it runs, a code we guessed wrong
+  means no reconnect for that failure.
+
+## Rollout / Migration
+
+1. Add `unreachable` to `ConnectionState`; set it when a cycle is spent. The union
+   is implemented by the simulator's `InMemoryLockerBus` as well, so this is a
+   typed change across every bus implementation rather than one file.
+2. Reset attempts after `modbus.reconnectCooldownSeconds` (default 60, bounds
+   5–3600, validated like `mqtt.keepaliveSeconds`), so a spent budget cannot
+   outlive its outage; start a new cycle from the next operation needing the bus.
+3. Route both direct dial sites through the coordinator — `connect()` and
+   `reloadRuntimeConfig()` — bounded to one cycle at startup.
+4. Make `runStartupFailsafe` skip its sweep and log once when the bus is
+   `unreachable`, keeping the zero-success throw for a reachable bus.
+5. Classify by error code, reading a nested `cause` too, and extend
+   `isModbusLibraryError` with the same codes so an unplugged adapter is reported
+   as `MODBUS_ERROR` rather than `UNKNOWN_ERROR`.
+6. Cover with a fake driver: a long outage recovers and the state returns to
+   `connected`, a spent cycle reports `unreachable` from the poll path as well as
+   the command path, an unreachable bus does not fail startup while a reachable bus
+   with silent boards still does, a reload against a closed port retries rather
+   than failing on the first attempt, each classified code reconnects while an
+   unknown one does not, and the cooldown setting is rejected at load outside its
+   bounds.
+
+No configuration changes are *required*: `modbus.reconnectCooldownSeconds` is
+optional and existing deployments inherit the default on their next image.
+
+## Supersedes / Superseded By
+
+- Partially supersedes:
+  [ADR-0006](0006-best-effort-startup-failsafe-for-unreachable-modbus-boards.md) —
+  its rule that startup fails when every board fails the failsafe no longer applies
+  when the bus itself is unreachable. The rest of ADR-0006 stands.
+- Related:
+  [ADR-0014](0014-locker-client-mqtt-session-and-reconnect.md) (the same question
+  for the MQTT link), [ADR-0028](0028-mqtt-listener-liveness-healthcheck.md)
+  (the autoheal sidecar that restarts unhealthy containers).
+
+Worth knowing when reading this: the MQTT session defaults to `clean: false`, so a
+client that recovers from a long outage receives the commands queued during it,
+with no age check. Whether those should be refused is #134, and this ADR makes the
+situation more common by making long outages survivable.
+
+## References
+
+- Related issues: #172, #169 (hardware confirmation), #134 (stale command age)
+- Code: `src/adapters/modbus/reconnect-coordinator.ts`,
+  `src/adapters/modbus/waveshare-modbus-bus-actor.ts`,
+  `src/domain/errors.ts`, `src/ports/locker-bus.port.ts`

--- a/locker-client/src/adapters/config/yaml-config.repository.ts
+++ b/locker-client/src/adapters/config/yaml-config.repository.ts
@@ -146,6 +146,12 @@ export class YamlConfigRepository implements ConfigRepositoryPort {
     // rather than failing loudly.
     requireBoundedSetting(base.modbus.baudRate, 'modbus.baudRate', 1_200, 921_600);
     requireBoundedSetting(base.modbus.timeout, 'modbus.timeout', 50, 60_000);
+    requireBoundedSetting(
+      base.modbus.reconnectCooldownSeconds,
+      'modbus.reconnectCooldownSeconds',
+      5,
+      3600,
+    );
     requireEnumSetting(base.modbus.dataBits, 'modbus.dataBits', [7, 8]);
     requireEnumSetting(base.modbus.stopBits, 'modbus.stopBits', [1, 2]);
     requireEnumSetting(base.modbus.parity, 'modbus.parity', ['none', 'even', 'odd']);

--- a/locker-client/src/adapters/modbus/reconnect-coordinator.ts
+++ b/locker-client/src/adapters/modbus/reconnect-coordinator.ts
@@ -1,19 +1,45 @@
 import { noopLogger, type LoggerPort } from '../../ports/logging.port';
 import { ModbusTransportError } from '../../domain/errors';
 
+/**
+ * Elapsed time, not wall-clock time. A Raspberry Pi has no RTC: it boots with a
+ * bogus clock and jumps when NTP first syncs, sometimes backwards. Measuring the
+ * cooldown with `Date.now()` would make that difference negative and refuse to
+ * recover until wall-clock time caught up — the latch this coordinator exists to
+ * remove, through the back door, and most likely at boot, which is exactly when an
+ * adapter is most likely to be missing.
+ */
+function monotonicNow(): number {
+  return performance.now();
+}
+
+/** How long a spent reconnect cycle waits before another one may start. */
+export const DEFAULT_MODBUS_RECONNECT_COOLDOWN_MS = 60_000;
+
 export class ReconnectCoordinator {
   private inFlight: Promise<void> | null = null;
   private attempts = 0;
   private timers: ReturnType<typeof setTimeout>[] = [];
+  private cycleSpentAt: number | null = null;
   private readonly maxAttempts: number;
   private readonly delayMs: number;
+  private readonly cooldownMs: number;
 
   constructor(
-    options: { maxAttempts?: number; delayMs?: number } = {},
+    options: { maxAttempts?: number; delayMs?: number; cooldownMs?: number } = {},
     private readonly log: LoggerPort = noopLogger,
   ) {
     this.maxAttempts = options.maxAttempts ?? 0;
     this.delayMs = options.delayMs ?? 5000;
+    this.cooldownMs = options.cooldownMs ?? DEFAULT_MODBUS_RECONNECT_COOLDOWN_MS;
+  }
+
+  /**
+   * True once a cycle has been spent and nothing has succeeded since. The caller
+   * owns the connection state, so it asks rather than being told.
+   */
+  isCycleSpent(): boolean {
+    return this.cycleSpentAt !== null;
   }
 
   getAttempts(): number {
@@ -34,6 +60,7 @@ export class ReconnectCoordinator {
 
   resetAttempts(): void {
     this.attempts = 0;
+    this.cycleSpentAt = null;
   }
 
   cancelScheduled(): void {
@@ -45,11 +72,19 @@ export class ReconnectCoordinator {
 
   private async runInternal(reconnectFn: () => Promise<void>): Promise<void> {
     if (this.maxAttempts > 0 && this.attempts >= this.maxAttempts) {
-      this.log.error('Modbus reconnect budget already exhausted, refusing further attempts', {
-        attempts: this.attempts,
-        maxAttempts: this.maxAttempts,
-      });
-      throw new ModbusTransportError('Max reconnect attempts reached');
+      // A budget that cannot be replenished is a latch: the bus would stay
+      // unusable long after the outage that spent it had ended. The cooldown is
+      // what makes the budget belong to the outage rather than to the process.
+      if (this.cycleSpentAt !== null && monotonicNow() - this.cycleSpentAt >= this.cooldownMs) {
+        this.log.warn('Modbus reconnect cooldown elapsed, starting a new cycle', {
+          previousAttempts: this.attempts,
+          cooldownMs: this.cooldownMs,
+        });
+        this.attempts = 0;
+        this.cycleSpentAt = null;
+      } else {
+        throw new ModbusTransportError('Max reconnect attempts reached');
+      }
     }
 
     this.attempts++;
@@ -57,6 +92,7 @@ export class ReconnectCoordinator {
     try {
       await reconnectFn();
       this.attempts = 0;
+      this.cycleSpentAt = null;
     } catch (error) {
       if (this.maxAttempts === 0 || this.attempts < this.maxAttempts) {
         this.log.warn('Modbus reconnect attempt failed, retrying', {
@@ -68,9 +104,14 @@ export class ReconnectCoordinator {
         return this.scheduleRetry(reconnectFn);
       }
 
+      // Logged once here, where the cycle ends, rather than on every refusal that
+      // follows: a bus down for an hour must not produce an hour of identical
+      // error lines, or the one that matters is never noticed.
+      this.cycleSpentAt = monotonicNow();
       this.log.error('Modbus reconnect gave up after final attempt', {
         attempts: this.attempts,
         maxAttempts: this.maxAttempts,
+        retryAfterMs: this.cooldownMs,
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;

--- a/locker-client/src/adapters/modbus/waveshare-modbus-bus-actor.ts
+++ b/locker-client/src/adapters/modbus/waveshare-modbus-bus-actor.ts
@@ -34,7 +34,7 @@ export class WaveshareModbusBusActor implements LockerBusPort {
 
   constructor(
     private readonly driver: WaveshareModbusDriver,
-    reconnectOptions?: { maxAttempts?: number; delayMs?: number },
+    reconnectOptions?: { maxAttempts?: number; delayMs?: number; cooldownMs?: number },
     /**
      * Accepts a getter so the boards are read when asked for, not captured once.
      * A runtime `apply_config` can add or remove a board, and a snapshot taken
@@ -48,13 +48,22 @@ export class WaveshareModbusBusActor implements LockerBusPort {
       {
         maxAttempts: reconnectOptions?.maxAttempts ?? DEFAULT_MODBUS_MAX_RECONNECT_ATTEMPTS,
         delayMs: reconnectOptions?.delayMs ?? 5000,
+        cooldownMs: reconnectOptions?.cooldownMs,
       },
       log,
     );
   }
 
+  /**
+   * Startup gets the same cycle of attempts as any later drop, and gives up
+   * quietly when it is spent: a device whose adapter is missing must still finish
+   * starting, so the fault surfaces as an unreachable bus rather than as a boot
+   * that never completes or a process that exits.
+   */
   async connect(): Promise<void> {
-    return this.run(() => this.connectInternal(), BusPriority.MAINTENANCE);
+    return this.run(async () => {
+      await this.dial();
+    }, BusPriority.MAINTENANCE);
   }
 
   async disconnect(): Promise<void> {
@@ -80,26 +89,16 @@ export class WaveshareModbusBusActor implements LockerBusPort {
         return true;
       }
 
-      try {
-        await this.reconnect.run(() => this.connectInternal());
-        return this.driver.isOpen();
-      } catch (error) {
-        // Callers only see false, so without this line an unreachable bus looks
-        // identical to a bus that is merely busy.
-        this.log.error('Modbus bus unreachable after reconnect attempts', {
-          attempts: this.reconnect.getAttempts(),
-          connectionState: this.connectionState,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return false;
-      }
+      return this.dial();
     }, BusPriority.MAINTENANCE);
   }
 
   async reloadRuntimeConfig(): Promise<void> {
     return this.run(async () => {
       if (!this.driver.isOpen()) {
-        await this.connectInternal();
+        // A reload arriving while the adapter is briefly away should not be the
+        // one path that still gets a single attempt.
+        await this.dial();
       }
     }, BusPriority.MAINTENANCE);
   }
@@ -186,6 +185,39 @@ export class WaveshareModbusBusActor implements LockerBusPort {
     return this.queue;
   }
 
+  /**
+   * Every dial goes through here, so a spent cycle is recorded in one place.
+   * Returns whether the bus ended up open; callers that only care about that see
+   * `false` rather than an exception.
+   */
+  private async dial(): Promise<boolean> {
+    try {
+      await this.reconnect.run(() => this.connectInternal());
+      return this.driver.isOpen();
+    } catch (error) {
+      this.markUnreachable(error);
+      return false;
+    }
+  }
+
+  /**
+   * A spent cycle is a statement, not a silence: without it the bus keeps
+   * reporting `connecting` — which claims an attempt is in flight — for as long as
+   * the adapter stays away.
+   */
+  private markUnreachable(error: unknown): void {
+    if (!this.reconnect.isCycleSpent()) {
+      return;
+    }
+
+    this.connectionState = 'unreachable';
+    this.log.error('Modbus bus unreachable after reconnect attempts', {
+      attempts: this.reconnect.getAttempts(),
+      connectionState: this.connectionState,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   private async connectInternal(): Promise<void> {
     this.connectionState = 'connecting';
     await this.driver.connect();
@@ -228,7 +260,16 @@ export class WaveshareModbusBusActor implements LockerBusPort {
 
       await this.driver.disconnect();
       this.connectionState = 'disconnected';
-      await this.reconnect.run(() => this.connectInternal());
+
+      // Reached by the compartment poll as well as by commands, so this is the
+      // path that notices a bus dying between commands at all.
+      try {
+        await this.reconnect.run(() => this.connectInternal());
+      } catch (reconnectError) {
+        this.markUnreachable(reconnectError);
+        throw reconnectError;
+      }
+
       return operation();
     }
   }

--- a/locker-client/src/application/open-compartment.ts
+++ b/locker-client/src/application/open-compartment.ts
@@ -227,8 +227,26 @@ export class OpenCompartmentUseCase {
   }
 }
 
-export async function runStartupFailsafe(bus: LockerBusPort): Promise<void> {
+export async function runStartupFailsafe(
+  bus: LockerBusPort,
+  log: LoggerPort = noopLogger,
+): Promise<void> {
   const slaveIds = bus.getConfiguredSlaveIds();
+
+  // Two failures look alike from here and are not alike at all. A reachable bus
+  // whose boards all stay silent is a wiring or configuration fault: a human has
+  // to fix it, and startup should say so loudly by refusing to come up. A bus that
+  // is itself unreachable is recoverable — reconnect keeps trying, and exiting
+  // would only restart the process until the adapter came back, churning the MQTT
+  // session and flapping the bank each time round.
+  if (bus.getConnectionState() === 'unreachable') {
+    log.error('Startup failsafe skipped: Modbus bus unreachable, relays left as found', {
+      configuredBoards: slaveIds.length,
+    });
+
+    return;
+  }
+
   let successCount = 0;
 
   for (const slaveId of slaveIds) {

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -109,7 +109,14 @@ export async function createApp(): Promise<AppContext> {
 
   const bus = new WaveshareModbusBusActor(
     driver,
-    { maxAttempts: DEFAULT_MODBUS_MAX_RECONNECT_ATTEMPTS, delayMs: 5000 },
+    {
+      maxAttempts: DEFAULT_MODBUS_MAX_RECONNECT_ATTEMPTS,
+      delayMs: 5000,
+      cooldownMs:
+        config.modbus.reconnectCooldownSeconds === undefined
+          ? undefined
+          : config.modbus.reconnectCooldownSeconds * 1000,
+    },
     () => configRepo.getConfiguredSlaveIds(),
     tracing,
     appLogger,
@@ -208,7 +215,7 @@ export async function createApp(): Promise<AppContext> {
   await transport.subscribe(commandTopic);
 
   await bus.connect();
-  await runStartupFailsafe(bus);
+  await runStartupFailsafe(bus, appLogger);
   heartbeat.start();
 
   const pollTimer = setInterval(() => {

--- a/locker-client/src/domain/config.ts
+++ b/locker-client/src/domain/config.ts
@@ -20,6 +20,12 @@ export interface ModbusConfig {
   stopBits?: 1 | 2;
   parity?: 'none' | 'even' | 'odd';
   timeout?: number;
+  /**
+   * How long a spent reconnect cycle waits before another is allowed. Bounds the
+   * retry rate against hardware that is genuinely gone, without letting a spent
+   * budget outlive the outage that spent it.
+   */
+  reconnectCooldownSeconds?: number;
 }
 
 /** Operator-managed settings loaded from locker-config.yml. */

--- a/locker-client/src/domain/errors.ts
+++ b/locker-client/src/domain/errors.ts
@@ -38,11 +38,48 @@ export class ModbusTransportError extends LockerError {
 }
 
 /**
+ * Serial faults the operating system reports by code. A removed adapter, a device
+ * node that no longer exists, a handle the kernel has invalidated: all of them
+ * mean the port went away and dialling again is the right response.
+ *
+ * Codes rather than wording, because a message is written for a human and a
+ * dependency may reword it without warning, while a code is part of the interface.
+ */
+const RECOVERABLE_SERIAL_CODES = new Set(['ENOENT', 'ENXIO', 'EIO', 'EBADF', 'ECONNREFUSED']);
+
+/**
+ * Reads `code` from the error and from a nested `cause`: serialport wraps in some
+ * paths, and a code we cannot reach classifies as unknown — which, with no
+ * catch-all, means no reconnect for the most recoverable failure there is.
+ */
+function serialErrorCode(error: unknown): string | null {
+  let current: unknown = error;
+
+  for (let depth = 0; depth < 5 && current !== null && typeof current === 'object'; depth++) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && code !== '') {
+      return code;
+    }
+
+    current = (current as { cause?: unknown }).cause ?? null;
+  }
+
+  return null;
+}
+
+function hasRecoverableSerialCode(error: unknown): boolean {
+  const code = serialErrorCode(error);
+
+  return code !== null && RECOVERABLE_SERIAL_CODES.has(code);
+}
+
+/**
  * Transport failures raised by `modbus-serial` itself.
  *
- * The library throws plain `Error`s, so its message text is the only signal
- * available. Matching it is fragile, which is why it is confined to this one
- * function: everything we raise ourselves carries an explicit code instead.
+ * A fault carrying a serial error code is one; for the rest the library throws
+ * plain `Error`s, so message text is the only signal available. Matching text is
+ * fragile, which is why it is confined to this one function: everything we raise
+ * ourselves carries an explicit code instead.
  *
  * The patterns name specific transport failures deliberately. A bare `modbus`
  * match caught nearly every hardware-adjacent message in this codebase,
@@ -55,6 +92,13 @@ export class ModbusTransportError extends LockerError {
 function isModbusLibraryError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
+  }
+
+  // A transport fault the device recovers from is still a transport fault: without
+  // this the backend would be told UNKNOWN_ERROR while the client reconnects
+  // correctly, which reads as a bug in us rather than a cable someone pulled.
+  if (hasRecoverableSerialCode(error)) {
+    return true;
   }
 
   const message = error.message.toLowerCase();
@@ -72,10 +116,16 @@ export function isReconnectableModbusError(error: unknown): boolean {
     return error.reconnectable;
   }
 
-  return (
-    error instanceof Error &&
-    (error.message.includes('Port Not Open') || error.message.includes('ECONNREFUSED'))
-  );
+  if (hasRecoverableSerialCode(error)) {
+    return true;
+  }
+
+  // The one message match left. `Port Not Open` is the library's own wording for a
+  // port it knows is closed, and it carries no code to match on. `EACCES` is
+  // deliberately not recoverable: a device the container user may not open — a
+  // missing `dialout` group — fails that way every time, and cycling against a
+  // fault only a human can fix is the loop this classification exists to avoid.
+  return error instanceof Error && error.message.includes('Port Not Open');
 }
 
 /**

--- a/locker-client/src/ports/locker-bus.port.ts
+++ b/locker-client/src/ports/locker-bus.port.ts
@@ -7,7 +7,15 @@ export enum BusPriority {
   MAINTENANCE = 1,
 }
 
-export type ConnectionState = 'disconnected' | 'connecting' | 'connected';
+/**
+ * `unreachable` means a reconnect cycle was spent without success: we tried, we
+ * failed, and we have stopped trying *for now*. It is distinct from `connecting`,
+ * which claims an attempt is in flight — a dead bus used to report that forever.
+ *
+ * Nothing on the wire changes: `modbus_connected` is derived from
+ * `state === 'connected'` and was already false in both cases.
+ */
+export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'unreachable';
 
 export interface LockerBusPort {
   connect(): Promise<void>;

--- a/locker-client/tests/application/open-compartment.test.ts
+++ b/locker-client/tests/application/open-compartment.test.ts
@@ -76,6 +76,29 @@ test('runStartupFailsafe skips boards when no runtime mapping exists', async () 
   assert.deepEqual(bus.turnAllOffCalls, []);
 });
 
+test('an unreachable bus does not fail startup', async () => {
+  // Exiting here would restart the process until the adapter came back, churning
+  // the MQTT session and flapping the bank each time round. Reconnect keeps
+  // trying instead, and the bus reports itself unreachable meanwhile.
+  const bus = new FakeLockerBus([1, 2]);
+  bus.unreachable = true;
+
+  await assert.doesNotReject(runStartupFailsafe(bus));
+
+  assert.deepEqual(bus.turnAllOffCalls, [], 'no point sweeping a bus we cannot reach');
+});
+
+test('a reachable bus whose boards all stay silent still fails startup', async () => {
+  // The other half of the distinction: the bus is fine, so silence means wiring or
+  // configuration — something only a human can fix, and startup should say so.
+  const bus = new FakeLockerBus([1, 2]);
+  bus.turnAllRelaysOff = async (): Promise<void> => {
+    throw new Error('board did not answer');
+  };
+
+  await assert.rejects(runStartupFailsafe(bus), /all Modbus boards unreachable/);
+});
+
 test('OpenCompartmentUseCase throws when runtime mapping is missing', async () => {
   const { useCase } = build({
     bus: new FakeLockerBus([]),

--- a/locker-client/tests/helpers/fake-locker-bus.ts
+++ b/locker-client/tests/helpers/fake-locker-bus.ts
@@ -30,7 +30,14 @@ export class FakeLockerBus implements LockerBusPort {
     this.connected = false;
   }
 
+  /** Set to mimic a bus whose reconnect cycle was spent. */
+  unreachable = false;
+
   getConnectionState() {
+    if (this.unreachable) {
+      return 'unreachable' as const;
+    }
+
     return this.connected ? ('connected' as const) : ('disconnected' as const);
   }
 

--- a/locker-client/tests/unit/error-mapping.test.ts
+++ b/locker-client/tests/unit/error-mapping.test.ts
@@ -52,8 +52,64 @@ test('only transport faults that reconnecting can clear are reconnectable', () =
     ),
     false,
   );
-  assert.equal(isReconnectableModbusError(new Error('connect ECONNREFUSED')), true);
+  // Real socket failures carry the code; the wording is incidental.
+  assert.equal(
+    isReconnectableModbusError(withCode(new Error('connect failed'), 'ECONNREFUSED')),
+    true,
+  );
   assert.equal(isReconnectableModbusError(new Error('something unrelated')), false);
+});
+
+/** Attaches a `code` the way the runtime does, so tests match real error shapes. */
+function withCode(error: Error, code: string, cause?: unknown): Error {
+  Object.assign(error, { code, ...(cause === undefined ? {} : { cause }) });
+
+  return error;
+}
+
+test('a serial port that went away is reconnectable, by code rather than wording', () => {
+  // What an unplugged USB adapter actually reports. None of these messages contain
+  // the strings the old classification looked for, so the most recoverable failure
+  // there is used to be treated as permanent.
+  for (const code of ['ENOENT', 'ENXIO', 'EIO', 'EBADF']) {
+    assert.equal(
+      isReconnectableModbusError(withCode(new Error('no such file or directory'), code)),
+      true,
+      `expected ${code} to be reconnectable`,
+    );
+  }
+});
+
+test('a permissions fault is not reconnectable', () => {
+  // EACCES means the container user may not open the device — a missing dialout
+  // group, say. It fails identically every time, so retrying only produces noise
+  // until a human changes something.
+  assert.equal(
+    isReconnectableModbusError(withCode(new Error('permission denied'), 'EACCES')),
+    false,
+  );
+});
+
+test('a code carried on a nested cause is still found', () => {
+  // serialport wraps in some paths, and a code we cannot reach classifies as
+  // unknown — which, with no catch-all, means no reconnect at all.
+  const wrapped = new Error('failed to open port');
+  Object.assign(wrapped, { cause: withCode(new Error('device not configured'), 'ENXIO') });
+
+  assert.equal(isReconnectableModbusError(wrapped), true);
+});
+
+test('a serial fault reports MODBUS_ERROR rather than unknown', () => {
+  // The device reconnects correctly; the backend must not be told the client hit
+  // something it could not identify.
+  assert.equal(
+    mapErrorToMqttCode(withCode(new Error('no such file or directory'), 'ENOENT')),
+    MqttErrorCode.MODBUS_ERROR,
+  );
+  assert.equal(
+    mapErrorToMqttCode(withCode(new Error('nope'), 'ESOMETHINGELSE')),
+    MqttErrorCode.UNKNOWN_ERROR,
+  );
 });
 
 test('a fault that merely mentions modbus is not reported as a hardware error', () => {

--- a/locker-client/tests/unit/reconnect-coordinator.test.ts
+++ b/locker-client/tests/unit/reconnect-coordinator.test.ts
@@ -60,3 +60,84 @@ test('ReconnectCoordinator deduplicates concurrent reconnect calls', async () =>
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+test('a spent budget does not outlive the outage that spent it', async () => {
+  // The bug this replaces: attempts reset only on a successful connect, so five
+  // failures left the bus unusable until the process restarted — however long the
+  // adapter had been back.
+  const coordinator = new ReconnectCoordinator({ maxAttempts: 2, delayMs: 1, cooldownMs: 20 });
+  let dialsBeforeRecovery = 0;
+
+  await assert.rejects(
+    coordinator.run(async () => {
+      dialsBeforeRecovery++;
+      throw new Error('adapter unplugged');
+    }),
+  );
+  assert.equal(dialsBeforeRecovery, 2, 'the cycle spends its budget');
+  assert.equal(coordinator.isCycleSpent(), true);
+
+  // Immediately afterwards the budget is still spent: this is the "declared dead"
+  // window, and it must not dial.
+  let dialedDuringCooldown = false;
+  await assert.rejects(
+    coordinator.run(async () => {
+      dialedDuringCooldown = true;
+    }),
+  );
+  assert.equal(dialedDuringCooldown, false, 'no dialling until the cooldown passes');
+
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  let recovered = false;
+  await coordinator.run(async () => {
+    recovered = true;
+  });
+
+  assert.equal(recovered, true, 'a new cycle starts once the cooldown has passed');
+  assert.equal(coordinator.isCycleSpent(), false);
+  assert.equal(coordinator.getAttempts(), 0);
+});
+
+test('giving up is logged once per cycle, not once per refusal', async () => {
+  // A bus down for an hour must not produce an hour of identical error lines, or
+  // the one that matters is never noticed.
+  const errors: string[] = [];
+  const warns: string[] = [];
+  const coordinator = new ReconnectCoordinator(
+    { maxAttempts: 2, delayMs: 1, cooldownMs: 10_000 },
+    {
+      warn: (message: string) => warns.push(message),
+      error: (message: string) => errors.push(message),
+    },
+  );
+
+  const fail = async (): Promise<void> => {
+    throw new Error('adapter unplugged');
+  };
+
+  await assert.rejects(coordinator.run(fail));
+  for (let i = 0; i < 5; i++) {
+    await assert.rejects(coordinator.run(fail));
+  }
+
+  assert.equal(errors.length, 1, 'one error for the cycle, not one per refusal');
+  assert.equal(warns.length, 1, 'the retry within the cycle still warns');
+});
+
+test('a successful connect clears the spent marker', async () => {
+  const coordinator = new ReconnectCoordinator({ maxAttempts: 1, delayMs: 1, cooldownMs: 5 });
+
+  await assert.rejects(
+    coordinator.run(async () => {
+      throw new Error('adapter unplugged');
+    }),
+  );
+  assert.equal(coordinator.isCycleSpent(), true);
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await coordinator.run(async () => {});
+
+  assert.equal(coordinator.isCycleSpent(), false);
+  assert.equal(coordinator.getAttempts(), 0);
+});

--- a/locker-client/tests/unit/waveshare-modbus-bus-actor.test.ts
+++ b/locker-client/tests/unit/waveshare-modbus-bus-actor.test.ts
@@ -402,3 +402,100 @@ test('configured slave ids are read live, so a runtime config change is visible'
     'a board added after construction must be visible to the bus',
   );
 });
+
+/** A driver whose port can be taken away and given back, like an adapter being unplugged. */
+class UnpluggableDriver extends FakeWaveshareModbusDriver {
+  present = true;
+  connectAttempts = 0;
+
+  /** The device node disappears, so the handle stops being usable too. */
+  unplug(): void {
+    this.present = false;
+    void super.disconnect();
+  }
+
+  async connect(): Promise<void> {
+    this.connectAttempts++;
+    if (!this.present) {
+      const error = new Error('no such file or directory');
+      Object.assign(error, { code: 'ENOENT' });
+      throw error;
+    }
+
+    await super.connect();
+  }
+
+  async readDiscreteInputs(slaveId: number, address: number, length: number): Promise<boolean[]> {
+    if (!this.present) {
+      const error = new Error('input/output error');
+      Object.assign(error, { code: 'EIO' });
+      throw error;
+    }
+
+    return super.readDiscreteInputs(slaveId, address, length);
+  }
+}
+
+test('a bus that dies between commands reports unreachable from the poll path', async () => {
+  // The compartment poll reaches the bus through readDoorSensors, not
+  // ensureConnected. Wiring only the command path would leave a bus that dies
+  // between commands never reporting unreachable at all.
+  const driver = new UnpluggableDriver();
+  const bus = new WaveshareModbusBusActor(
+    driver,
+    { maxAttempts: 2, delayMs: 1, cooldownMs: 20 },
+    [1],
+  );
+  await bus.connect();
+  assert.equal(bus.getConnectionState(), 'connected');
+
+  driver.unplug();
+  // Polling is best-effort and reports unknown rather than throwing, which is
+  // exactly why the state has to carry the verdict instead.
+  assert.deepEqual(await bus.readDoorSensors(1, 0, 1), ['unknown']);
+
+  assert.equal(bus.getConnectionState(), 'unreachable');
+});
+
+test('a bus that comes back is used again without a restart', async () => {
+  const driver = new UnpluggableDriver();
+  const bus = new WaveshareModbusBusActor(
+    driver,
+    { maxAttempts: 2, delayMs: 1, cooldownMs: 20 },
+    [1],
+  );
+  await bus.connect();
+
+  driver.unplug();
+  assert.equal(await bus.ensureConnected(), false);
+  assert.equal(bus.getConnectionState(), 'unreachable');
+
+  driver.present = true;
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  assert.equal(await bus.ensureConnected(), true, 'a new cycle starts after the cooldown');
+  assert.equal(bus.getConnectionState(), 'connected', 'and the state leaves unreachable');
+});
+
+test('a missing adapter at startup leaves the bus unreachable instead of failing', async () => {
+  // Startup must finish: the fault surfaces as an unreachable bus, not as a boot
+  // that never completes or a process that exits into a restart loop.
+  const driver = new UnpluggableDriver();
+  driver.present = false;
+  const bus = new WaveshareModbusBusActor(driver, { maxAttempts: 2, delayMs: 1 }, [1]);
+
+  await assert.doesNotReject(bus.connect());
+
+  assert.equal(bus.getConnectionState(), 'unreachable');
+  assert.equal(driver.connectAttempts, 2, 'startup gets one full cycle, not one attempt');
+});
+
+test('a config reload against a closed port retries rather than failing once', async () => {
+  const driver = new UnpluggableDriver();
+  driver.present = false;
+  const bus = new WaveshareModbusBusActor(driver, { maxAttempts: 3, delayMs: 1 }, [1]);
+
+  await assert.doesNotReject(bus.reloadRuntimeConfig());
+
+  assert.equal(driver.connectAttempts, 3, 'the reload path uses the coordinator too');
+});

--- a/locker-client/tests/unit/yaml-config.repository.test.ts
+++ b/locker-client/tests/unit/yaml-config.repository.test.ts
@@ -183,3 +183,20 @@ test('a fractional heartbeat is rejected, matching the inbound schema', () => {
     /heartbeatInterval must be a whole number/,
   );
 });
+
+test('a reconnect cooldown outside its bounds fails at load', () => {
+  // Too short turns recovery into a retry loop against dead hardware; too long
+  // delays recovery after a brief blip. Both are caught here rather than in the
+  // field.
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  reconnectCooldownSeconds: 1']);
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /reconnectCooldownSeconds must be between/,
+  );
+
+  writeConfig(['modbus:', '  port: /dev/ttyTEST', '  reconnectCooldownSeconds: 7200']);
+  assert.throws(
+    () => new YamlConfigRepository(new MemoryOverlayStore(), configFile).load(),
+    /reconnectCooldownSeconds must be between/,
+  );
+});


### PR DESCRIPTION
Closes the recovery hole in #172. Decisions and alternatives: [ADR-0051](docs/adr/0051-modbus-reconnect-declares-an-unreachable-bus.md), which **partially supersedes [ADR-0006](docs/adr/0006-best-effort-startup-failsafe-for-unreachable-modbus-boards.md)** for the unreachable-bus case.

## The problem

`ReconnectCoordinator` allowed five attempts and reset `attempts` only on a successful connect. Twenty-five seconds with the adapter unplugged left the counter spent, and every later attempt was refused immediately — a Pi that lost its adapter for half a minute stayed unable to reach its hardware until the container restarted, however long the adapter had been back.

Three faults sat alongside it: startup got a single attempt because `connect()` bypassed the coordinator; reconnectable errors were recognised by message text, so an unplugged adapter (`ENOENT`/`EIO`/`ENXIO`) was classified as permanent; and `ConnectionState` had no way to say "dead", leaving a spent bus reporting `connecting` forever.

## What changes

- **The budget belongs to the outage, not the process.** A spent cycle is retried once a cooldown passes, and the periodic compartment poll starts the new cycle — no timer of its own. Elapsed time is measured **monotonically**: a Pi has no RTC, and a backward jump at first NTP sync would have re-created the latch this removes.
- **A spent cycle declares `unreachable`,** in **both** failure paths — the command path via `ensureConnected()` and the poll path via `runWithReconnectRetry()`, which is the one that notices a bus dying between commands at all.
- **All three dial sites go through the coordinator** — `connect()`, `ensureConnected()`, `reloadRuntimeConfig()` — so startup and config reloads get a cycle rather than one attempt.
- **Startup survives a missing adapter.** `runStartupFailsafe` skips its sweep when the bus is unreachable, while still failing when the bus is reachable and every board stays silent — a wiring fault a human must fix. Previously that throw reached `main().catch(process.exit(1))`, restarting the process until the adapter returned.
- **Classification by error code**, read from the error and a nested `cause`: `ENOENT`, `ENXIO`, `EIO`, `EBADF`, `ECONNREFUSED`. `EACCES` is deliberately excluded — a missing `dialout` group fails that way every time, and cycling against it is the loop this exists to avoid. `isModbusLibraryError` gained the same codes, so an unplugged adapter reports `MODBUS_ERROR` rather than `UNKNOWN_ERROR`.
- **New setting** `modbus.reconnectCooldownSeconds` — default 60, bounds 5–3600, validated like `mqtt.keepaliveSeconds`. Optional; existing deployments inherit the default.

## Nothing changes on the wire

`modbus_connected` is derived from `state === 'connected'` and was already `false` while a dial was in progress, so the admin's Hardware badge reads the same before and after. `unreachable` is for the client's own correctness — distinguishing a spent cycle from an attempt in flight, in the logs and in the code that decides whether to start another.

## Worth knowing when reviewing

- `markUnreachable()` only fires when `isCycleSpent()`, which requires `maxAttempts > 0`. The actor always passes 5, so nothing today hits it — but a bare `ReconnectCoordinator` (default 0, unlimited) would never report `unreachable`. Latent assumption, not a bug.
- `readDoorSensors` swallows failures into `'unknown'` by design, so the poll path cannot signal a dead bus by throwing. That is precisely why the state carries the verdict.
- `createSimulatorApp.ts` calls the failsafe too, but `InMemoryLockerBus` never reports `unreachable`, so the behaviour change does not reach the simulator.

## Verification

309 tests pass, 2 skipped, 0 fail; format, lint and typecheck clean; the simulator runs unaffected. 14 tests added, including the poll-path case, the return-to-`connected` case, once-per-cycle log volume, and the failsafe split.

**ADR status stays `Proposed`.** The error-code list is what the serial layer is documented to report for a removed device — it has not been confirmed against a real adapter being unplugged. That belongs to #169's soak test, and a code guessed wrong means no reconnect for that failure.