### PR TITLE
fix(backend): make event-sourced writes atomic

### DIFF
--- a/docs/adr/0054-atomic-event-projection-and-after-commit-reactors.md
+++ b/docs/adr/0054-atomic-event-projection-and-after-commit-reactors.md
@@ -1,0 +1,137 @@
+# ADR-0054: Atomic event projection and after-commit reactors
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-23
+
+## Context
+
+ADR-0033 made all event-sourced projectors synchronous and kept reactors
+queued. This provides read-your-writes, but a projector exception can currently
+leave the event committed without its read-model update. Replaying the event
+store repairs the projection later, even though the original request reported a
+failure.
+
+Wrapping the complete synchronous persistence flow in a database transaction
+fixes that inconsistency. It also means Spatie's queued
+`HandleStoredEventJob` is dispatched while the transaction is open. With
+Laravel's default `after_commit = false`, a worker can process that job before
+the event and projection commit, or retain side effects after a rollback.
+
+The application writes stored events through two paths:
+
+- aggregate roots call `persist()`;
+- MQTT handlers and reactors dispatch `ShouldBeStored` events through Laravel's
+  event dispatcher.
+
+Spatie's `AggregateRoot::persistInTransaction()` is not sufficient because it
+commits event rows before invoking synchronous projectors.
+
+## Decision
+
+Make both stored-event write paths transactional:
+
+- all application aggregates inherit from a transactional aggregate root that
+  wraps the complete `persist()` flow, including synchronous projectors;
+- direct `ShouldBeStored` events use an application dispatcher that wraps
+  Laravel event dispatch in a database transaction;
+- the inherited `persistInTransaction()` behavior is replaced so projectors
+  execute before the outer transaction commits.
+
+Replace Spatie's configured stored-event job with an application subclass that
+implements Laravel's `ShouldQueueAfterCommit`. This scopes after-commit
+dispatching to queued event-sourcing handlers. The global queue connection
+configuration remains unchanged.
+
+## Rationale
+
+Central boundaries reduce the chance that a new write path omits the
+transaction. The custom stored-event job uses Spatie's supported
+`stored_event_job` extension point and Laravel's native after-commit mechanism.
+Scoping the behavior avoids changing unrelated jobs, notifications, mailables,
+or broadcasts shortly before the beta release.
+
+## Alternatives Considered
+
+### Use Spatie's `persistInTransaction()`
+
+- Pros: built into the package.
+- Cons: synchronous projectors run only after the event transaction commits.
+- Why not chosen: it does not make the event and projection atomic.
+
+### Wrap every call site independently
+
+- Pros: no shared application abstraction.
+- Cons: many existing sites must be audited and future sites can bypass the
+  invariant.
+- Why not chosen: omission risk is too high for a reliability guarantee.
+
+### Enable `after_commit` on the queue connection globally
+
+- Pros: one configuration change protects every queued operation.
+- Cons: changes unrelated queue, notification, mail, and broadcast timing.
+- Why not chosen: the beta fix should have the smallest practical blast radius.
+
+### Add a transactional outbox
+
+- Pros: also closes the gap between a successful database commit and a failed
+  Redis enqueue.
+- Cons: requires another persistence model, publisher process, retries, and
+  operational monitoring.
+- Why not chosen: valuable post-beta hardening, but disproportionate for the
+  current beta scope.
+
+## Consequences
+
+### Positive
+
+- A synchronous projector failure rolls back its stored event.
+- Queued reactors are not enqueued for rolled-back events.
+- Existing outer transactions compose with the event-sourcing transaction.
+- Unrelated Laravel queue behavior is unchanged.
+
+### Negative
+
+- Direct stored events must use the application dispatcher rather than
+  Laravel's global `event()` helper.
+- Aggregate persistence now always incurs a database transaction, including in
+  callers that do not already own one.
+
+### Risks
+
+- This does not provide exactly-once reactor execution; queue redelivery still
+  requires idempotent handlers.
+- A database commit can still succeed while the subsequent Redis enqueue fails.
+- Direct `ShouldBeStored` dispatch can bypass the application dispatcher unless
+  review and tests enforce the convention.
+
+## Rollout / Migration
+
+1. Move all application aggregates to the transactional base class.
+2. Replace direct stored-event dispatches in MQTT handlers, reactors, and
+   commands with the transactional dispatcher.
+3. Configure the after-commit stored-event job.
+4. Verify projector-failure rollback and commit/rollback queue behavior.
+5. Track reactor idempotency, uniform Filament error handling, outbox
+   evaluation, and orphan-event monitoring in post-beta issue #230.
+
+Rollback consists of restoring the Spatie aggregate base class, direct Laravel
+event dispatch, and the default stored-event job configuration.
+
+## Supersedes / Superseded By
+
+- Supersedes: none
+- Superseded by: none
+
+## References
+
+- ADR-0033: Synchronous projectors, queued reactors
+- GitHub issue #139
+- GitHub issue #230: post-beta event-sourcing reliability hardening
+- Spatie Laravel Event Sourcing 7.15 `AggregateRoot`, `EventSubscriber`, and
+  `HandleStoredEventJob`
+- Laravel 12 queued jobs and database transactions

