### PR TITLE
feat(mqtt): secure production broker transport

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,35 +1,71 @@
 # Installation
 
-- [Installation](#installation)
-  - [Architecture Overview](#architecture-overview)
-  - [Cloud Backend Setup](#cloud-backend-setup)
-  - [Locker Client Setup](#locker-client-setup)
+- [Architecture overview](#architecture-overview)
+- [Release and security status](#release-and-security-status)
+- [Cloud backend setup](#cloud-backend-setup)
+  - [Standalone Docker deployment](#standalone-docker-deployment)
+  - [Coolify deployment](#coolify-deployment)
+  - [Verify MQTT TLS](#verify-mqtt-tls)
+- [Locker client setup](#locker-client-setup-raspberry-pi)
+- [Mobile app setup](#mobile-app-setup)
 
-The Open Locker System is split into multiple components. We use Docker to ensure a
-consistent and easy installation process.
+Open Locker is a monorepo with independently deployable backend, locker-client,
+and mobile components. Docker provides the backend and Raspberry Pi runtime;
+the mobile application uses React Native with Expo.
 
-## Architecture Overview
+## Architecture overview
 
-The system consists of two main parts:
+1. **Cloud backend (`locker-backend/`)**
+   - Laravel 12 REST API and Filament 5 admin panel
+   - PostgreSQL, Redis, queue/event workers, scheduler, and Laravel Reverb
+   - Mosquitto with `mosquitto-go-auth`, authenticating through Laravel
+   - publishes locker commands over MQTT and consumes client state/responses
+   - never communicates with Modbus hardware directly
+2. **Locker client (`locker-client/`)**
+   - TypeScript/Node service in Docker on a Raspberry Pi
+   - provisions and communicates with the backend through MQTT
+   - owns serialized Modbus RTU communication with Waveshare hardware
+   - persists MQTT identity, credentials, runtime configuration, and command
+     deduplication state under `/data`
+3. **Mobile app (`mobile-app/`)**
+   - React Native application built with Expo
+   - consumes the backend REST API through a generated RTK Query client
+   - receives live updates through Reverb
 
-1. **Cloud Backend**: A central server (VPS) running:
-   - Laravel Application (API + Admin Panel)
-   - PostgreSQL Database
-   - Mosquitto MQTT Broker (with HTTP Auth)
-   - Redis & Workers
+The runtime flow is:
 
-2. **Locker Client**: An IoT device (Raspberry Pi) at the physical locker location
-   running:
-   - Dockerized client software
-   - Modbus communication to locker hardware
+`Mobile app → Laravel API → MQTT → locker-client → Modbus RTU → locker hardware`
 
-This guide provides instructions for setting up both components.
+## Release and security status
 
-## Cloud Backend Setup
+There is currently **no production deployment**. The first beta is a controlled
+pre-production pilot governed by the
+[beta release checklist](release-checklist.md) and
+[rollback runbook](releases/beta-rollback.md).
 
-This setup is intended for a central server (e.g., VPS, Cloud Instance).
+Component source tags are independent:
 
-### 1. Initial Setup
+- `backend-vX.Y.Z`
+- `client-vX.Y.Z`
+- `mobile-vX.Y.Z`
+
+For beta deployments, set `BACKEND_IMAGE_TAG` and `LOCKER_CLIENT_IMAGE_TAG` to
+the exact immutable GHCR tags produced and verified for the corresponding source
+tags. Do not deploy or roll back a pilot with `latest`. Verify the image digest
+because release workflow implementation is itself tracked by #50.
+
+Production MQTT is exposed only as MQTTS on port 8883 through Traefik. Plaintext
+port 1883 remains available inside the production Docker network and in the
+explicit development stack, but is not published by production Compose. Passing
+the end-to-end MQTTS smoke test below remains a beta release gate.
+
+## Cloud backend setup
+
+This setup is intended for development or a controlled server environment. A
+public deployment additionally requires the security and operational gates in
+the release checklist.
+
+### 1. Initial setup
 
 Clone the repository and prepare the environment:
 
@@ -39,156 +75,310 @@ cd Open-Locker
 cp locker-backend/.env.example locker-backend/.env
 ```
 
-Edit `locker-backend/.env` and configure:
-- `APP_URL`: Your server's domain/IP
-- `DB_PASSWORD`: Secure database password
-- `MOSQ_HTTP_USER` & `MOSQ_HTTP_PASS`: Credentials for MQTT Broker <-> Backend communication
+Edit `locker-backend/.env` and configure at least:
 
-### 2. Configure MQTT Authentication
+- `APP_URL` and a persistent `APP_KEY`
+- PostgreSQL database name, user, and a strong `DB_PASSWORD`
+- mail delivery, which is required for administrator password setup
+- Reverb application credentials and public endpoint
+- public application, Reverb, and MQTT DNS names
+- backend MQTT credentials (`MQTT_USERNAME` and `MQTT_PASSWORD`)
+- provisioning credentials (`MQTT_PROVISIONING_USERNAME` and
+  `MQTT_PROVISIONING_PASSWORD`)
+- `MOSQ_HTTP_PASS`, shared only between `mosquitto-go-auth` and Laravel
 
-We use `mosquitto-go-auth` to authenticate MQTT clients against the Laravel API.
+### 2. Configure MQTT authentication
 
-**Option A: Using `just` (Recommended)**
-
-Use the provided task runner to generate the configuration automatically:
+Mosquitto authenticates clients against the Laravel `/api/mosq/*` endpoints.
+The recommended repository task generates the local configuration:
 
 ```bash
-# Ensure you have 'just' installed
 just setup-mqtt
 ```
 
-**Option B: Manual Setup (No Shell Access/No Just)**
+For manual setup:
 
-If you cannot use `just`, you must manually configure the Auth Secret:
+1. Copy the Mosquitto configuration template to
+   `locker-backend/mosquitto/mosquitto.conf`.
+2. Set the auth and ACL webhook query secret to the same `MOSQ_HTTP_PASS` used
+   by Laravel.
+3. Restart Mosquitto.
 
-1. Create `locker-backend/mosquitto/mosquitto.conf` by copying the example.
-2. Update the webhook URIs in `mosquitto.conf` to include your `MOSQ_HTTP_PASS` as a secret token:
-   ```conf
-   auth_opt_http_getuser_uri /api/mosq/auth?mosq_secret=YOUR_SECURE_PASSWORD
-   auth_opt_http_superuser_uri /api/mosq/superuser?mosq_secret=YOUR_SECURE_PASSWORD
-   auth_opt_http_aclcheck_uri /api/mosq/acl?mosq_secret=YOUR_SECURE_PASSWORD
-   ```
-   *(Replace `YOUR_SECURE_PASSWORD` with the value of `MOSQ_HTTP_PASS` from your `.env`)*
-3. Restart the Mosquitto container.
+This configures HTTP-backed authentication. Public transport encryption is
+provided by Traefik according to
+[ADR-0053](adr/0053-terminate-public-mqtt-tls-at-traefik.md).
 
-### 3. Start Services
+### 3. Start services
 
-Start the backend stack using Docker Compose from the `locker-backend` directory:
+Run the development stack from the backend directory:
 
 ```bash
 cd locker-backend
-
-# Development (local)
 docker compose up -d
-
-# Production (on server)
-docker compose -f docker-compose.prod.yml up -d
 ```
 
-#### Pin the backend image version (recommended)
+Production supports two edge adapters over the same base stack:
 
-By default, `docker-compose.prod.yml` uses the `latest` image tag:
+- standalone Docker Compose starts the repository-maintained Traefik service;
+- Coolify uses Coolify's managed Traefik service.
 
-```yaml
-image: ghcr.io/open-locker/locker-backend:${BACKEND_IMAGE_TAG:-latest}
-```
+Both expose HTTPS on 443 and MQTTS on 8883. Normal production commands do not
+publish Mosquitto's plaintext port 1883. The rollout procedure below defines the
+only temporary exception for clients that have not migrated yet.
 
-For production deployments, we strongly recommend pinning the image to an immutable tag:
+#### Standalone Docker deployment
 
-- **Commit SHA tag** (always available): `BACKEND_IMAGE_TAG=<github_sha>`
-- **Release tag** (optional): `BACKEND_IMAGE_TAG=vX.Y.Z`
-
-Example:
+Create DNS A/AAAA records for `APP_DOMAIN`, `REVERB_DOMAIN`, and `MQTT_DOMAIN`
+that point to the server. Allow inbound TCP 80, 443, and 8883 in the provider
+firewall. Set those domains and `ACME_EMAIL` in `locker-backend/.env`, then run:
 
 ```bash
-export BACKEND_IMAGE_TAG="<github_sha>"
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d --force-recreate
+cd locker-backend
+export BACKEND_IMAGE_TAG="<immutable-release-image-tag>"
+docker compose \
+  -f docker-compose.prod.yml \
+  -f docker-compose.prod.traefik.yml \
+  pull
+docker compose \
+  -f docker-compose.prod.yml \
+  -f docker-compose.prod.traefik.yml \
+  up -d --force-recreate
 ```
 
-Tip: put `BACKEND_IMAGE_TAG=<github_sha>` in `locker-backend/.env` so you don't need to export it
-in every shell session.
+`docker-compose.prod.yml` runs the app, PostgreSQL, Redis, queue and event
+workers, scheduler, Reverb, MQTT listener, and Mosquitto. It maps
+`BACKEND_IMAGE_TAG` to `APP_VERSION`; confirm it through `GET /api/identify`.
+The Traefik overlay publishes 80, 443, and 8883, stores ACME state in the
+`traefik-certificates` volume, and forwards decrypted MQTT only over the private
+Compose network to `mqtt:1883`.
 
-If you use the provided `docker-compose.prod.yml`, the API will also expose this value via
-`GET /api/identify` as `version`, because the compose file sets `APP_VERSION` from `BACKEND_IMAGE_TAG`.
+Do not copy the development `1883:1883` mapping into the base or edge adapter.
+The time-limited migration overlay below is the only exception.
+Docker-published ports can bypass host-only UFW rules; verify the rendered
+Compose configuration as well as the upstream firewall.
 
-### 4. Create Admin User
+#### Coolify deployment
 
-Once the services are running, create your first admin user:
+Coolify's current documentation does not describe a per-resource **Custom
+Compose Override**. Its similarly named custom override file configures
+Coolify's own infrastructure under `/data/coolify/source`, not an application
+resource, and must not be used for this stack.
+
+Use Coolify v4's documented Git-based Docker Compose application instead:
+
+1. Create DNS records for the application, Reverb, and MQTT hosts.
+2. In **Project → Environment → Add Resource**, select the repository and choose
+   the **Docker Compose** build pack. In the resource's **General** settings set
+   **Docker Compose Location** to
+   `/locker-backend/docker-compose.prod.coolify.yml`. This single entry file
+   uses Compose `extends` to load every service from `docker-compose.prod.yml`;
+   no UI override is required.
+3. Add the values from `.env.prod.example` under the resource's
+   **Environment Variables**. Use real secrets and domains, pin
+   `BACKEND_IMAGE_TAG`, and set a deployment-unique
+   `COOLIFY_MQTT_ROUTER_NAME` when multiple Open Locker stacks share a proxy.
+   The adapter attaches Mosquitto to Coolify's external `coolify` network and
+   defines the TCP router; it does not publish a broker port itself.
+4. Open **Servers → your server → Proxy → Configuration**. Preserve the existing
+   proxy configuration and add host port 8883 plus the static MQTT entrypoint:
+
+   ```yaml
+   ports:
+     - "8883:8883"
+
+   command:
+     - "--entrypoints.mqtts.address=:8883"
+   ```
+
+   Merge these entries into the existing `ports` and `command` lists rather
+   than replacing Coolify's HTTP/HTTPS settings.
+5. Confirm that the proxy's ACME resolver is named `letsencrypt`, as referenced
+   by the override. If the server uses a differently named resolver, update the
+   `tls.certresolver` label to that existing name.
+6. Restart the Coolify proxy, deploy the Open Locker resource, and allow
+   inbound TCP 8883 in the provider firewall/security group. Do not add a
+   `1883:1883` mapping in Coolify's port UI.
+
+The MQTT hostname must match the `HostSNI` rule and certificate SAN exactly.
+Coolify's normal HTTP domain route alone does not create a raw TCP MQTT route.
+Traefik is configured to obtain and renew the certificate; Mosquitto does not
+receive or mount the private key. The repository can validate the rendered
+Compose model, but successful routing, ACME issuance, and renewal must still be
+verified on the target Coolify v4 server.
+
+Official references:
+
+- [Coolify Docker Compose applications](https://coolify.io/docs/applications/build-packs/docker-compose)
+- [Coolify custom infrastructure overrides](https://coolify.io/docs/knowledge-base/custom-compose-overrides)
+
+After backend updates, restart long-running queue workers. This is mandatory for
+the credential issuance migration described in PR #227.
+
+### 4. Verify MQTT TLS
+
+From a machine outside the Docker host, verify the certificate chain and
+hostname:
 
 ```bash
-docker compose exec app php artisan filament:user
+export MQTT_DOMAIN=mqtt.example.com
+openssl s_client \
+  -connect "${MQTT_DOMAIN}:8883" \
+  -servername "${MQTT_DOMAIN}" \
+  -verify_hostname "${MQTT_DOMAIN}" \
+  -verify_return_error </dev/null
 ```
 
-You can now access the Admin Panel at `https://your-domain.com/admin`.
+Then use valid backend MQTT credentials to verify an authenticated round trip:
 
----
+```bash
+mosquitto_sub \
+  -h "${MQTT_DOMAIN}" -p 8883 --capath /etc/ssl/certs \
+  -u "<backend-mqtt-user>" -P "<backend-mqtt-password>" \
+  -t "smoke/mqtt-tls" -C 1 &
+mosquitto_pub \
+  -h "${MQTT_DOMAIN}" -p 8883 --capath /etc/ssl/certs \
+  -u "<backend-mqtt-user>" -P "<backend-mqtt-password>" \
+  -t "smoke/mqtt-tls" -m "ok"
+```
 
-## Locker Client Setup (Raspberry Pi)
+Repeat with a restricted device or provisioning identity and a topic outside
+its documented ACL; the broker must reject it. Finally, confirm that plaintext
+MQTT is not externally reachable:
 
-> 🚧 **Work in Progress**: The dedicated Locker Client application is currently under development.
-> Detailed setup instructions and the client software package will follow in an upcoming release.
->
-> Currently, the hardware integration logic resides within the backend codebase for testing purposes.
+```bash
+nc -vz "${MQTT_DOMAIN}" 1883
+```
 
-The Raspberry Pi serves as the local controller for the lockers. It connects to
-the Cloud Backend via MQTT and controls the hardware via Modbus.
+For final acceptance, that command must fail. During the staged migration it
+will still succeed by design, so record the MQTTS checks but do not close the
+release gate until the migration overlay or legacy Coolify mapping is removed.
+Also verify provisioning, heartbeat, a supervised open command, response, and
+state update from a real client using `mqtts://${MQTT_DOMAIN}:8883`. HTTPS health
+does not substitute for this TCP/TLS test.
+
+### 5. Migrate existing plaintext clients
+
+For a new deployment, skip this section and never expose port 1883. For an
+existing deployment whose clients still use remote plaintext MQTT, use this
+ordered, time-limited migration:
+
+1. For standalone Compose, set `MQTT_MIGRATION_BIND_ADDRESS` to the server
+   address currently used by old clients and add
+   `docker-compose.prod.mqtt-migration.yml` to the command. For an existing
+   Coolify resource that already publishes 1883, leave that legacy mapping
+   unchanged during steps 2 and 3; do not add it to a resource where it is
+   already absent.
+2. Deploy and verify MQTTS on 8883 while the old clients remain connected.
+3. Upgrade every production locker client to an image that requires `mqtts://`
+   and configure `MQTT_BROKER_URL=mqtts://mqtt.example.com:8883`.
+4. Redeploy without the migration overlay, unset
+   `MQTT_MIGRATION_BIND_ADDRESS`, and verify externally that port 1883 fails.
+
+Do not use this overlay for a new deployment or leave it enabled as a fallback.
+After migration, deploy the repository-owned Coolify Compose definition; that
+coordinated cutover removes the legacy mapping. Repository validation does not
+prove that the target host firewall or Coolify proxy behaves correctly; verify
+both ports externally.
+
+### 6. Create the first administrator
+
+Configure `ADMIN_EMAIL` before the first deployment, or run:
+
+```bash
+docker compose exec app php artisan first-admin:create admin@example.com
+```
+
+Mail delivery must work so the administrator can set a password. The Filament 5
+admin panel is available under `/admin` on the configured backend URL.
+
+## Locker client setup (Raspberry Pi)
 
 ### Prerequisites
 
-- Raspberry Pi 3/4/5 or Zero 2 W
-- Raspberry Pi OS Lite (64-bit recommended)
-- Docker & Docker Compose installed
-- Recommended hardware BOM: [Bill of Materials](Bill-of-Materials.md)
+- Raspberry Pi 3/4/5 or Zero 2 W with 64-bit Raspberry Pi OS
+- Docker with the Compose plugin
+- supported USB/RS485 connection and Waveshare relay hardware
+- recommended hardware from the [Bill of Materials](Bill-of-Materials.md)
+- a one-time provisioning token issued from the backend admin panel
 
-### 1. Setup
-
-Clone the repository on the Pi:
+### 1. Prepare files
 
 ```bash
-git clone https://github.com/Open-Locker/Open-Locker.git
-cd Open-Locker/locker-client  # (Assuming client code path)
+cd locker-client
+cp .env.example .env
+mkdir -p config data
+chmod 700 data
+cp locker-config.yml.example config/locker-config.yml
 ```
 
-*(Note: If you are using the mono-repo, navigate to the appropriate client directory)*
+Set `LOCKER_CLIENT_IMAGE_TAG` to the verified immutable beta image tag. Set the
+one-time `PROVISIONING_TOKEN`, bootstrap MQTT credentials, and
+`MQTT_BROKER_URL=mqtts://<mqtt-domain>:8883` in `.env`. The client uses the
+operating-system CA store and always validates the certificate chain and
+hostname for `mqtts://` connections. A private or self-signed CA is not supported
+by the production reference deployment.
 
-### 2. Configuration
+The token is shown only once. If it is lost or consumed before provisioning
+finishes, restart provisioning in the admin panel and use the new token.
 
-Create a `.env` file for the client:
+### 2. Configure Modbus RTU
 
-```env
-MQTT_BROKER_HOST=your-cloud-backend.com
-MQTT_BROKER_PORT=1883
-MQTT_USERNAME=provisioning_client  # Initial provisioning user
-MQTT_PASSWORD=your_provisioning_password
-LOCKER_ID=unique-locker-id
+Edit `config/locker-config.yml`:
+
+```yaml
+modbus:
+  port: /dev/ttyACM0
+  baudRate: 9600
+  dataBits: 8
+  stopBits: 1
+  parity: none
+  timeout: 1000
+  flashDurationMs: 200
 ```
 
-### 3. Modbus Hardware Configuration
+Map the same serial device in `locker-client/docker-compose.yml`. The client
+supports the Modbus RTU/Waveshare path; the old backend Modbus integration and
+the previous environment-based TCP/RTU examples do not describe the current
+architecture. Compartment mapping is delivered later by the backend through
+MQTT `apply_config` and persisted in `/data`.
 
-Configure the hardware interface in `.env` depending on your connection type:
-
-**Option A: Modbus TCP (Networked)**
-```env
-MODBUS_DRIVER=tcp
-MODBUS_TCP_IP=192.168.1.100
-MODBUS_TCP_PORT=502
-```
-
-**Option B: Modbus RTU (USB/Serial)**
-```env
-MODBUS_DRIVER=rtu
-MODBUS_RTU_DEVICE=/dev/ttyUSB0
-MODBUS_RTU_BAUD=9600
-MODBUS_RTU_PARITY=N
-MODBUS_RTU_DATA_BITS=8
-MODBUS_RTU_STOP_BITS=1
-```
-
-### 4. Start Client
+### 3. Start and verify
 
 ```bash
 docker compose up -d
+docker compose logs -f locker-client
 ```
 
-The client will connect to the Cloud Backend, authenticate, and listen for commands.
+Verify the running image digest, successful provisioning/MQTT connection,
+heartbeat, runtime configuration, Modbus reachability, and a supervised
+compartment snapshot/open cycle. Keep `config/` and `/data` backed up and
+private. Do not delete identity, credential, runtime-overlay, or dedup files as
+a routine recovery step.
+
+During PR #227's credential rollout, update the client before re-provisioning
+any bank. Existing legacy credentials continue to work until deliberate
+re-provisioning.
+
+## Mobile app setup
+
+Install and check the Expo application with pnpm:
+
+```bash
+cd mobile-app
+pnpm install
+pnpm check
+pnpm test:ci
+pnpm start
+```
+
+The generated RTK Query client comes from the live backend OpenAPI document:
+
+```bash
+pnpm generate:api
+```
+
+Run that command with the backend available at `EXPO_PUBLIC_API_BASE_URL` after
+an API contract change. Beta distribution uses TestFlight for iOS and the
+configured Android beta/internal track; versioned mobile releases use
+`mobile-v*` tags. Store rollout and rollback follow the release checklist rather
+than the Docker deployment process.

--- a/docs/Locker-as-a-service.md
+++ b/docs/Locker-as-a-service.md
@@ -5,7 +5,7 @@ The idea is to have a central service so the users do not have to configure it. 
 - [Locker as a service](#locker-as-a-service)
   - [Hosting](#hosting)
   - [Services](#services)
-    - [Traeffik Reverse Proxy](#traeffik-reverse-proxy)
+    - [Traefik Reverse Proxy](#traefik-reverse-proxy)
     - [Mosquitto](#mosquitto)
     - [Locker Client](#locker-client)
       - [Registration process](#registration-process)
@@ -31,13 +31,31 @@ We need to setup a domain and book a server. The server needs a docker installat
   * Report state
   * Setup Guide
 
-### Traeffik Reverse Proxy
+### Traefik Reverse Proxy
 
-Setup a traeffik Reverse Proxy for SSL Certificate termination and to have a single entrypoint.
+Production uses Traefik as the public TLS boundary:
+
+- HTTPS is exposed on TCP 443 for the API, admin panel, and Reverb.
+- MQTTS is exposed on TCP 8883 for locker clients.
+- Traefik terminates both TLS protocols and manages certificates through ACME.
+- Laravel remains on HTTP 8080 and Mosquitto remains on MQTT 1883 inside the
+  private Docker network.
+
+Normal production deployments do not publish port 1883. An existing fleet may
+retain it only through the explicit, time-limited migration overlay while MQTTS
+is brought up and clients are migrated; it is removed immediately afterward.
+Coolify uses its managed Traefik proxy; the standalone Docker reference starts
+Traefik through a Compose overlay. See
+[ADR-0053](adr/0053-terminate-public-mqtt-tls-at-traefik.md) and the
+[installation guide](Installation.md) for both deployment procedures.
 
 ### Mosquitto
 
-Deploy a Mosquitto Mqtt broker used  to communicate with the lockers.
+Mosquitto provides username/password authentication and topic ACLs through the
+Laravel HTTP auth backend. It accepts plaintext MQTT only on the private Docker
+network because public transport security is enforced by Traefik. Locker
+clients connect to `mqtts://<mqtt-domain>:8883` and validate the public
+certificate and hostname.
 
 ### Locker Client
 

--- a/docs/adr/0053-terminate-public-mqtt-tls-at-traefik.md
+++ b/docs/adr/0053-terminate-public-mqtt-tls-at-traefik.md
@@ -1,0 +1,152 @@
+# ADR-0053: Terminate public MQTT TLS at Traefik
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-23
+
+## Context
+
+Production Compose currently publishes Mosquitto's plaintext listener on host
+port 1883. Locker clients therefore send MQTT credentials, commands, and state
+without transport encryption. An HTTP reverse-proxy route does not protect raw
+MQTT traffic.
+
+Open Locker supports two deployment models:
+
+1. Coolify, using Coolify's managed Traefik proxy.
+2. Plain Docker Compose, using a repository-maintained Traefik overlay.
+
+Both models need the same public contract while preserving simple,
+container-local communication between Laravel and Mosquitto:
+
+- public HTTPS on port 443;
+- public MQTTS on port 8883;
+- internal Laravel HTTP on port 8080;
+- internal plaintext MQTT on port 1883.
+
+## Decision
+
+1. Traefik terminates TLS for public HTTP and MQTT connections in both supported
+   deployment models.
+2. Mosquitto listens on plaintext port 1883 inside the Compose network only.
+   Production Compose must not publish that port on the host.
+3. The MQTTS router listens on public TCP port 8883, selects the broker by
+   `HostSNI`, terminates TLS with an ACME-managed certificate, and forwards
+   plaintext MQTT to `mqtt:1883` over the private Docker network.
+4. Coolify deployments use Coolify's managed Traefik instance with an explicit
+   TCP entrypoint and router. Plain-Docker deployments use the maintained
+   Traefik Compose overlay.
+5. Production locker clients use `mqtts://<mqtt-host>:8883` and verify the
+   certificate chain and hostname against their operating-system trust store.
+   No option to disable certificate verification is provided.
+6. Backend containers continue to use `mqtt:1883` because that connection never
+   leaves the private Compose network.
+7. Client certificates are not required. Existing MQTT username/password
+   authentication and HTTP-backed ACL checks remain authoritative.
+
+## Rationale
+
+Using the same TLS boundary in both deployment models keeps the external
+contract and certificate lifecycle consistent. Traefik already manages HTTPS
+certificates in Coolify and can also manage certificates in the standalone
+reference stack. Mosquitto therefore does not need access to private keys or a
+separate renewal process.
+
+Keeping the backend-to-broker connection internal avoids unnecessary TLS
+configuration without exposing plaintext traffic on the host.
+
+## Alternatives Considered
+
+### Alternative A: Terminate TLS directly in Mosquitto
+
+- Pros: direct host port mapping; no TCP router is required.
+- Cons: Mosquitto needs mounted private keys and a separate certificate renewal
+  and reload process in both deployment models.
+- Why not chosen: it duplicates certificate ownership already provided by
+  Traefik and makes Coolify and standalone operations less consistent.
+
+### Alternative B: Publish plaintext MQTT on port 1883
+
+- Pros: no proxy or certificate configuration.
+- Cons: exposes credentials and locker commands in plaintext.
+- Why not chosen: it does not meet the production security boundary.
+
+### Alternative C: Encrypt backend-to-broker traffic as well
+
+- Pros: encryption also exists inside the Compose network.
+- Cons: adds certificate trust and rotation to every backend worker without
+  reducing the public exposure addressed by this decision.
+- Why not chosen: the internal Docker network is the accepted trust boundary.
+
+## Consequences
+
+### Positive
+
+- Public MQTT credentials and payloads are encrypted in transit.
+- Port 1883 is not reachable from outside the production Docker network.
+- Coolify and standalone deployments share one external MQTT contract.
+- ACME issuance and renewal remain owned by the edge proxy.
+
+### Negative
+
+- Operators must configure a TCP entrypoint and router in addition to normal
+  HTTP routes.
+- Traefik-to-Mosquitto traffic is plaintext inside the Docker network.
+- MQTTS depends on correct DNS, SNI, firewall, and ACME configuration.
+- A staged migration temporarily retains the pre-existing plaintext endpoint
+  for old clients. The standalone migration overlay is opt-in, requires an
+  explicit bind address, and must be removed immediately after client migration.
+
+### Risks
+
+- Mapping host port 8883 directly to Mosquitto port 1883 would expose plaintext
+  MQTT under a misleading port number. Mitigation: only Traefik publishes 8883.
+- A missing TCP router may leave clients unable to connect while HTTPS remains
+  healthy. Mitigation: require a separate MQTTS smoke test.
+- A proxy attached to the wrong Docker network cannot reach Mosquitto.
+  Mitigation: document and verify the shared network in both deployment paths.
+- The standalone Docker provider reads the Docker socket, which is a privileged
+  control-plane boundary. Mitigation: mount it read-only, disable automatic
+  exposure, and run only trusted containers on the host.
+
+## Rollout / Migration
+
+1. If existing remote clients still require plaintext MQTT, retain the old
+   endpoint only for the migration window. Standalone Compose uses the
+   explicitly selected `docker-compose.prod.mqtt-migration.yml` overlay with
+   `MQTT_MIGRATION_BIND_ADDRESS` set to the address used by those clients.
+   Existing Coolify deployments leave an already-present legacy mapping
+   unchanged; they do not add one when it is already absent. Normal production
+   configuration publishes no port 1883.
+2. Add the MQTTS TCP entrypoint, router, DNS record, and ACME certificate while
+   existing clients still use the temporary old endpoint.
+3. Verify certificate validation, authentication, ACL behavior, and command
+   flow through port 8883.
+4. Deploy locker clients configured with the MQTTS URL.
+5. Remove the legacy endpoint: standalone redeploys without
+   `docker-compose.prod.mqtt-migration.yml` and unsets
+   `MQTT_MIGRATION_BIND_ADDRESS`; Coolify deploys the repository-owned Compose
+   definition without its old mapping. Verify that port 1883 is no longer
+   externally reachable.
+6. Keep this ADR proposed until both deployment paths have passed the documented
+   smoke test.
+
+## Supersedes / Superseded By
+
+- Supersedes: none.
+- Related: [ADR-0014](0014-mqtt-session-and-reconnect-policy.md) defines MQTT
+  session behavior; [ADR-0050](0050-per-provisioning-mqtt-credential-identities.md)
+  defines MQTT credential identities.
+
+## References
+
+- Related issues: #163
+- Related docs: [Installation](../Installation.md),
+  [AsyncAPI MQTT contract](../asyncapi/mqtt.yaml)
+- External references:
+  [Traefik TCP TLS](https://doc.traefik.io/traefik/reference/routing-configuration/tcp/tls/),
+  [Traefik Docker routing](https://doc.traefik.io/traefik/reference/routing-configuration/other-providers/docker/)

--- a/docs/asyncapi/mqtt.yaml
+++ b/docs/asyncapi/mqtt.yaml
@@ -10,6 +10,12 @@ servers:
     host: localhost:1883
     protocol: mqtt
     description: Example local MQTT broker used for development.
+  productionBroker:
+    host: open-locker.cloud:8883
+    protocol: mqtts
+    description: >-
+      Production MQTT broker behind the TLS-terminating edge proxy. Clients
+      must validate the certificate chain and open-locker.cloud hostname.
 channels:
   lockerCommand:
     address: locker/{locker_uuid}/command

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,10 +6,9 @@ stop/rollback decision. It is not approval for an unrestricted production
 rollout.
 
 Use this checklist with the
-[beta rollback runbook](releases/beta-rollback.md). The operational decision is
-recorded in
-[ADR-0052](adr/0052-controlled-beta-release-and-rollback.md); component tags
-follow [ADR-0043](adr/0043-monorepo-release-strategy.md).
+[beta rollback runbook](releases/beta-rollback.md). The operational rollout is
+tracked in [issue #209](https://github.com/Open-Locker/Open-Locker/issues/209);
+component tags follow [ADR-0043](adr/0043-monorepo-release-strategy.md).
 
 ## Release record
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,200 @@
+# Beta Release Checklist
+
+Open Locker has **no production deployment yet**. This beta is a controlled
+pre-production pilot with named testers, selected Raspberry Pis, and an explicit
+stop/rollback decision. It is not approval for an unrestricted production
+rollout.
+
+Use this checklist with the
+[beta rollback runbook](releases/beta-rollback.md). The operational decision is
+recorded in
+[ADR-0052](adr/0052-controlled-beta-release-and-rollback.md); component tags
+follow [ADR-0043](adr/0043-monorepo-release-strategy.md).
+
+## Release record
+
+- [ ] Release owner:
+- [ ] Backend operator:
+- [ ] Pi/client operator:
+- [ ] Mobile operator:
+- [ ] Pilot site and tester group:
+- [ ] Planned start, decision time, and monitoring window:
+- [ ] Previous tags: `backend-v________`, `client-v________`,
+      `mobile-v________`
+- [ ] Candidate tags: `backend-v________`, `client-v________`,
+      `mobile-v________`
+- [ ] Database backup identifier and timestamp:
+- [ ] Pi configuration and `/data` backup location:
+
+## 1. Hard gates
+
+Do not synchronize `dev` to `main`, create release tags, submit store builds, or
+re-provision a locker until every hard gate is closed and verified.
+
+- [ ] #50 — per-component release workflows and notes are operational with
+      `backend-v*`, `client-v*`, and `mobile-v*`.
+- [ ] #134 — stale `open_compartment` commands have an accepted and tested age
+      policy; delayed commands cannot unexpectedly open a door.
+- [ ] #163 — MQTTS is verified end to end through the selected production
+      Traefik adapter, and plaintext port 1883 is confirmed unreachable from
+      outside the Docker network.
+- [ ] #169 — the Raspberry Pi soak test has completed for the agreed duration
+      with recorded logs, resource use, reconnect behavior, and hardware result.
+- [ ] #209 — the beta scope and release-readiness issue is closed or has explicit
+      release-owner acceptance with no unresolved blocker.
+- [ ] #67 — complete the Beta task and record its outcome. It is required Beta
+      work even though it is tracked separately from the hard-gate list above.
+
+## 2. Candidate and branch preparation
+
+- [ ] Confirm all intended changes are integrated and reviewed on `dev`.
+- [ ] Confirm no open Beta change is represented as shipped merely because it
+      exists in a pull request.
+- [ ] Run the complete component checks on the exact candidate commit:
+  - [ ] Backend: `cd locker-backend && composer quality`
+  - [ ] Locker client: `cd locker-client && pnpm check && pnpm test`
+  - [ ] Mobile: `cd mobile-app && pnpm check && pnpm test:ci`
+  - [ ] MQTT contract CI and any cross-component integration checks pass.
+- [ ] Regenerate and verify the mobile API client from the live candidate
+      backend when the OpenAPI contract changed.
+- [ ] Review API, MQTT, schema, and migration compatibility in the release
+      notes, including minimum supported component versions.
+- [ ] Merge `dev` into `main` through the normal reviewed synchronization path.
+- [ ] Verify `main` contains the exact candidate and rerun required protected
+      branch checks. Merging to `main` is not itself a release.
+
+## 3. Version and artifact preparation
+
+- [ ] Choose independent SemVer prerelease tags only for changed components, for
+      example `backend-v1.0.0-beta.1`, `client-v1.0.0-beta.1`, and
+      `mobile-v1.0.0-beta.1`.
+- [ ] Confirm each tag will point to the intended commit on `main`.
+- [ ] Confirm non-`main` and manual workflow runs cannot overwrite `latest` or
+      mint a SemVer release.
+- [ ] Create each required component tag using the approved release process.
+- [ ] Verify each generated release contains component-scoped notes, contract
+      changes, migration instructions, known risks, and rollback tags.
+- [ ] Backend image exists under the immutable version tag and reports that
+      version from `GET /api/identify`.
+- [ ] Client multi-architecture image exists under the immutable version tag,
+      has the expected digest, and is pullable on the target Pi architecture.
+- [ ] Mobile artifacts identify the intended version/build and originated from
+      the tagged or approved `main` release path.
+- [ ] Record immutable tags and image digests. Do not deploy `latest` to the beta
+      pilot.
+
+## 4. Backups and rollback readiness
+
+- [ ] Take a database backup immediately before rollout; record its timestamp,
+      size, storage location, and readability/restore verification.
+- [ ] Review migrations for old-backend/new-schema compatibility.
+- [ ] State whether backend code rollback is safe without schema rollback.
+- [ ] If restore might be required, state the maximum accepted data-loss window
+      and who may authorize it. Restore remains the last resort.
+- [ ] Back up Pi `config/` and `/data` without changing permissions or deleting
+      client identity, credentials, runtime overlay, or dedup state.
+- [ ] Confirm previous immutable component tags remain pullable/installable.
+- [ ] Review and assign every step in the
+      [beta rollback runbook](releases/beta-rollback.md).
+
+## 5. MQTT credential rollout (PR #227)
+
+The order is mandatory. Existing legacy credentials continue to work until a
+bank is deliberately re-provisioned.
+
+- [ ] Deploy the compatible `client-v*` image to every pilot Pi first and verify
+      it persists `lockerUuid` separately from the opaque MQTT username.
+- [ ] Do **not** reset or re-provision any locker bank before the compatible
+      client is confirmed.
+- [ ] Deploy the backend image and database migration that add identity mapping,
+      revocation metadata, and the updated provisioning reply.
+- [ ] Restart all queue workers after the backend deployment; queued reactors
+      must not continue running old credential-issuance code.
+- [ ] Verify legacy credentials still authenticate and remain scoped to their
+      own locker topics.
+- [ ] Re-provision only the designated pilot bank, then verify one enabled
+      identity, a new opaque username, correct locker UUID topics, and denial of
+      the revoked identity.
+- [ ] Do not delete or reuse revoked identity rows.
+
+## 6. Modbus acceptance (PR #228)
+
+- [ ] Record the exact Pi, USB/serial adapter, Waveshare board, port, and client
+      tag used for acceptance.
+- [ ] Confirm startup completes safely when the bus is temporarily unavailable
+      and does not energize a relay.
+- [ ] Unplug the adapter long enough to exhaust a reconnect cycle; verify the bus
+      becomes unreachable without a process restart loop.
+- [ ] Reconnect the adapter; verify polling initiates a later reconnect cycle and
+      returns to connected without operator restart.
+- [ ] Confirm observed serial error codes match the reconnectable classification
+      assumed by PR #228 and
+      [ADR-0051](adr/0051-modbus-reconnect-declares-an-unreachable-bus.md). Any
+      unclassified real-device error blocks acceptance.
+- [ ] Verify heartbeat/admin hardware status, serialized Modbus operations,
+      Waveshare hardware-flash pulse limits, and one supervised open cycle.
+- [ ] Attach this evidence to the #169 Pi soak result.
+
+## 7. Pre-production deployment and smoke tests
+
+- [ ] Deploy the pinned backend tag, run migrations, and restart long-running
+      services and queue workers.
+- [ ] Verify backend health, database, Redis, scheduler, queue/event workers,
+      Reverb, MQTT listener, and admin sign-in.
+- [ ] Perform an external MQTTS smoke test using the deployed certificate trust
+      path: connect, authenticate, publish/subscribe only to authorized topics,
+      and verify a deliberately unauthorized topic is denied.
+- [ ] Confirm plaintext MQTT is not accidentally exposed where #163's accepted
+      beta design forbids it.
+- [ ] Deploy the pinned client tag to the selected Pi and verify image digest,
+      online heartbeat, Modbus reachability, retained compartment snapshot, and
+      stable reconnect behavior.
+- [ ] Complete the core flow with a supervised locker: sign in, list accessible
+      compartments, request open, observe one hardware pulse, and receive the
+      live door-state update.
+- [ ] Verify command deduplication by the approved non-actuating test method; do
+      not intentionally cause a second physical pulse.
+- [ ] Verify content notes, audit/event history, and admin operational views.
+
+## 8. Mobile beta distribution
+
+- [ ] Verify the candidate against the beta backend on physical iOS and Android
+      devices before submission.
+- [ ] Submit the approved `mobile-v*` build to TestFlight and the configured
+      Android Beta/internal testing track from the release path.
+- [ ] Confirm the Android artifact and track are appropriate for the named pilot;
+      an internal APK is not automatically an external beta programme.
+- [ ] Restrict access to the named pilot tester group.
+- [ ] On both platforms verify sign-in, terms, compartment list, open request,
+      live door state, content notes, session expiry, and displayed backend
+      identity/version.
+- [ ] Record store processing status and the known-good build that testers can
+      use if distribution is paused.
+
+## 9. Go/no-go and release notes
+
+- [ ] Release notes state that this is a controlled pre-production beta and that
+      no production deployment currently exists.
+- [ ] Notes list all component tags/digests, schema and contract changes,
+      PR #227 credential ordering, PR #228 Modbus acceptance evidence, known
+      issues, upgrade steps, and rollback targets.
+- [ ] The release owner reviews hard gates, soak evidence, backups, artifact
+      evidence, and smoke-test results.
+- [ ] Record one decision: **continue**, **pause**, or **roll back**, with owner,
+      time, rationale, and affected versions.
+
+## 10. Post-release monitoring
+
+- [ ] Monitor API errors and latency, queue failures/depth, MQTT auth/ACL denials,
+      reconnects, duplicate commands, Reverb delivery, and database health.
+- [ ] Monitor Pi CPU, memory, disk, container restarts, MQTT stability, Modbus
+      reconnect cycles, heartbeat freshness, and relay/door anomalies.
+- [ ] Monitor mobile crashes, sign-in failures, open-flow failures, and tester
+      feedback on both platforms.
+- [ ] Check at the agreed early interval, after 24 hours, and at the end of the
+      pilot observation window.
+- [ ] Stop expansion immediately for a security boundary failure, data
+      corruption, unexpected door actuation, repeated stuck relay, credential
+      cross-access, or loss of the core open/status flow.
+- [ ] Close the pilot only after monitoring evidence and follow-up actions are
+      recorded; otherwise keep it paused or execute the rollback runbook.

--- a/docs/releases/beta-rollback.md
+++ b/docs/releases/beta-rollback.md
@@ -1,0 +1,127 @@
+# Beta Rollback Runbook
+
+This runbook applies to the controlled pre-production beta pilot. Open Locker
+does not currently have a production deployment. The policy behind this runbook
+is proposed in
+[ADR-0052](../adr/0052-controlled-beta-release-and-rollback.md).
+
+## Before rollout
+
+- Name one release owner with authority to continue, pause, or roll back, plus
+  an operator for each affected component.
+- Record the deployed `backend-v*`, `client-v*`, and `mobile-v*` tags and the
+  intended rollback tags. Never use `latest` as either release evidence or a
+  rollback target.
+- Take a database backup, record its timestamp, and verify that it can be read.
+- Review every migration for backward compatibility with the rollback backend.
+  If old code cannot run against the migrated schema, require a forward fix or a
+  tested migration-down/restore plan before proceeding.
+- Back up each Pi's operator-managed configuration and persistent `/data`
+  directory. Do not delete credential, client-ID, runtime-overlay, or dedup state
+  as a routine rollback action.
+- Define the smoke-test evidence, observation window, and decision time in the
+  [beta release checklist](../release-checklist.md).
+
+## Decision point
+
+The release owner chooses one of three outcomes after the deployment smoke tests:
+
+1. **Continue** when the API, MQTTS, Modbus, mobile, and core locker-open flow
+   pass and no stop condition is active.
+2. **Pause** when impact is contained and more evidence can be gathered without
+   exposing additional testers or lockers.
+3. **Roll back** when security, data integrity, credential isolation, physical
+   lock safety, or the core open/status flow fails.
+
+Record the decision, owner, time, failing check, affected component versions,
+and selected recovery path.
+
+## Backend rollback
+
+1. Stop further rollout and suspend writes if migration or data integrity is in
+   doubt.
+2. Confirm whether the previous backend tag supports the current database
+   schema.
+3. If compatible, deploy the previous immutable `backend-v*` tag.
+4. Restart the queue and event workers so no process continues running code from
+   the failed release. Restart the MQTT listener or other long-running backend
+   services when their image changed.
+5. Run the API, worker, MQTT command/response, and admin smoke tests.
+6. If the schema is incompatible, prefer a tested forward fix or reversible
+   migration. Restore the database only as a last resort.
+
+For a restore, the release owner must explicitly approve the data-loss window
+from the backup timestamp through the write freeze. Keep writes stopped, archive
+the failed database state for diagnosis, restore the verified backup, deploy its
+compatible backend tag, restart workers, and repeat all smoke tests.
+
+## Locker-client rollback
+
+1. Stop automatic updates for the affected pilot Pi and pin the previous
+   immutable `client-v*` image tag.
+2. Preserve `config/` and `/data`; do not trigger re-provisioning merely to roll
+   code back.
+3. Redeploy the client and verify the running image/tag, MQTT connection,
+   heartbeat, Modbus reachability, compartment snapshot, and one supervised
+   open/door-state cycle.
+4. Resume automatic updates only after the intended channel is known to point at
+   an approved immutable version.
+
+PR #227 constrains rollback as well as rollout: a compatible client must be
+deployed before any bank receives a new opaque MQTT identity. Existing legacy
+credentials remain valid until deliberate re-provisioning. Do not delete or
+reuse revoked identities. If the backend issuance path was deployed, restart
+queue workers after any backend version change and verify that one bank has at
+most one enabled identity.
+
+## MQTT edge and TLS rollback
+
+1. Do not restore public plaintext port 1883 as a routine rollback. Keep the
+   MQTTS endpoint and certificate trust boundary in place when rolling back only
+   backend or client code.
+2. If a Traefik or certificate change caused the incident, pause client rollout,
+   restore the previous known-good edge configuration, and verify DNS, SNI, the
+   certificate chain and hostname, ACME resolver state, and TCP routing from
+   8883 to the private broker port 1883.
+3. For Coolify, restore the previously recorded proxy configuration and
+   Git-based Docker Compose resource revision. For standalone Compose, restore
+   the previously tested Traefik overlay and pinned image configuration.
+4. Use the temporary plaintext migration overlay only when it was already part
+   of the approved migration window and the release owner explicitly accepts
+   the exposure. Set its bind address explicitly, keep the provider firewall
+   scope as narrow as the old clients permit, record the removal deadline, and
+   remove it immediately after recovery.
+5. From outside the host, repeat certificate verification and an authenticated,
+   ACL-scoped MQTT round trip. Confirm port 1883 is unreachable before declaring
+   rollback complete.
+
+## Mobile rollback
+
+- Stop or restrict TestFlight and Android beta distribution immediately.
+- If the store still offers a known-good build to testers, direct the pilot
+  group to that build and verify its backend compatibility.
+- Installed mobile builds cannot be remotely replaced atomically. If downgrade
+  is unavailable or unsafe, ship a forward fix under a new `mobile-v*` tag.
+- Keep the backend compatible with the affected mobile versions during the
+  transition; do not assume every tester updates at once.
+- Repeat sign-in, compartment listing, open request, live door state, and content
+  note checks on both iOS and Android before reopening distribution.
+
+## Recovery verification
+
+Do not declare rollback complete until all applicable checks pass:
+
+- backend health and identity endpoints respond with the expected version;
+- queue workers, event worker, scheduler, Reverb, and MQTT listener are healthy;
+- an MQTTS client authenticates with the deployed trust configuration and
+  plaintext MQTT is not accidentally accepted where the beta policy forbids it;
+- the Pi reports online with Modbus reachable, publishes a compartment snapshot,
+  and completes one supervised open/door-state cycle;
+- revoked MQTT credentials are denied and current credentials remain scoped to
+  their locker bank;
+- TestFlight and Android beta builds complete the mobile core loop;
+- logs show no repeated queue failures, reconnect loop, stuck relay, duplicate
+  command execution, or unexpected credential issuance.
+
+Continue heightened monitoring for the observation window recorded in the
+checklist. The release owner closes the incident or keeps the pilot paused.

--- a/docs/releases/beta-rollback.md
+++ b/docs/releases/beta-rollback.md
@@ -2,8 +2,8 @@
 
 This runbook applies to the controlled pre-production beta pilot. Open Locker
 does not currently have a production deployment. The policy behind this runbook
-is proposed in
-[ADR-0052](../adr/0052-controlled-beta-release-and-rollback.md).
+is tracked in
+[issue #209](https://github.com/Open-Locker/Open-Locker/issues/209).
 
 ## Before rollout
 

--- a/docs/releases/beta.md
+++ b/docs/releases/beta.md
@@ -412,7 +412,7 @@ not feature inventory alone.
 - Monorepo release strategy — `#50` (ADR-0043)
 - [Beta release checklist](../release-checklist.md)
 - [Beta rollback runbook](beta-rollback.md)
-- [ADR-0052: Controlled beta release and rollback](../adr/0052-controlled-beta-release-and-rollback.md)
+- [Controlled beta rollout tracking — issue #209](https://github.com/Open-Locker/Open-Locker/issues/209)
 - ADR-0032 — mobile internal test builds
 - ADR-0036 — website in the monorepo
 - Milestones: *Milestone 1 – Hardware MVP*, *Milestone 2 – Internal MVP*,

--- a/docs/releases/beta.md
+++ b/docs/releases/beta.md
@@ -6,6 +6,12 @@
 
 ## Beta goal
 
+Open Locker has no production deployment. This Beta is a **controlled
+pre-production pilot**, not a production launch or an unrestricted public
+rollout. Execution is governed by the
+[Beta release checklist](../release-checklist.md) and
+[Beta rollback runbook](beta-rollback.md).
+
 The goal of this Beta is to exercise the **core loop** end-to-end — authenticate, see
 accessible compartments, open one, and watch door state update live — and to establish a
 **baseline for collecting user feedback**. Feature completeness beyond that loop is
@@ -13,19 +19,19 @@ secondary; field hardening and release mechanics are what make the exercise trus
 
 ## Highlights (TL;DR)
 
-- First tagged release of the monorepo (no prior tags or GitHub Releases).
+- Planned first tagged release of the monorepo under component-specific tags.
 - Core loop: sign in → list accessible compartments → open → live door state + content notes.
 - Event-sourced compartment domain with auditable content notes (Item domain removed).
 - Capability-based roles (incl. manager), group access, terms gate, EN/DE in app and admin.
 - Canonical MQTT contract; locker-client v2 on Pi with Modbus, recovery, and fleet simulator.
 - Mobile app on Expo with RTK Query codegen and Reverb realtime.
 - Filament v5 ops-oriented admin: users, groups, compartments, open requests, audit log.
-- Beta cut assumes open PRs listed below are merged first (stacked chain + related work).
+- The Beta cut requires every hard gate in the release checklist to be closed.
 
 ## Scope
 
-Nothing has ever been tagged or released — the repository has zero tags and zero GitHub
-Releases — so the Beta is the **first release**. This document therefore has two parts:
+This Beta is intended to be the first coordinated component-tagged release. This
+document therefore has two parts:
 
 1. **Feature list** — what the system does at Beta, by component. This is the
    "what do we have" answer.
@@ -37,10 +43,10 @@ form of this is generated per component into the GitHub Release attached to each
 (`backend-vX.Y.Z`, `client-vX.Y.Z`, `mobile-vX.Y.Z`). This file is the one-off Beta list;
 it is not a committed rolling `CHANGELOG.md`.
 
-**Verification basis:** a feature counts as done if its code is merged into `dev` **or**
-sits in an open pull request intended for the Beta cut. Work that exists only as an issue
-is out of scope. Open PRs remain in the feature list below; cutting Beta assumes those
-PRs (notably the stacked chain in §3) have merged.
+**Verification basis:** a feature counts as done only when its code is merged into
+`dev` and passes the relevant checks. Open pull requests and issues are candidate work,
+not shipped Beta functionality. Before release, the approved candidate is synchronized
+from `dev` to `main` and tagged there.
 
 The baseline is the end of *Milestone 3 – MVP*. Everything below the "Earlier (MVP and
 before)" headings predates that and is listed only for completeness of the feature set.
@@ -163,7 +169,7 @@ in the feature list and change log; collected here so they are hard to miss.
 - EN/DE localization with a persisted in-app language switcher; centralized theme and UI
   defaults, dark-mode-aware logo and splash scaling (`#93`, `#98`).
 - Internal test builds from CI: EAS build + TestFlight submission from `main`
-  (`#19`, ADR-0033).
+  (`#19`, ADR-0032).
 - Legacy auth context and hand-written API layer removed (`#85`).
 - react-doctor evaluated for code health, expo-doctor kept in the quality gate (`#64`).
 
@@ -189,7 +195,8 @@ in the feature list and change log; collected here so they are hard to miss.
 - Contract-aligned locker fleet simulator: in-memory bus, credential and overlay stores,
   scenario files and a traffic log, so the whole stack runs without hardware
   (`#82`, `#23`, ADR-0031, `docs/simulator.md`).
-- Watchtower-based update flow; ships as `ghcr.io/open-locker/locker-client:latest`.
+- Watchtower-based update flow; the Beta pins a verified immutable client image tag
+  rather than `latest`.
 
 ### Hardware
 
@@ -206,7 +213,7 @@ in the feature list and change log; collected here so they are hard to miss.
 - Starlight documentation section with aligned branding; BOM migrated in as a Hardware
   page (`#92`); copy and layout fine-tuning (`#179`).
 - Architecture docs, MQTT architecture and integration plan, AsyncAPI specs,
-  observability notes, installation and simulator guides, 43 ADRs.
+  observability notes, installation and simulator guides, and ADRs.
 
 ### CI / infrastructure
 
@@ -358,105 +365,54 @@ Modbus simulator, and the first locker-client implementation.
 
 ## 3. Beta readiness — finish, consolidate, tighten
 
-Ordered by what would stop the release, not by effort.
+The [Beta release checklist](../release-checklist.md) is the source of truth for
+execution and evidence. The following items remain hard gates; this document does not
+claim they are complete merely because related code or a pull request exists:
 
-### Would block shipping
+- **#50 — release mechanics:** implement and verify the ADR-0043 tag namespaces,
+  artifact publishing, component-scoped release notes, and protection against
+  non-`main` or manual runs publishing a misleading `latest`.
+- **#134 — stale commands:** accept and test an age policy so a delayed
+  `open_compartment` command cannot unexpectedly actuate a door.
+- **#163 — MQTTS:** complete transport security and pass an external end-to-end smoke
+  test. The current plaintext development listener is not Beta-ready.
+- **#169 — Raspberry Pi soak:** record the agreed soak duration, resource behavior,
+  reconnect evidence, and real Modbus hardware result.
+- **#209 — Beta readiness:** close the milestone/release decision with no unresolved
+  blocker.
 
-**Land the stacked PR chain (#183 → #210).** Fourteen of the features listed above sit
-in one bottom-up stack, plus #120 separately. Nothing in it is released until the whole
-chain merges, and every day it stays open the rebase cost grows. This is the single
-biggest risk to the Beta date.
+Issue #67 is also required Beta work and must have a recorded outcome before the pilot,
+although it is tracked separately from the hard-gate list.
 
-**Resolve or replace PR #107 (`dev` → `main`).** It is open since 2026-06-11, marked
-`CONFLICTING`, and carries +145,808/−9,447. Meanwhile `main` last moved on 2026-07-20
-and is 245 commits behind `dev`. Beta ships from `main`, so this is a hard gate. A fresh
-merge PR is likely cheaper than salvaging this one.
+### Required rollout order
 
-**Roll out the monorepo release strategy (`#50`; ADR-0043) before cutting anything.**
-There are still zero tags and zero Releases, so today there is no way to say "this Pi
-runs Beta" or to roll back. The ADR's own rollout list also flags that
-`workflow_dispatch` on `docker-ghcr.yml` publishes `latest` from whatever branch it runs
-on — a dispatch from `dev` would overwrite production. Fix that before the first tag,
-not after.
+1. Complete all component checks on `dev`, synchronize the approved candidate to
+   `main`, and rerun protected checks.
+2. Create only the required component tags (`backend-v*`, `client-v*`, `mobile-v*`) on
+   the intended `main` commit and verify immutable artifacts and release notes.
+3. Take and verify backups and record component-specific rollback tags.
+4. For PR #227, deploy the compatible client first and prohibit re-provisioning until it
+   is confirmed. Then deploy the backend migration/code and restart all queue workers
+   before allowing opaque MQTT credential issuance.
+5. Accept PR #228's Modbus reconnect behavior only after #169 confirms the assumed
+   real-device error codes, unreachable state, and automatic recovery on a Pi.
+6. Run backend, MQTTS, Pi/Modbus, and mobile smoke tests; distribute iOS through
+   TestFlight and Android through the configured controlled Beta/internal track.
+7. At the named decision point, the release owner records **continue**, **pause**, or
+   **roll back** using the [Beta rollback runbook](beta-rollback.md).
 
-**MQTT TLS (#163).** `mosquitto.conf.template` defines only `listener 1883` with
-`auth_opt_http_with_tls false`. Broker credentials and open commands cross the network in
-clear. This is the one security item worth hard-blocking on: a Beta runs on someone
-else's network.
-
-**Soak-test the v2 client on a Pi (#169).** v1 was replaced wholesale. The rewrite is
-well covered by tests, but nothing here shows it running for days against real Modbus
-hardware. Beta is exactly where an undetected slow leak or a wedged bus shows up.
-
-**Make client shutdown and async lifecycle safe (#170).** An unclean stop in the middle
-of a Modbus write is how a relay gets left energised. Cheap to fix, unpleasant to
-discover in the field.
-
-### Consolidate
-
-**Fix the duplicate ADR numbers.** 0018, 0023, 0024, 0025, 0028, 0029 and 0030 are each
-used by two different ADRs. Commit messages and PR bodies reference ADRs by number, so
-those references are currently ambiguous. Renumbering is trivial now and gets harder
-with every new ADR.
-
-**Promote the ADRs that describe shipped behaviour.** The ADRs for separate ACK
-(`#94`), OpenTelemetry (`#65`), first-admin bootstrap (`#141`), and Android build
-caching (`#204`) are still `Proposed`, though their code is merged. The release
-strategy the cut itself depends on is now Accepted (ADR-0043). A Proposed ADR
-describing what the system already does trains people to ignore the status field.
-
-**Close the issues whose work already shipped** — #109 (audit log), #52 (healthcheck),
-#122 (group memberships), plus the stack's issues as it merges. The milestone should
-read true on release day, and right now it undercounts what is done.
-
-**Refactor the CI workflows (#99).** It is the last structural CI item. Doing it after
-the stack lands means touching six workflows once instead of twice.
-
-### Remove
-
-**`TODO.md`.** A German checklist from the pre-MQTT architecture rebuild, with every box
-already ticked. It is superseded by the ADRs and the issue tracker, and a stale roadmap
-in the repo root is the first thing a new contributor reads.
-
-**The stale-docs warning in `CLAUDE.md`.** It still calls out a Flutter app and Dart
-client that the README no longer describes. The root `docker-compose.yml` mention is
-partly still fair — the README tree still lists one — so trim the Flutter/Dart half of
-the warning rather than deleting the whole note.
-
-### Decide before calling it Beta
-
-**What "Beta" means for distribution.** `eas.json` submits Android to the `internal`
-track and builds an APK, and iOS goes to TestFlight internally (#19). That is a team
-build, not a beta programme. If external testers are the point, this needs a closed or
-open testing track and an AAB — worth settling before the tag, since store review is the
-slowest link.
-
-**Stale `open_compartment` commands (#134).** Still an open discussion. A command
-replayed after a long delay opens a physical door with nobody expecting it. Beta is the
-right moment to decide, because it is the first time real doors are involved.
-
-**Where OpenTelemetry traces go.** PR #189 instruments the open flow end to end, but no
-collector or backend is deployed or documented. Instrumentation with nowhere to send
-data is cost without benefit — and the open flow is precisely what you want traced when
-a Beta site reports "the door didn't open".
-
-**Runtime config completeness (#174).** Left open, and it determines how much a locker
-can be reconfigured without a redeploy — which is what you want during a Beta, when
-settings change often and physical access is inconvenient.
-
-### Not missing, worth stating
-
-No gaps found in the core loop: authenticate, see accessible compartments, open one,
-watch its door state update live, with the whole path audited and event-sourced. The
-admin side covers users, groups, roles, access grants, compartments, open requests,
-terms and an audit log, in EN and DE. For a Beta, the feature set is there — the risk is
-concentrated in release mechanics and field hardening, not in missing product.
+The core feature set is intended to support authenticate → list accessible compartments
+→ open → live door-state update. The Beta decision still depends on operational evidence,
+not feature inventory alone.
 
 ---
 
 ## References
 
 - Monorepo release strategy — `#50` (ADR-0043)
+- [Beta release checklist](../release-checklist.md)
+- [Beta rollback runbook](beta-rollback.md)
+- [ADR-0052: Controlled beta release and rollback](../adr/0052-controlled-beta-release-and-rollback.md)
 - ADR-0032 — mobile internal test builds
 - ADR-0036 — website in the monorepo
 - Milestones: *Milestone 1 – Hardware MVP*, *Milestone 2 – Internal MVP*,

--- a/locker-backend/.env.prod.example
+++ b/locker-backend/.env.prod.example
@@ -3,9 +3,17 @@ APP_ENV=production
 APP_KEY=          # in Prod zwingend per php artisan key:generate setzen //TODO justfile ergänzen um den befehl
 APP_DEBUG=false
 APP_TIMEZONE=UTC
-APP_URL=https://your-domain.tld
+APP_URL=https://app.example.com
 APP_VERSION=0.1.0
 APP_SERVICE="app"
+
+# Standalone Traefik edge (docker-compose.prod.traefik.yml)
+APP_DOMAIN=app.example.com
+REVERB_DOMAIN=reverb.example.com
+MQTT_DOMAIN=mqtt.example.com
+ACME_EMAIL=admin@example.com
+# Unique per Coolify deployment on a shared proxy.
+COOLIFY_MQTT_ROUTER_NAME=open-locker-mqtt
 
 APP_LOCALE=de
 APP_FALLBACK_LOCALE=de
@@ -55,7 +63,7 @@ REVERB_APP_ID=open-locker
 REVERB_APP_KEY=change_me_reverb_key
 REVERB_APP_SECRET=change_me_reverb_secret
 VITE_REVERB_APP_KEY=change_me_reverb_key
-VITE_REVERB_HOST=reverb.your-domain.tld
+VITE_REVERB_HOST=reverb.example.com
 VITE_REVERB_PORT=443
 VITE_REVERB_SCHEME=https
 

--- a/locker-backend/docker-compose.prod.coolify.yml
+++ b/locker-backend/docker-compose.prod.coolify.yml
@@ -1,0 +1,76 @@
+services:
+  app:
+    extends:
+      file: docker-compose.prod.yml
+      service: app
+
+  queue-worker:
+    extends:
+      file: docker-compose.prod.yml
+      service: queue-worker
+
+  event-worker:
+    extends:
+      file: docker-compose.prod.yml
+      service: event-worker
+
+  mqtt-listener:
+    extends:
+      file: docker-compose.prod.yml
+      service: mqtt-listener
+
+  autoheal:
+    extends:
+      file: docker-compose.prod.yml
+      service: autoheal
+
+  scheduler:
+    extends:
+      file: docker-compose.prod.yml
+      service: scheduler
+
+  reverb:
+    extends:
+      file: docker-compose.prod.yml
+      service: reverb
+
+  mqtt:
+    extends:
+      file: docker-compose.prod.yml
+      service: mqtt
+    networks:
+      - default
+      - coolify
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=coolify"
+      - "traefik.tcp.routers.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.rule=HostSNI(`${MQTT_DOMAIN:?Set MQTT_DOMAIN}`)"
+      - "traefik.tcp.routers.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.entrypoints=mqtts"
+      - "traefik.tcp.routers.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.tls=true"
+      - "traefik.tcp.routers.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.tls.certresolver=letsencrypt"
+      - "traefik.tcp.routers.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.service=${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}"
+      - "traefik.tcp.services.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.loadbalancer.server.port=1883"
+
+  redis:
+    extends:
+      file: docker-compose.prod.yml
+      service: redis
+
+  db:
+    extends:
+      file: docker-compose.prod.yml
+      service: db
+
+networks:
+  coolify:
+    external: true
+
+volumes:
+  locker-redis:
+    driver: local
+  locker-pgsql:
+    driver: local
+  locker-storage:
+    driver: local
+  locker-mqtt-data:
+    driver: local

--- a/locker-backend/docker-compose.prod.mqtt-migration.yml
+++ b/locker-backend/docker-compose.prod.mqtt-migration.yml
@@ -1,0 +1,7 @@
+# TEMPORARY MQTT TLS MIGRATION ONLY.
+# Do not include this overlay in a normal production deployment. Remove it as
+# soon as every locker client uses MQTTS and verify port 1883 is unreachable.
+services:
+  mqtt:
+    ports:
+      - "${MQTT_MIGRATION_BIND_ADDRESS:?Set only during the scheduled migration}:1883:1883"

--- a/locker-backend/docker-compose.prod.traefik.yml
+++ b/locker-backend/docker-compose.prod.traefik.yml
@@ -1,0 +1,64 @@
+services:
+  traefik:
+    image: traefik:v3.6.1
+    restart: unless-stopped
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.mqtts.address=:8883"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--ping=true"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8883:8883"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "traefik-certificates:/letsencrypt"
+    security_opt:
+      - "no-new-privileges:true"
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.open-locker-app.rule=Host(`${APP_DOMAIN:?Set APP_DOMAIN}`)"
+      - "traefik.http.routers.open-locker-app.entrypoints=websecure"
+      - "traefik.http.routers.open-locker-app.tls=true"
+      - "traefik.http.routers.open-locker-app.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.open-locker-app.service=open-locker-app"
+      - "traefik.http.services.open-locker-app.loadbalancer.server.port=8080"
+
+  reverb:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.open-locker-reverb.rule=Host(`${REVERB_DOMAIN:?Set REVERB_DOMAIN}`)"
+      - "traefik.http.routers.open-locker-reverb.entrypoints=websecure"
+      - "traefik.http.routers.open-locker-reverb.tls=true"
+      - "traefik.http.routers.open-locker-reverb.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.open-locker-reverb.service=open-locker-reverb"
+      - "traefik.http.services.open-locker-reverb.loadbalancer.server.port=8080"
+
+  mqtt:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.open-locker-mqtt.rule=HostSNI(`${MQTT_DOMAIN:?Set MQTT_DOMAIN}`)"
+      - "traefik.tcp.routers.open-locker-mqtt.entrypoints=mqtts"
+      - "traefik.tcp.routers.open-locker-mqtt.tls=true"
+      - "traefik.tcp.routers.open-locker-mqtt.tls.certresolver=letsencrypt"
+      - "traefik.tcp.routers.open-locker-mqtt.service=open-locker-mqtt"
+      - "traefik.tcp.services.open-locker-mqtt.loadbalancer.server.port=1883"
+
+volumes:
+  traefik-certificates:
+    driver: local

--- a/locker-backend/docker-compose.prod.yml
+++ b/locker-backend/docker-compose.prod.yml
@@ -27,6 +27,11 @@ x-laravel-env-prod: &laravel_env_prod
 
 x-laravel-service-prod: &laravel_service_prod
   image: ghcr.io/open-locker/locker-backend:${BACKEND_IMAGE_TAG:-latest}
+  # Compose's project .env is only used for interpolation. Laravel processes
+  # need the same file explicitly loaded into every app/worker container.
+  env_file:
+    - path: ./.env
+      required: true
   volumes:
     # Mount storage for persistent file uploads
     - "locker-storage:/var/www/html/storage/app/public"
@@ -185,8 +190,8 @@ services:
   mqtt:
     image: iegomez/mosquitto-go-auth:2.1.0-mosquitto_2.0.15
     restart: unless-stopped
-    ports:
-      - "1883:1883"
+    expose:
+      - "1883"
     volumes:
       - "./mosquitto/mosquitto.conf:/etc/mosquitto/mosquitto.conf:ro"
       - "locker-mqtt-data:/mosquitto/data"

--- a/locker-client/.env.example
+++ b/locker-client/.env.example
@@ -17,7 +17,8 @@ MQTT_DEFAULT_USERNAME=provisioning_client
 MQTT_DEFAULT_PASSWORD=a_public_password
 
 # --- Runtime connectivity ---
-MQTT_BROKER_URL=mqtt://open-locker.cloud
+# Production requires MQTTS with a certificate trusted by the system CA store.
+MQTT_BROKER_URL=mqtts://mqtt.example.com:8883
 
 # Optional: stable MQTT client identity (defaults to generated ID in DATA_DIR)
 # MQTT_CLIENT_ID=

--- a/locker-client/Dockerfile
+++ b/locker-client/Dockerfile
@@ -12,6 +12,8 @@ FROM node:22-slim
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends util-linux \
     && rm -rf /var/lib/apt/lists/* \

--- a/locker-client/README.md
+++ b/locker-client/README.md
@@ -22,7 +22,8 @@ chmod 700 data
 cp locker-config.yml.example config/locker-config.yml
 
 # Issue a one-time token in the backend admin, immediately set
-# PROVISIONING_TOKEN in .env, and adjust the serial port.
+# PROVISIONING_TOKEN and MQTT_BROKER_URL=mqtts://<mqtt-host>:8883
+# in .env, and adjust the serial port.
 docker compose up -d
 docker compose logs -f locker-client
 ```
@@ -38,6 +39,12 @@ provisioned clients keep using their MQTT credentials and need no change.
 The Compose stack runs the client from
 `ghcr.io/open-locker/locker-client:${LOCKER_CLIENT_IMAGE_TAG:-latest}` and uses
 Watchtower for labeled automatic updates.
+
+Production MQTT is available only through MQTTS on port 8883. For `mqtts://`
+connections the client always verifies the broker certificate chain and
+hostname against the Raspberry Pi operating-system CA store. It does not offer
+an option to disable verification. Plaintext `mqtt://localhost:1883` is reserved
+for explicit local development and simulator use.
 
 Required mounts:
 

--- a/locker-client/docs/WAVESHARE_INTEGRATION.md
+++ b/locker-client/docs/WAVESHARE_INTEGRATION.md
@@ -113,7 +113,7 @@ Command execution is deduplicated by:
 Example `.env`:
 
 ```env
-MQTT_BROKER_URL=mqtt://open-locker.cloud
+MQTT_BROKER_URL=mqtts://mqtt.example.com:8883
 MQTT_DEFAULT_USERNAME=provisioning_client
 MQTT_DEFAULT_PASSWORD=a_public_password
 LOG_LEVEL=info

--- a/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
+++ b/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
@@ -7,6 +7,20 @@ import type {
 } from '../../ports/mqtt.port';
 import { logger } from '../../infrastructure/logging';
 
+export function withVerifiedMqttTls(
+  brokerUrl: string,
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!brokerUrl.toLowerCase().startsWith('mqtts://')) {
+    return options;
+  }
+
+  return {
+    ...options,
+    rejectUnauthorized: true,
+  };
+}
+
 export class MqttTransportAdapter implements MessageTransportPort {
   private client: MqttClient | null = null;
   private connectionState: MqttConnectionState = 'disconnected';
@@ -114,13 +128,13 @@ export class MqttTransportAdapter implements MessageTransportPort {
     this.connectionState = 'connecting';
 
     return new Promise((resolve, reject) => {
-      const clientOptions = {
+      const clientOptions = withVerifiedMqttTls(brokerUrl, {
         keepalive: this.transport.keepalive,
         clean: this.transport.clean,
         reconnectPeriod: this.transport.reconnectPeriod,
         connectTimeout: this.transport.connectTimeout,
         ...options,
-      };
+      });
 
       this.client = mqtt.connect(brokerUrl, clientOptions);
       let initialConnectSettled = false;

--- a/locker-client/src/application/provision-device.ts
+++ b/locker-client/src/application/provision-device.ts
@@ -11,7 +11,7 @@ import {
   readPrivateFileSync,
 } from '../infrastructure/file-persistence';
 
-export const DEFAULT_MQTT_BROKER_URL = 'mqtt://open-locker.cloud';
+export const DEFAULT_MQTT_BROKER_URL = 'mqtts://open-locker.cloud:8883';
 
 export function getOrCreateClientId(clientIdFilePath: string): string {
   const configuredClientId = process.env.MQTT_CLIENT_ID?.trim();

--- a/locker-client/src/bootstrap/createApp.ts
+++ b/locker-client/src/bootstrap/createApp.ts
@@ -34,6 +34,7 @@ import { logger, setLogTraceContextProvider, shipLogsTo } from '../infrastructur
 import { createWinstonLoggerPort } from '../infrastructure/winston-logger.adapter';
 import { DATA_DIR, MQTT_CLIENT_ID_FILE } from '../infrastructure/paths';
 import { ensurePrivateDirectory } from '../infrastructure/file-persistence';
+import { assertSecureProductionMqttUrl } from '../infrastructure/mqtt-url-policy';
 
 /**
  * How long any single shutdown step may take before the sequence moves on.
@@ -47,6 +48,9 @@ export interface AppContext {
 }
 
 export async function createApp(): Promise<AppContext> {
+  const brokerUrl = process.env.MQTT_BROKER_URL?.trim() || DEFAULT_MQTT_BROKER_URL;
+  assertSecureProductionMqttUrl(brokerUrl);
+
   ensurePrivateDirectory(DATA_DIR);
   const configRepo = new YamlConfigRepository(new FileRuntimeOverlayStore());
   const config = configRepo.load();
@@ -56,7 +60,6 @@ export async function createApp(): Promise<AppContext> {
   const transport = new MqttTransportAdapter(configRepo.getMqttTransportSettings());
 
   const clientId = getOrCreateClientId(MQTT_CLIENT_ID_FILE);
-  const brokerUrl = process.env.MQTT_BROKER_URL?.trim() || DEFAULT_MQTT_BROKER_URL;
 
   if (!credentialStore.isProvisioned()) {
     const token = process.env.PROVISIONING_TOKEN?.trim();

--- a/locker-client/src/bootstrap/createSimulatorApp.ts
+++ b/locker-client/src/bootstrap/createSimulatorApp.ts
@@ -29,7 +29,7 @@ import {
   HeartbeatUseCase,
   PollCompartmentStateUseCase,
 } from '../application/state-publishing';
-import { DEFAULT_MQTT_BROKER_URL, provisionDevice } from '../application/provision-device';
+import { provisionDevice } from '../application/provision-device';
 import type { DoorState } from '../domain/compartment';
 import { createTracing } from '../adapters/tracing/create-tracing';
 import { logger, setLogTraceContextProvider, shipLogsTo } from '../infrastructure/logging';
@@ -71,6 +71,7 @@ export interface SimulatorContext {
 
 /** The contract's door states; anything else is rejected by the backend. */
 const DOOR_STATES: DoorState[] = ['open', 'closed', 'unknown'];
+export const DEFAULT_SIMULATOR_MQTT_BROKER_URL = 'mqtt://localhost:1883';
 
 export type PublishFn = (
   topic: string,
@@ -338,7 +339,9 @@ export async function createSimulatorApp(
   options: CreateSimulatorOptions,
 ): Promise<SimulatorContext> {
   const brokerUrl =
-    options.brokerUrl?.trim() || options.scenario.broker_url?.trim() || DEFAULT_MQTT_BROKER_URL;
+    options.brokerUrl?.trim() ||
+    options.scenario.broker_url?.trim() ||
+    DEFAULT_SIMULATOR_MQTT_BROKER_URL;
   const credentialCache = options.credentialCache ?? new EphemeralCredentialCache();
   const logTraffic = options.logTraffic ?? true;
 

--- a/locker-client/src/infrastructure/mqtt-url-policy.ts
+++ b/locker-client/src/infrastructure/mqtt-url-policy.ts
@@ -1,0 +1,18 @@
+export interface RuntimeEnvironment {
+  APP_ENV?: string;
+  NODE_ENV?: string;
+}
+
+export function assertSecureProductionMqttUrl(
+  brokerUrl: string,
+  environment: RuntimeEnvironment = process.env,
+): void {
+  const isProduction = [environment.APP_ENV, environment.NODE_ENV].some((value) => {
+    const normalized = (value ?? '').trim().toLowerCase();
+    return normalized === 'production' || normalized === 'prod';
+  });
+
+  if (isProduction && !brokerUrl.toLowerCase().startsWith('mqtts://')) {
+    throw new Error('Production MQTT_BROKER_URL must use mqtts://');
+  }
+}

--- a/locker-client/tests/simulator/composition-parity.test.ts
+++ b/locker-client/tests/simulator/composition-parity.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { test } from 'node:test';
+import { DEFAULT_SIMULATOR_MQTT_BROKER_URL } from '../../src/bootstrap/createSimulatorApp';
 
 /**
  * The simulator is only a faithful stand-in while it dispatches the same
@@ -57,4 +58,8 @@ test('both composition roots register the same command handlers', () => {
     production,
     'a handler registered in one composition root but not the other means the simulator no longer mirrors the client',
   );
+});
+
+test('simulator defaults to the local plaintext broker', () => {
+  assert.equal(DEFAULT_SIMULATOR_MQTT_BROKER_URL, 'mqtt://localhost:1883');
 });

--- a/locker-client/tests/unit/mqtt-transport.test.ts
+++ b/locker-client/tests/unit/mqtt-transport.test.ts
@@ -1,6 +1,26 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { MqttTransportAdapter } from '../../src/adapters/mqtt/mqtt-transport.adapter';
+import {
+  MqttTransportAdapter,
+  withVerifiedMqttTls,
+} from '../../src/adapters/mqtt/mqtt-transport.adapter';
+
+test('MQTTS always verifies the certificate and hostname', () => {
+  assert.deepEqual(
+    withVerifiedMqttTls('mqtts://mqtt.example.com:8883', {
+      rejectUnauthorized: false,
+    }),
+    {
+      rejectUnauthorized: true,
+    },
+  );
+});
+
+test('local plaintext MQTT keeps its connection options', () => {
+  const options = { clientId: 'local-client' };
+
+  assert.strictEqual(withVerifiedMqttTls('mqtt://localhost:1883', options), options);
+});
 
 test('MqttTransportAdapter defaults to unlimited reconnect', () => {
   const transport = new MqttTransportAdapter({

--- a/locker-client/tests/unit/mqtt-url-policy.test.ts
+++ b/locker-client/tests/unit/mqtt-url-policy.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { assertSecureProductionMqttUrl } from '../../src/infrastructure/mqtt-url-policy';
+
+test('accepts MQTTS in production', () => {
+  assert.doesNotThrow(() =>
+    assertSecureProductionMqttUrl('mqtts://mqtt.example.com:8883', {
+      NODE_ENV: 'production',
+    }),
+  );
+});
+
+test('rejects plaintext MQTT in production', () => {
+  assert.throws(
+    () =>
+      assertSecureProductionMqttUrl('mqtt://mqtt.example.com:1883', {
+        APP_ENV: 'production',
+      }),
+    /must use mqtts:\/\//,
+  );
+});
+
+test('keeps local plaintext development available', () => {
+  assert.doesNotThrow(() =>
+    assertSecureProductionMqttUrl('mqtt://localhost:1883', {
+      NODE_ENV: 'development',
+    }),
+  );
+});

--- a/locker-client/tests/unit/provision-device.test.ts
+++ b/locker-client/tests/unit/provision-device.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test, type TestContext } from 'node:test';
-import { getOrCreateClientId, provisionDevice } from '../../src/application/provision-device';
+import {
+  DEFAULT_MQTT_BROKER_URL,
+  getOrCreateClientId,
+  provisionDevice,
+} from '../../src/application/provision-device';
 import {
   MqttSchemaValidationError,
   parseProvisioningResponse,
@@ -14,6 +18,10 @@ import type { MessageTransportPort, MqttTransportSettings } from '../../src/port
 import { assertMatchesSchema, readAsyncApiExample } from '../contract/jsonSchema';
 
 const supportsUnixModes = process.platform !== 'win32';
+
+test('default broker uses the verified production MQTTS endpoint', () => {
+  assert.equal(DEFAULT_MQTT_BROKER_URL, 'mqtts://open-locker.cloud:8883');
+});
 
 class FakeMessageTransport implements MessageTransportPort {
   published: Array<{ topic: string; payload: string }> = [];

--- a/website/src/content/docs/dokumentation/operations.md
+++ b/website/src/content/docs/dokumentation/operations.md
@@ -8,12 +8,35 @@ sidebar:
 ## Deploying the cloud backend
 
 The backend runs as a Docker Compose stack on a central server (VPS or cloud
-instance):
+instance). A standalone deployment adds the maintained Traefik edge:
 
 ```bash
 cd locker-backend
-docker compose -f docker-compose.prod.yml up -d
+docker compose \
+  -f docker-compose.prod.yml \
+  -f docker-compose.prod.traefik.yml \
+  up -d
 ```
+
+Set `APP_DOMAIN`, `REVERB_DOMAIN`, `MQTT_DOMAIN`, and `ACME_EMAIL` first. The
+public contract is HTTPS on 443 and MQTTS on 8883. Mosquitto port 1883 is
+plaintext only inside the Docker network and is not published in production.
+
+For Coolify v4, use the Git-based **Docker Compose** build pack and set
+**Docker Compose Location** to
+`/locker-backend/docker-compose.prod.coolify.yml`. The entry file loads the base
+stack with Compose `extends`; Coolify's similarly named custom Compose override
+configures Coolify's own infrastructure and is not an application overlay. The
+managed Traefik proxy must publish a TCP `mqtts` entrypoint on 8883; the adapter
+routes `HostSNI(MQTT_DOMAIN)` through that entrypoint to Mosquitto port 1883. A
+normal HTTPS domain route or direct port mapping does not secure MQTT. Follow
+the installation guide for the exact procedure and required external
+verification; live Coolify routing and certificate issuance are not proven by
+repository validation.
+
+The complete standalone and Coolify procedures, including firewall, DNS,
+certificate, and smoke-test steps, are maintained in the repository
+[installation guide](https://github.com/Open-Locker/Open-Locker/blob/main/docs/Installation.md).
 
 ### Pin the image version (recommended)
 
@@ -43,6 +66,11 @@ just setup-mqtt
 Without `just`: copy `mosquitto.conf` from the example and add
 `mosq_secret=<MOSQ_HTTP_PASS>` to the webhook URIs, then restart the
 Mosquitto container.
+
+Locker clients use `mqtts://<mqtt-domain>:8883` and validate the public
+certificate and hostname. Before accepting a deployment, test an authenticated
+MQTT round trip through 8883 and confirm that port 1883 is unreachable from
+outside the Docker host.
 
 Set the same valid Laravel `APP_KEY` on every backend instance. The backend
 derives a domain-separated provisioning-token HMAC subkey from it; no additional


### PR DESCRIPTION
## Summary

- terminate public MQTT TLS at Traefik on port 8883 while keeping Mosquitto private on the Compose network
- support both Coolify-managed Traefik and a standalone Traefik Compose overlay, including an explicit plaintext migration overlay
- require verified `mqtts://` transport for production locker clients and document rollout, rollback, and operational checks
- record the architecture decision in `docs/adr/0053-terminate-public-mqtt-tls-at-traefik.md`

## Deployment paths

### Coolify

- attach Mosquitto to Coolify's external proxy network
- configure a TCP router on the `mqtts` entrypoint with ACME-backed TLS
- forward decrypted MQTT traffic privately to `mqtt:1883`

### Standalone

- deploy the production stack with `docker-compose.prod.traefik.yml`
- expose Traefik on 80, 443, and 8883 while leaving Mosquitto unexposed
- use `docker-compose.prod.mqtt-migration.yml` only during a scheduled legacy-client migration

## Security behavior

- production clients reject plaintext `mqtt://` broker URLs
- MQTTS always verifies the certificate chain and hostname through the system CA store
- no certificate-verification bypass is exposed
- backend-to-broker MQTT remains plaintext only inside the private Compose network
- public port 1883 is removed from the normal production deployment

## Test plan

- [x] validate the Coolify Compose model
- [x] validate the standalone Traefik Compose model
- [x] validate the MQTT migration overlay
- [x] run `pnpm check`
- [x] run `pnpm test` — 315 passed, 2 skipped
- [x] build the website

## Remaining verification

- [ ] perform a real Coolify deployment
- [ ] restart the Coolify proxy after adding the MQTT TCP entrypoint
- [ ] verify DNS and SNI routing for the MQTT hostname
- [ ] verify ACME certificate issuance and renewal
- [ ] verify host and provider firewall rules
- [ ] verify external port 8883 is reachable with valid MQTTS
- [ ] verify external port 1883 is unreachable after migration

Refs #163

Made with [Cursor](https://cursor.com)