### PR TITLE
fix(admin): show locker bank location as group subtitle

### DIFF
--- a/locker-backend/app/Filament/Resources/CompartmentResource.php
+++ b/locker-backend/app/Filament/Resources/CompartmentResource.php
@@ -10,6 +10,7 @@ use App\Filament\Resources\CompartmentResource\Pages;
 use App\Filament\Resources\CompartmentResource\RelationManagers\GroupAccessesRelationManager;
 use App\Filament\Resources\CompartmentResource\RelationManagers\UserAccessesRelationManager;
 use App\Filament\Support\CompartmentDoorStateColumn;
+use App\Filament\Support\LockerBankGroupHeading;
 use App\Filament\Support\OpenCompartmentAction;
 use App\Models\Compartment;
 use App\Models\LockerBank;
@@ -22,7 +23,6 @@ use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
 
 class CompartmentResource extends Resource
 {
@@ -119,20 +119,10 @@ class CompartmentResource extends Resource
             ->groups([
                 Group::make('locker_bank_id')
                     ->label(__('Locker bank'))
-                    // Visible title is the bank name. Location is the subtitle.
-                    // A hidden id keeps Filament/accordion titles unique.
-                    ->getTitleFromRecordUsing(function (Compartment $record): HtmlString {
-                        $name = $record->lockerBank?->name ?: __('Locker bank');
-
-                        return new HtmlString(
-                            e($name).'<span hidden>'.e((string) $record->locker_bank_id).'</span>'
-                        );
-                    })
-                    ->getDescriptionFromRecordUsing(function (Compartment $record): ?string {
-                        $location = $record->lockerBank?->location_description;
-
-                        return filled($location) ? $location : null;
-                    })
+                    // Visible title is the bank name plus a connection badge.
+                    // Location is the subtitle. A hidden id keeps titles unique.
+                    ->getTitleFromRecordUsing(LockerBankGroupHeading::title(...))
+                    ->getDescriptionFromRecordUsing(LockerBankGroupHeading::description(...))
                     ->orderQueryUsing(function (Builder $query, string $direction): Builder {
                         return $query
                             ->orderBy(

--- a/locker-backend/app/Filament/Resources/CompartmentResource.php
+++ b/locker-backend/app/Filament/Resources/CompartmentResource.php
@@ -22,6 +22,7 @@ use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 
 class CompartmentResource extends Resource
 {
@@ -118,15 +119,19 @@ class CompartmentResource extends Resource
             ->groups([
                 Group::make('locker_bank_id')
                     ->label(__('Locker bank'))
-                    // Filament and the accordion script key groups by title, so
-                    // the title must stay unique even when name and location match.
-                    ->getTitleFromRecordUsing(function (Compartment $record): string {
-                        $bank = $record->lockerBank;
-                        $name = $bank?->name ?: __('Locker bank');
-                        $location = $bank?->location_description;
-                        $label = filled($location) ? "{$name} — {$location}" : $name;
+                    // Visible title is the bank name. Location is the subtitle.
+                    // A hidden id keeps Filament/accordion titles unique.
+                    ->getTitleFromRecordUsing(function (Compartment $record): HtmlString {
+                        $name = $record->lockerBank?->name ?: __('Locker bank');
 
-                        return $label.' · '.$record->locker_bank_id;
+                        return new HtmlString(
+                            e($name).'<span hidden>'.e((string) $record->locker_bank_id).'</span>'
+                        );
+                    })
+                    ->getDescriptionFromRecordUsing(function (Compartment $record): ?string {
+                        $location = $record->lockerBank?->location_description;
+
+                        return filled($location) ? $location : null;
                     })
                     ->orderQueryUsing(function (Builder $query, string $direction): Builder {
                         return $query
@@ -172,6 +177,7 @@ class CompartmentResource extends Resource
             ])
             // No search or filters: the collapsed bank groups are the only navigation
             // this list needs, and a locker-bank filter would just duplicate them (#167).
+            ->recordActionsColumnLabel(__('Actions'))
             ->actions([
                 Action::make('access')
                     ->label(__('Access'))

--- a/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
+++ b/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
@@ -24,12 +24,15 @@ final class LockerBankGroupHeading
             default => 'gray',
         };
 
+        // Filament puts the title into aria-label="..." without escaping
+        // Htmlable values. Double quotes would close that attribute and dump
+        // the collapse button markup onto the page.
         return new HtmlString(
-            '<span class="inline-flex items-center gap-2">'
+            '<span class=\'inline-flex items-center gap-2\'>'
             .'<span data-group-name>'.e($name).'</span>'
             .'<span hidden>'.e((string) $record->locker_bank_id).'</span>'
-            .'<span class="fi-badge fi-size-sm fi-color fi-color-'.$color.'">'
-            .'<span class="fi-badge-label-ctn"><span class="fi-badge-label">'.e(__($status)).'</span></span>'
+            .'<span class=\'fi-badge fi-size-sm fi-color fi-color-'.$color.'\'>'
+            .'<span class=\'fi-badge-label-ctn\'><span class=\'fi-badge-label\'>'.e(__($status)).'</span></span>'
             .'</span>'
             .'</span>'
         );

--- a/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
+++ b/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
@@ -8,8 +8,8 @@ use App\Models\Compartment;
 use Illuminate\Support\HtmlString;
 
 /**
- * Visible group heading for the compartment list: bank name, connection badge,
- * and a hidden id so Filament/accordion titles stay unique.
+ * Visible group heading for the compartment list: bank name, connection
+ * indicator, and a hidden id so Filament/accordion titles stay unique.
  */
 final class LockerBankGroupHeading
 {
@@ -18,22 +18,21 @@ final class LockerBankGroupHeading
         $bank = $record->lockerBank;
         $name = $bank?->name ?: __('Locker bank');
         $status = $bank?->connection_status ?: 'unknown';
+        $label = __($status);
         $color = match ($status) {
-            'online' => 'success',
-            'offline' => 'danger',
-            default => 'gray',
+            'online' => '#16a34a',
+            'offline' => '#dc2626',
+            default => '#9ca3af',
         };
 
         // Filament puts the title into aria-label="..." without escaping
         // Htmlable values. Double quotes would close that attribute and dump
         // the collapse button markup onto the page.
         return new HtmlString(
-            '<span class=\'inline-flex items-center gap-2\'>'
+            '<span style=\'display:inline-flex;align-items:center;column-gap:.375rem;white-space:nowrap\'>'
             .'<span data-group-name>'.e($name).'</span>'
             .'<span hidden>'.e((string) $record->locker_bank_id).'</span>'
-            .'<span class=\'fi-badge fi-size-sm fi-color fi-color-'.$color.'\'>'
-            .'<span class=\'fi-badge-label-ctn\'><span class=\'fi-badge-label\'>'.e(__($status)).'</span></span>'
-            .'</span>'
+            .'<span data-connection-status=\''.e($status).'\' title=\''.e($label).'\' aria-label=\''.e($label).'\' style=\'display:inline-block;width:.625rem;height:.625rem;border-radius:9999px;background:'.$color.';flex:0 0 auto\'></span>'
             .'</span>'
         );
     }

--- a/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
+++ b/locker-backend/app/Filament/Support/LockerBankGroupHeading.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Support;
+
+use App\Models\Compartment;
+use Illuminate\Support\HtmlString;
+
+/**
+ * Visible group heading for the compartment list: bank name, connection badge,
+ * and a hidden id so Filament/accordion titles stay unique.
+ */
+final class LockerBankGroupHeading
+{
+    public static function title(Compartment $record): HtmlString
+    {
+        $bank = $record->lockerBank;
+        $name = $bank?->name ?: __('Locker bank');
+        $status = $bank?->connection_status ?: 'unknown';
+        $color = match ($status) {
+            'online' => 'success',
+            'offline' => 'danger',
+            default => 'gray',
+        };
+
+        return new HtmlString(
+            '<span class="inline-flex items-center gap-2">'
+            .'<span data-group-name>'.e($name).'</span>'
+            .'<span hidden>'.e((string) $record->locker_bank_id).'</span>'
+            .'<span class="fi-badge fi-size-sm fi-color fi-color-'.$color.'">'
+            .'<span class="fi-badge-label-ctn"><span class="fi-badge-label">'.e(__($status)).'</span></span>'
+            .'</span>'
+            .'</span>'
+        );
+    }
+
+    public static function description(Compartment $record): ?string
+    {
+        $location = $record->lockerBank?->location_description;
+
+        return filled($location) ? $location : null;
+    }
+}

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -204,5 +204,7 @@ class CompartmentListGroupingTest extends TestCase
         $this->assertStringContainsString('fi-color-success', (string) $group->getTitle($onlineCompartment));
         $this->assertStringContainsString(__('offline'), (string) $group->getTitle($offlineCompartment));
         $this->assertStringContainsString('fi-color-danger', (string) $group->getTitle($offlineCompartment));
+        $this->assertStringNotContainsString('"', (string) $group->getTitle($onlineCompartment));
+        $this->assertStringNotContainsString('"', (string) $group->getTitle($offlineCompartment));
     }
 }

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -42,6 +42,10 @@ class CompartmentListGroupingTest extends TestCase
 
     private function visibleGroupTitle(mixed $title): string
     {
+        if (preg_match('/data-group-name[^>]*>(.*?)</', (string) $title, $matches) === 1) {
+            return html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5);
+        }
+
         $withoutHiddenId = preg_replace('/<span hidden>.*?<\/span>/', '', (string) $title) ?? (string) $title;
 
         return trim(strip_tags($withoutHiddenId));
@@ -174,5 +178,31 @@ class CompartmentListGroupingTest extends TestCase
     public function test_the_actions_column_has_a_header_label(): void
     {
         $this->assertSame(__('Actions'), $this->tableFor($this->admin())->getRecordActionsColumnLabel());
+    }
+
+    public function test_group_titles_show_the_bank_connection_status(): void
+    {
+        $admin = $this->admin();
+
+        $onlineBank = LockerBank::factory()->create([
+            'name' => 'Online bank',
+            'connection_status' => 'online',
+        ]);
+        $offlineBank = LockerBank::factory()->create([
+            'name' => 'Offline bank',
+            'connection_status' => 'offline',
+        ]);
+        $onlineCompartment = Compartment::factory()->for($onlineBank)->create();
+        $offlineCompartment = Compartment::factory()->for($offlineBank)->create();
+
+        $group = $this->tableFor($admin)->getDefaultGroup();
+
+        $this->assertNotNull($group);
+        $this->assertSame('Online bank', $this->visibleGroupTitle($group->getTitle($onlineCompartment)));
+        $this->assertSame('Offline bank', $this->visibleGroupTitle($group->getTitle($offlineCompartment)));
+        $this->assertStringContainsString(__('online'), (string) $group->getTitle($onlineCompartment));
+        $this->assertStringContainsString('fi-color-success', (string) $group->getTitle($onlineCompartment));
+        $this->assertStringContainsString(__('offline'), (string) $group->getTitle($offlineCompartment));
+        $this->assertStringContainsString('fi-color-danger', (string) $group->getTitle($offlineCompartment));
     }
 }

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -10,6 +10,7 @@ use App\Models\LockerBank;
 use App\Models\User;
 use Filament\Tables\Table;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\HtmlString;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -37,6 +38,13 @@ class CompartmentListGroupingTest extends TestCase
         $admin->makeAdmin();
 
         return $admin;
+    }
+
+    private function visibleGroupTitle(mixed $title): string
+    {
+        $withoutHiddenId = preg_replace('/<span hidden>.*?<\/span>/', '', (string) $title) ?? (string) $title;
+
+        return trim(strip_tags($withoutHiddenId));
     }
 
     public function test_the_list_is_grouped_by_locker_bank_by_default(): void
@@ -112,11 +120,14 @@ class CompartmentListGroupingTest extends TestCase
         $this->assertSame((string) $firstBank->id, $group->getStringKey($firstCompartment));
         $this->assertSame((string) $secondBank->id, $group->getStringKey($secondCompartment));
         $this->assertNotSame($group->getStringKey($firstCompartment), $group->getStringKey($secondCompartment));
-        $this->assertSame('Main office — North wing · '.$firstBank->id, $group->getTitle($firstCompartment));
-        $this->assertSame('Main office — South wing · '.$secondBank->id, $group->getTitle($secondCompartment));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($firstCompartment)));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($secondCompartment)));
+        $this->assertNotSame((string) $group->getTitle($firstCompartment), (string) $group->getTitle($secondCompartment));
+        $this->assertSame('North wing', $group->getDescription($firstCompartment, $group->getTitle($firstCompartment)));
+        $this->assertSame('South wing', $group->getDescription($secondCompartment, $group->getTitle($secondCompartment)));
     }
 
-    public function test_same_named_banks_with_the_same_location_still_get_distinct_titles(): void
+    public function test_same_named_banks_with_the_same_location_keep_distinct_titles(): void
     {
         $admin = $this->admin();
 
@@ -134,9 +145,10 @@ class CompartmentListGroupingTest extends TestCase
         $group = $this->tableFor($admin)->getDefaultGroup();
 
         $this->assertNotNull($group);
-        $this->assertSame('Main office — North wing · '.$firstBank->id, $group->getTitle($firstCompartment));
-        $this->assertSame('Main office — North wing · '.$secondBank->id, $group->getTitle($secondCompartment));
-        $this->assertNotSame($group->getTitle($firstCompartment), $group->getTitle($secondCompartment));
+        $this->assertInstanceOf(HtmlString::class, $group->getTitle($firstCompartment));
+        $this->assertSame('North wing', $group->getDescription($firstCompartment, $group->getTitle($firstCompartment)));
+        $this->assertSame('North wing', $group->getDescription($secondCompartment, $group->getTitle($secondCompartment)));
+        $this->assertNotSame((string) $group->getTitle($firstCompartment), (string) $group->getTitle($secondCompartment));
     }
 
     public function test_same_named_banks_without_a_location_still_get_distinct_titles(): void
@@ -153,7 +165,14 @@ class CompartmentListGroupingTest extends TestCase
         $group = $this->tableFor($admin)->getDefaultGroup();
 
         $this->assertNotNull($group);
-        $this->assertSame('Main office · '.$firstBank->id, $group->getTitle($firstCompartment->unsetRelation('lockerBank')));
-        $this->assertSame('Main office · '.$secondBank->id, $group->getTitle($secondCompartment->unsetRelation('lockerBank')));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($firstCompartment->unsetRelation('lockerBank'))));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($secondCompartment->unsetRelation('lockerBank'))));
+        $this->assertNull($group->getDescription($firstCompartment, $group->getTitle($firstCompartment)));
+        $this->assertNotSame((string) $group->getTitle($firstCompartment), (string) $group->getTitle($secondCompartment));
+    }
+
+    public function test_the_actions_column_has_a_header_label(): void
+    {
+        $this->assertSame(__('Actions'), $this->tableFor($this->admin())->getRecordActionsColumnLabel());
     }
 }

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -150,6 +150,8 @@ class CompartmentListGroupingTest extends TestCase
 
         $this->assertNotNull($group);
         $this->assertInstanceOf(HtmlString::class, $group->getTitle($firstCompartment));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($firstCompartment)));