--- a/locker-backend/app/Aggregates/CompartmentAccessAggregate.php
+++ b/locker-backend/app/Aggregates/CompartmentAccessAggregate.php
@@ -8,9 +8,8 @@ use App\StorableEvents\CompartmentAccessGranted;
 use App\StorableEvents\CompartmentAccessRevoked;
 use Carbon\CarbonInterface;
 use Ramsey\Uuid\Uuid;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
-class CompartmentAccessAggregate extends AggregateRoot
+class CompartmentAccessAggregate extends TransactionalAggregateRoot
 {
     public static function aggregateUuidFor(int $userId, string $compartmentUuid): string
     {

--- a/locker-backend/app/Aggregates/CompartmentContentNoteAggregate.php
+++ b/locker-backend/app/Aggregates/CompartmentContentNoteAggregate.php
@@ -6,9 +6,8 @@ namespace App\Aggregates;
 
 use App\StorableEvents\CompartmentContentNoteUpdated;
 use Carbon\CarbonInterface;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
-class CompartmentContentNoteAggregate extends AggregateRoot
+class CompartmentContentNoteAggregate extends TransactionalAggregateRoot
 {
     public function updateNote(
         int $actorUserId,

--- a/locker-backend/app/Aggregates/CompartmentOpenAggregate.php
+++ b/locker-backend/app/Aggregates/CompartmentOpenAggregate.php
@@ -7,9 +7,8 @@ namespace App\Aggregates;
 use App\StorableEvents\CompartmentOpenAuthorized;
 use App\StorableEvents\CompartmentOpenDenied;
 use App\StorableEvents\CompartmentOpenRequested;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
-class CompartmentOpenAggregate extends AggregateRoot
+class CompartmentOpenAggregate extends TransactionalAggregateRoot
 {
     public function requestOpen(string $commandId, int $actorUserId, string $compartmentUuid): self
     {

--- a/locker-backend/app/Aggregates/GroupAggregate.php
+++ b/locker-backend/app/Aggregates/GroupAggregate.php
@@ -12,13 +12,12 @@ use App\StorableEvents\UserAddedToGroup;
 use App\StorableEvents\UserRemovedFromGroup;
 use Carbon\CarbonInterface;
 use LogicException;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
 /**
  * One aggregate per group; the group's UUID is the aggregate UUID (the group is
  * itself the consistency boundary, so no derived UUID is needed).
  */
-class GroupAggregate extends AggregateRoot
+class GroupAggregate extends TransactionalAggregateRoot
 {
     private bool $archived = false;
 

--- a/locker-backend/app/Aggregates/LockerBankAggregate.php
+++ b/locker-backend/app/Aggregates/LockerBankAggregate.php
@@ -15,9 +15,8 @@ use App\StorableEvents\LockerWasProvisioned;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
-class LockerBankAggregate extends AggregateRoot
+class LockerBankAggregate extends TransactionalAggregateRoot
 {
     // We will add methods here to handle commands like
     // `registerLockerBank` which will then record events

--- a/locker-backend/app/Aggregates/TermsDocumentAggregate.php
+++ b/locker-backend/app/Aggregates/TermsDocumentAggregate.php
@@ -11,9 +11,8 @@ use App\StorableEvents\UserAcceptedTermsVersion;
 use Carbon\CarbonInterface;
 use LogicException;
 use Ramsey\Uuid\Uuid;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
-class TermsDocumentAggregate extends AggregateRoot
+class TermsDocumentAggregate extends TransactionalAggregateRoot
 {
     private bool $documentCreated = false;
 

--- a/locker-backend/app/Aggregates/TransactionalAggregateRoot.php
+++ b/locker-backend/app/Aggregates/TransactionalAggregateRoot.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Aggregates;
+
+use Illuminate\Support\Facades\DB;
+use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+
+abstract class TransactionalAggregateRoot extends AggregateRoot
+{
+    public function persist(): static
+    {
+        return DB::transaction(fn () => parent::persist());
+    }
+
+    public static function persistInTransaction(AggregateRoot ...$aggregateRoots): void
+    {
+        DB::transaction(static function () use ($aggregateRoots): void {
+            foreach ($aggregateRoots as $aggregateRoot) {
+                $aggregateRoot->persist();
+            }
+        });
+    }
+}

--- a/locker-backend/app/Aggregates/UserRoleAggregate.php
+++ b/locker-backend/app/Aggregates/UserRoleAggregate.php
@@ -8,13 +8,12 @@ use App\StorableEvents\UserRoleGranted;
 use App\StorableEvents\UserRoleRevoked;
 use Carbon\CarbonInterface;
 use Ramsey\Uuid\Uuid;
-use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
 /**
  * One aggregate per user; owns that user's role assignments.
  * `actorUserId` is null for system-initiated grants (bootstrap / backfill).
  */
-class UserRoleAggregate extends AggregateRoot
+class UserRoleAggregate extends TransactionalAggregateRoot
 {
     /** @var array<string, true> currently-held roles, rebuilt from events */
     private array $roles = [];

--- a/locker-backend/app/Console/Commands/DetectOfflineLockers.php
+++ b/locker-backend/app/Console/Commands/DetectOfflineLockers.php
@@ -6,10 +6,16 @@ namespace App\Console\Commands;
 
 use App\Models\LockerBank;
 use App\StorableEvents\LockerConnectionLost;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Console\Command;
 
 class DetectOfflineLockers extends Command
 {
+    public function __construct(private readonly StoredEventDispatcher $storedEventDispatcher)
+    {
+        parent::__construct();
+    }
+
     /** @var string */
     protected $signature = 'locker:detect-offline {--dry-run : Do not write changes or emit events}';
 
@@ -53,7 +59,7 @@ class DetectOfflineLockers extends Command
             if ($affected === 1) {
                 $lost++;
 
-                event(new LockerConnectionLost(
+                $this->storedEventDispatcher->dispatch(new LockerConnectionLost(
                     lockerBankUuid: (string) $lockerBank->id,
                     detectedAtIso8601: $now->toIso8601String(),
                     lastHeartbeatAtIso8601: $lockerBank->last_heartbeat_at?->toIso8601String(),

--- a/locker-backend/app/Mqtt/Handlers/CommandResponseHandler.php
+++ b/locker-backend/app/Mqtt/Handlers/CommandResponseHandler.php
@@ -7,6 +7,7 @@ namespace App\Mqtt\Handlers;
 use App\Mqtt\InboundMqttProtocolGuard;
 use App\Services\CommandResponseInboxService;
 use App\StorableEvents\CommandResponseReceived;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
@@ -16,6 +17,7 @@ class CommandResponseHandler extends AbstractInboundMqttHandler
 {
     public function __construct(
         private readonly CommandResponseInboxService $inbox,
+        private readonly StoredEventDispatcher $storedEventDispatcher,
         InboundMqttProtocolGuard $guard,
     ) {
         parent::__construct($guard);
@@ -110,7 +112,7 @@ class CommandResponseHandler extends AbstractInboundMqttHandler
             $data['applied_config_hash'] = $payload['applied_config_hash'];
         }
 
-        event(new CommandResponseReceived(
+        $this->storedEventDispatcher->dispatch(new CommandResponseReceived(
             lockerBankUuid: $lockerBankUuid,
             transactionId: $transactionId,
             action: $action,

--- a/locker-backend/app/Mqtt/Handlers/CompartmentSnapshotHandler.php
+++ b/locker-backend/app/Mqtt/Handlers/CompartmentSnapshotHandler.php
@@ -10,6 +10,7 @@ use App\Models\LockerBank;
 use App\Mqtt\InboundMqttProtocolGuard;
 use App\StorableEvents\CompartmentDoorStateChanged;
 use App\StorableEvents\CompartmentStateChangesApplied;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 
@@ -18,8 +19,10 @@ use Illuminate\Support\Facades\Log;
  */
 class CompartmentSnapshotHandler extends AbstractInboundMqttHandler
 {
-    public function __construct(InboundMqttProtocolGuard $guard)
-    {
+    public function __construct(
+        InboundMqttProtocolGuard $guard,
+        private readonly StoredEventDispatcher $storedEventDispatcher,
+    ) {
         parent::__construct($guard);
     }
 
@@ -124,7 +127,7 @@ class CompartmentSnapshotHandler extends AbstractInboundMqttHandler
 
             $hadDoorDelta = true;
 
-            event(new CompartmentDoorStateChanged(
+            $this->storedEventDispatcher->dispatch(new CompartmentDoorStateChanged(
                 lockerBankUuid: $lockerBankUuid,
                 compartmentUuid: (string) $compartment->id,
                 compartmentNumber: $number,
@@ -136,7 +139,7 @@ class CompartmentSnapshotHandler extends AbstractInboundMqttHandler
         }
 
         if ($hadDoorDelta) {
-            event(new CompartmentStateChangesApplied(
+            $this->storedEventDispatcher->dispatch(new CompartmentStateChangesApplied(
                 lockerBankUuid: $lockerBankUuid,
                 changesObservedAtIso8601: $ts->toIso8601String(),
                 mqttMessageId: $mqttMessageId,

--- a/locker-backend/app/Mqtt/Handlers/DeviceEventHandler.php
+++ b/locker-backend/app/Mqtt/Handlers/DeviceEventHandler.php
@@ -6,13 +6,16 @@ namespace App\Mqtt\Handlers;
 
 use App\Mqtt\InboundMqttProtocolGuard;
 use App\StorableEvents\DeviceEventReceived;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class DeviceEventHandler extends AbstractInboundMqttHandler
 {
-    public function __construct(InboundMqttProtocolGuard $guard)
-    {
+    public function __construct(
+        InboundMqttProtocolGuard $guard,
+        private readonly StoredEventDispatcher $storedEventDispatcher,
+    ) {
         parent::__construct($guard);
     }
 
@@ -60,7 +63,7 @@ class DeviceEventHandler extends AbstractInboundMqttHandler
             'event_id' => $eventId,
         ]);
 
-        event(new DeviceEventReceived(
+        $this->storedEventDispatcher->dispatch(new DeviceEventReceived(
             lockerBankUuid: $lockerBankUuid,
             event: $eventName,
             eventId: $eventId,

--- a/locker-backend/app/Mqtt/Handlers/LockerHeartbeatHandler.php
+++ b/locker-backend/app/Mqtt/Handlers/LockerHeartbeatHandler.php
@@ -7,6 +7,7 @@ namespace App\Mqtt\Handlers;
 use App\Models\LockerBank;
 use App\Mqtt\InboundMqttProtocolGuard;
 use App\StorableEvents\LockerConnectionRestored;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 
@@ -15,8 +16,10 @@ use Illuminate\Support\Facades\Log;
  */
 class LockerHeartbeatHandler extends AbstractInboundMqttHandler
 {
-    public function __construct(InboundMqttProtocolGuard $guard)
-    {
+    public function __construct(
+        InboundMqttProtocolGuard $guard,
+        private readonly StoredEventDispatcher $storedEventDispatcher,
+    ) {
         parent::__construct($guard);
     }
 
@@ -94,7 +97,7 @@ class LockerHeartbeatHandler extends AbstractInboundMqttHandler
         ]);
 
         if ($wasOffline) {
-            event(new LockerConnectionRestored(
+            $this->storedEventDispatcher->dispatch(new LockerConnectionRestored(
                 lockerBankUuid: $lockerBankUuid,
                 restoredAtIso8601: $ts->toIso8601String(),
                 reason: 'heartbeat',

--- a/locker-backend/app/Reactors/CommandResponseReactor.php
+++ b/locker-backend/app/Reactors/CommandResponseReactor.php
@@ -10,6 +10,7 @@ use App\StorableEvents\CompartmentOpeningFailed;
 use App\StorableEvents\CompartmentOpeningRequested;
 use App\StorableEvents\LockerConfigAckFailed;
 use App\StorableEvents\LockerConfigAcknowledged;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
@@ -23,6 +24,8 @@ use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
  */
 class CommandResponseReactor extends Reactor implements ShouldQueue
 {
+    public function __construct(private readonly StoredEventDispatcher $storedEventDispatcher) {}
+
     public string $queue = 'events';
 
     /**
@@ -51,7 +54,7 @@ class CommandResponseReactor extends Reactor implements ShouldQueue
                 return;
             }
 
-            event(new LockerConfigAcknowledged(
+            $this->storedEventDispatcher->dispatch(new LockerConfigAcknowledged(
                 lockerBankUuid: $event->lockerBankUuid,
                 transactionId: $event->transactionId,
                 appliedConfigHash: $appliedHash,
@@ -66,7 +69,7 @@ class CommandResponseReactor extends Reactor implements ShouldQueue
                 return;
             }
 
-            event(new LockerConfigAckFailed(
+            $this->storedEventDispatcher->dispatch(new LockerConfigAckFailed(
                 lockerBankUuid: $event->lockerBankUuid,
                 transactionId: $event->transactionId,
                 errorCode: $event->errorCode,
@@ -115,7 +118,7 @@ class CommandResponseReactor extends Reactor implements ShouldQueue
                     return;
                 }
 
-                event(new CompartmentOpenAcknowledged(
+                $this->storedEventDispatcher->dispatch(new CompartmentOpenAcknowledged(
                     lockerBankUuid: $event->lockerBankUuid,
                     compartmentUuid: $compartmentUuid,
                     compartmentNumber: $compartmentNumber,
@@ -130,7 +133,7 @@ class CommandResponseReactor extends Reactor implements ShouldQueue
                 return;
             }
 
-            event(new CompartmentOpeningFailed(
+            $this->storedEventDispatcher->dispatch(new CompartmentOpeningFailed(
                 lockerBankUuid: $event->lockerBankUuid,
                 compartmentUuid: $compartmentUuid,
                 compartmentNumber: $compartmentNumber,

--- a/locker-backend/app/Reactors/DoorDetectionReactor.php
+++ b/locker-backend/app/Reactors/DoorDetectionReactor.php
@@ -12,6 +12,7 @@ use App\StorableEvents\CompartmentOpeningRequested;
 use App\StorableEvents\CompartmentOpenNotDetected;
 use App\StorableEvents\CompartmentUncommandedOpenDetected;
 use App\StorableEvents\DeviceEventReceived;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Log;
 use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
@@ -33,6 +34,8 @@ use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
  */
 class DoorDetectionReactor extends Reactor implements ShouldQueue
 {
+    public function __construct(private readonly StoredEventDispatcher $storedEventDispatcher) {}
+
     public string $queue = 'events';
 
     public const OPEN_DETECTED = 'compartment_open_detected';
@@ -70,7 +73,7 @@ class DoorDetectionReactor extends Reactor implements ShouldQueue
                 return;
             }
 
-            event(new CompartmentDoorAlreadyOpen(
+            $this->storedEventDispatcher->dispatch(new CompartmentDoorAlreadyOpen(
                 lockerBankUuid: $event->lockerBankUuid,
                 compartmentUuid: $request['compartmentUuid'],
                 compartmentNumber: $request['compartmentNumber'],
@@ -87,7 +90,7 @@ class DoorDetectionReactor extends Reactor implements ShouldQueue
 
         $detectionMs = $event->data['detection_ms'] ?? null;
 
-        event(new CompartmentDoorOpenDetected(
+        $this->storedEventDispatcher->dispatch(new CompartmentDoorOpenDetected(
             lockerBankUuid: $event->lockerBankUuid,
             compartmentUuid: $request['compartmentUuid'],
             compartmentNumber: $request['compartmentNumber'],
@@ -115,7 +118,7 @@ class DoorDetectionReactor extends Reactor implements ShouldQueue
 
         $errorCode = $event->data['error_code'] ?? null;
 
-        event(new CompartmentOpenNotDetected(
+        $this->storedEventDispatcher->dispatch(new CompartmentOpenNotDetected(
             lockerBankUuid: $event->lockerBankUuid,
             compartmentUuid: $request['compartmentUuid'],
             compartmentNumber: $request['compartmentNumber'],
@@ -165,7 +168,7 @@ class DoorDetectionReactor extends Reactor implements ShouldQueue
 
         $sinceFire = $event->data['milliseconds_since_last_relay_fire'] ?? null;
 
-        event(new CompartmentUncommandedOpenDetected(
+        $this->storedEventDispatcher->dispatch(new CompartmentUncommandedOpenDetected(
             lockerBankUuid: $event->lockerBankUuid,
             compartmentUuid: (string) $compartment->id,
             compartmentNumber: $compartmentNumber,

--- a/locker-backend/app/Reactors/MqttReactor.php
+++ b/locker-backend/app/Reactors/MqttReactor.php
@@ -14,6 +14,7 @@ use App\StorableEvents\LockerConfigApplyRequested;
 use App\StorableEvents\LockerProvisioningFailed;
 use App\StorableEvents\LockerProvisioningReplyFailed;
 use App\StorableEvents\LockerWasProvisioned;
+use App\Support\EventSourcing\StoredEventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -27,6 +28,7 @@ class MqttReactor extends Reactor implements ShouldQueue
         private readonly ApplyConfigCommandPublisher $applyConfigCommandPublisher,
         private readonly ProvisioningReplyPublisher $provisioningReplyPublisher,
         private readonly MqttUserService $mqttUserService,
+        private readonly StoredEventDispatcher $storedEventDispatcher,
     ) {}
 
     /**
@@ -112,7 +114,7 @@ class MqttReactor extends Reactor implements ShouldQueue
             ]);
 
             // Record a failure event so we have a durable audit trail
-            event(new LockerProvisioningReplyFailed(
+            $this->storedEventDispatcher->dispatch(new LockerProvisioningReplyFailed(
                 lockerBankUuid: $event->lockerBankUuid,
                 replyToTopic: $event->replyToTopic,
                 reason: $e->getMessage(),

--- a/locker-backend/app/Support/EventSourcing/HandleStoredEventAfterCommitJob.php
+++ b/locker-backend/app/Support/EventSourcing/HandleStoredEventAfterCommitJob.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\EventSourcing;
+
+use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Spatie\EventSourcing\StoredEvents\HandleStoredEventJob;
+
+final class HandleStoredEventAfterCommitJob extends HandleStoredEventJob implements ShouldQueueAfterCommit {}

--- a/locker-backend/app/Support/EventSourcing/StoredEventDispatcher.php
+++ b/locker-backend/app/Support/EventSourcing/StoredEventDispatcher.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\EventSourcing;
+
+use Illuminate\Support\Facades\DB;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+final class StoredEventDispatcher
+{
+    public function dispatch(ShouldBeStored $event): void
+    {
+        DB::transaction(static function () use ($event): void {
+            event($event);
+        });
+    }
+}

--- a/locker-backend/config/event-sourcing.php
+++ b/locker-backend/config/event-sourcing.php
@@ -94,7 +94,7 @@ return [
      * can change this to a class of your own. The only restriction is that
      * it should implement \Spatie\EventSourcing\StoredEvents\HandleDomainEventJob.
      */
-    'stored_event_job' => Spatie\EventSourcing\StoredEvents\HandleStoredEventJob::class,
+    'stored_event_job' => App\Support\EventSourcing\HandleStoredEventAfterCommitJob::class,
 
     /*
      * Similar to Relation::enforceMorphMap() this option will make sure that every event has a

--- a/locker-backend/tests/Feature/EventSourcingAtomicityTest.php
+++ b/locker-backend/tests/Feature/EventSourcingAtomicityTest.php
@@ -52,14 +52,16 @@ class EventSourcingAtomicityTest extends TestCase
         $this->assertSame(0, EloquentStoredEvent::query()->count());
     }
 
-    public function test_stored_event_job_is_enqueued_only_after_the_outer_transaction_commits(): void
+    public function test_aggregate_stored_event_job_is_enqueued_only_after_the_outer_transaction_commits(): void
     {
         config()->set('queue.default', 'database');
         app(Projectionist::class)->addReactor(QueuedAtomicityReactor::class);
 
         DB::beginTransaction();
 
-        app(StoredEventDispatcher::class)->dispatch(new AtomicityTestEvent('commit'));
+        AtomicityTestAggregate::retrieve('aggregate-commit')
+            ->record('commit')
+            ->persist();
 
         $this->assertDatabaseCount('stored_events', 1);
         $this->assertDatabaseCount('jobs', 0);

--- a/locker-backend/tests/Feature/EventSourcingAtomicityTest.php
+++ b/locker-backend/tests/Feature/EventSourcingAtomicityTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Aggregates\TransactionalAggregateRoot;
+use App\Support\EventSourcing\StoredEventDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
+use Spatie\EventSourcing\Projectionist;
+use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+use Tests\TestCase;
+
+class EventSourcingAtomicityTest extends TestCase
+{
+    public function test_aggregate_event_rolls_back_when_a_synchronous_projector_fails(): void
+    {
+        app(Projectionist::class)->addProjector(FailingAtomicityProjector::class);
+
+        $thrown = false;
+
+        try {
+            AtomicityTestAggregate::retrieve('aggregate-rollback')
+                ->record('aggregate')
+                ->persist();
+        } catch (RuntimeException) {
+            $thrown = true;
+        }
+
+        $this->assertTrue($thrown);
+        $this->assertSame(0, EloquentStoredEvent::query()->count());
+    }
+
+    public function test_direct_stored_event_rolls_back_when_a_synchronous_projector_fails(): void
+    {
+        app(Projectionist::class)->addProjector(FailingAtomicityProjector::class);
+
+        $thrown = false;
+
+        try {
+            app(StoredEventDispatcher::class)->dispatch(new AtomicityTestEvent('direct'));
+        } catch (RuntimeException) {
+            $thrown = true;
+        }
+
+        $this->assertTrue($thrown);
+        $this->assertSame(0, EloquentStoredEvent::query()->count());
+    }
+
+    public function test_stored_event_job_is_enqueued_only_after_the_outer_transaction_commits(): void
+    {
+        config()->set('queue.default', 'database');
+        app(Projectionist::class)->addReactor(QueuedAtomicityReactor::class);
+
+        DB::beginTransaction();
+
+        app(StoredEventDispatcher::class)->dispatch(new AtomicityTestEvent('commit'));
+
+        $this->assertDatabaseCount('stored_events', 1);
+        $this->assertDatabaseCount('jobs', 0);
+
+        DB::commit();
+
+        $this->assertDatabaseCount('jobs', 1);
+    }
+
+    public function test_stored_event_job_is_discarded_when_the_outer_transaction_rolls_back(): void
+    {
+        config()->set('queue.default', 'database');
+        app(Projectionist::class)->addReactor(QueuedAtomicityReactor::class);
+
+        DB::beginTransaction();
+
+        app(StoredEventDispatcher::class)->dispatch(new AtomicityTestEvent('rollback'));
+
+        $this->assertDatabaseCount('stored_events', 1);
+        $this->assertDatabaseCount('jobs', 0);
+
+        DB::rollBack();
+
+        $this->assertDatabaseCount('stored_events', 0);
+        $this->assertDatabaseCount('jobs', 0);
+    }
+}
+
+final class AtomicityTestAggregate extends TransactionalAggregateRoot
+{
+    public function record(string $value): self
+    {
+        $this->recordThat(new AtomicityTestEvent($value));
+
+        return $this;
+    }
+}
+
+final class AtomicityTestEvent extends ShouldBeStored
+{
+    public function __construct(public readonly string $value) {}
+}
+
+final class FailingAtomicityProjector extends Projector
+{
+    public function onAtomicityTestEvent(AtomicityTestEvent $event): void
+    {
+        throw new RuntimeException("Projection failed for {$event->value}.");
+    }
+}
+
+final class QueuedAtomicityReactor extends Reactor implements ShouldQueue
+{
+    public function onAtomicityTestEvent(AtomicityTestEvent $event): void {}
+}


### PR DESCRIPTION
## Summary
- wrap aggregate and direct stored-event writes so events and synchronous projectors commit or roll back together
- dispatch Spatie's queued handler job only after the surrounding database transaction commits
- document the beta guarantees in ADR-0054 and defer stronger reliability work to #230

## Test plan
- [x] Run `php artisan test --compact tests/Feature/EventSourcingAtomicityTest.php`
- [x] Run the complete backend suite with a 1 GB PHP memory limit (399 tests, 1454 assertions)
- [x] Run `composer format-check` (358 files)
- [x] Run PHPStan; it reaches one pre-existing error in unchanged `AuditEventPresenter.php:154`

Closes #139

Made with [Cursor](https://cursor.com)