+        $this->assertSame('Main office', $this->visibleGroupTitle($group->getTitle($secondCompartment)));
         $this->assertSame('North wing', $group->getDescription($firstCompartment, $group->getTitle($firstCompartment)));
         $this->assertSame('North wing', $group->getDescription($secondCompartment, $group->getTitle($secondCompartment)));
         $this->assertNotSame((string) $group->getTitle($firstCompartment), (string) $group->getTitle($secondCompartment));

--- a/locker-backend/tests/Feature/CompartmentListGroupingTest.php
+++ b/locker-backend/tests/Feature/CompartmentListGroupingTest.php
@@ -200,10 +200,12 @@ class CompartmentListGroupingTest extends TestCase
         $this->assertNotNull($group);
         $this->assertSame('Online bank', $this->visibleGroupTitle($group->getTitle($onlineCompartment)));
         $this->assertSame('Offline bank', $this->visibleGroupTitle($group->getTitle($offlineCompartment)));
-        $this->assertStringContainsString(__('online'), (string) $group->getTitle($onlineCompartment));
-        $this->assertStringContainsString('fi-color-success', (string) $group->getTitle($onlineCompartment));
-        $this->assertStringContainsString(__('offline'), (string) $group->getTitle($offlineCompartment));
-        $this->assertStringContainsString('fi-color-danger', (string) $group->getTitle($offlineCompartment));
+        $this->assertStringContainsString('white-space:nowrap', (string) $group->getTitle($onlineCompartment));
+        $this->assertStringContainsString("data-connection-status='online'", (string) $group->getTitle($onlineCompartment));
+        $this->assertStringContainsString("title='".__('online')."'", (string) $group->getTitle($onlineCompartment));
+        $this->assertStringContainsString("data-connection-status='offline'", (string) $group->getTitle($offlineCompartment));
+        $this->assertStringContainsString("title='".__('offline')."'", (string) $group->getTitle($offlineCompartment));
+        $this->assertStringNotContainsString('fi-badge', (string) $group->getTitle($onlineCompartment));
         $this->assertStringNotContainsString('"', (string) $group->getTitle($onlineCompartment));
         $this->assertStringNotContainsString('"', (string) $group->getTitle($offlineCompartment));
     }


### PR DESCRIPTION
## Summary
- Follow-up to #234 / #167: group headers on `/admin/compartments` now show the locker bank **name** as the title and the **location as a Filament subtitle**, instead of `Name — Location · {uuid}`.
- Each bank header shows a compact **connection dot** (green / red / gray) next to the name, from `connection_status`.
- A hidden bank id stays in the title so Filament and the accordion still treat same-named banks as separate groups.
- The last table column now has an **Actions** / **Aktionen** header.

## Test plan
- [ ] Open `/admin/compartments` and confirm each group title is the bank name plus a status dot, with the location underneath when set.
- [ ] Confirm no UUID and no Alpine/HTML leak beside the header.
- [ ] Open two banks that share a name and different locations; opening one must not open the other.
- [ ] Confirm the last column header reads **Aktionen** (DE) / **Actions** (EN).
- [ ] `php artisan test --filter=CompartmentListGroupingTest`