### PR TITLE
fix(mobile): reserve store CI for release tags

### DIFF
--- a/.github/scripts/validate_release_workflows.rb
+++ b/.github/scripts/validate_release_workflows.rb
@@ -93,21 +93,21 @@ end
 
 def mobile_policy(event:, ref:, current_main_tip: true)
   push = event == :push
-  main = ref == 'refs/heads/main'
   tag = ref.start_with?('refs/tags/mobile-v')
-  blocked = push && (main || tag) && !current_main_tip
-  store = push && (main || tag) && !blocked
+  blocked = push && tag && !current_main_tip
+  store = push && tag && current_main_tip
 
   {
-    triggered: event != :pull_request,
-    profile: blocked ? :blocked : (store ? :store : :preview),
+    triggered: true,
+    android_profile: blocked ? :blocked : (store ? :store : :preview),
+    ios_profile: blocked ? :blocked : (store ? :store : :ios_simulator),
     submit: store,
     release: push && tag && current_main_tip,
   }
 end
 
 def mobile_concurrency(event:, ref:)
-  store = event == :push && (ref == 'refs/heads/main' || ref.start_with?('refs/tags/mobile-v'))
+  store = event == :push && ref.start_with?('refs/tags/mobile-v')
   {
     group: store ? 'mobile-store' : "mobile-preview-#{ref}",
     cancel_in_progress: false,
@@ -148,63 +148,104 @@ def validate_event_matrix
   assert(client_manual == { triggered: true, publish: false, latest: false, release: false }, 'client manual matrix failed')
 
   mobile_cases = [
-    [:pull_request, 'refs/pull/10/merge', true, false, :preview, false, false],
-    [:push, 'refs/heads/dev', true, true, :preview, false, false],
-    [:push, 'refs/heads/main', true, true, :store, true, false],
-    [:push, 'refs/heads/main', false, true, :blocked, false, false],
-    [:push, 'refs/tags/mobile-v1.0.0-beta.1', true, true, :store, true, true],
-    [:push, 'refs/tags/mobile-v1.0.0-beta.1', false, true, :blocked, false, false],
-    [:workflow_dispatch, 'refs/tags/mobile-v1.0.0-beta.1', true, true, :preview, false, false],
+    [:pull_request, 'refs/pull/10/merge', true, true, :preview, :ios_simulator, false, false],
+    [:push, 'refs/heads/dev', true, true, :preview, :ios_simulator, false, false],
+    [:push, 'refs/heads/main', true, true, :preview, :ios_simulator, false, false],
+    [:push, 'refs/heads/main', false, true, :preview, :ios_simulator, false, false],
+    [:push, 'refs/tags/mobile-v1.0.0-beta.1', true, true, :store, :store, true, true],
+    [:push, 'refs/tags/mobile-v1.0.0-beta.1', false, true, :blocked, :blocked, false, false],
+    [:workflow_dispatch, 'refs/tags/mobile-v1.0.0-beta.1', true, true, :preview, :ios_simulator, false, false],
   ]
-  mobile_cases.each do |event, ref, tip, triggered, profile, submit, release|
+  mobile_cases.each do |event, ref, tip, triggered, android_profile, ios_profile, submit, release|
     result = mobile_policy(event: event, ref: ref, current_main_tip: tip)
-    expected = { triggered: triggered, profile: profile, submit: submit, release: release }
+    expected = {
+      triggered: triggered,
+      android_profile: android_profile,
+      ios_profile: ios_profile,
+      submit: submit,
+      release: release,
+    }
     assert(result == expected, "mobile matrix failed for #{event} #{ref}")
   end
 
   running_tag = mobile_concurrency(event: :push, ref: 'refs/tags/mobile-v1.0.0-beta.1')
+  arriving_tag = mobile_concurrency(event: :push, ref: 'refs/tags/mobile-v1.0.1-beta.1')
   arriving_main = mobile_concurrency(event: :push, ref: 'refs/heads/main')
-  assert(running_tag[:group] == arriving_main[:group], 'tag and main store runs must serialize globally')
+  assert(running_tag[:group] == arriving_tag[:group], 'mobile store tag runs must serialize globally')
+  assert(running_tag[:group] != arriving_main[:group], 'main preview runs must not use store concurrency')
   assert(running_tag[:cancel_in_progress] == false, 'a running tag release must not be canceled')
-  assert(arriving_main[:cancel_in_progress] == false, 'main must not cancel a running tag release')
+  assert(arriving_tag[:cancel_in_progress] == false, 'a later tag must not cancel a running tag release')
 end
 
 def validate_mobile_workflow
   document = workflow('mobile-app-build.yml')
+  triggers = document.fetch('on')
   jobs = document.fetch('jobs')
   concurrency = document.fetch('concurrency')
 
-  expected_group = "${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/mobile-v')) && 'mobile-store' || format('mobile-preview-{0}', github.ref) }}"
+  assert(triggers.key?('pull_request'), 'mobile workflow must run for pull requests')
+  assert(triggers.fetch('push').fetch('branches') == %w[main dev], 'mobile workflow has wrong branch triggers')
+  assert(triggers.fetch('push').fetch('tags') == ['mobile-v*'], 'mobile workflow has wrong tag trigger')
+  assert(triggers.key?('workflow_dispatch'), 'mobile workflow must support manual preview builds')
+  expected_group = "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v') && 'mobile-store' || format('mobile-preview-{0}', github.ref) }}"
   assert(concurrency.fetch('group') == expected_group, 'mobile workflow must serialize complete store runs')
   assert(concurrency.fetch('cancel-in-progress') == false, 'mobile store runs must never cancel in-progress releases')
 
-  %w[release-gate release-quality release].each do |job_name|
+  %w[release-gate release-quality].each do |job_name|
     assert(
-      jobs.fetch(job_name).fetch('if').start_with?("github.event_name == 'push'"),
+      jobs.fetch(job_name).fetch('if') ==
+        "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')",
       "mobile #{job_name} must be push-only",
     )
   end
+  release = jobs.fetch('release')
+  assert(
+    release.fetch('if') == "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')",
+    'mobile GitHub Release must be tag-push-only',
+  )
+  assert(release.fetch('needs') == %w[release-quality android ios], 'mobile release has wrong dependencies')
+  gate_script = step(jobs.fetch('release-gate'), 'Verify tag commit belongs to main').fetch('run')
+  assert(gate_script.include?('git rev-parse origin/main'), 'mobile release tag must target the current main tip')
 
   %w[android ios].each do |job_name|
     job = jobs.fetch(job_name)
     assert(!job.key?('concurrency'), "#{job_name}: concurrency must protect the complete workflow")
-    main_tip = step(job, 'Verify current main tip for store build')
-    assert(main_tip.fetch('if').include?("github.event_name == 'push'"), "#{job_name}: stale main guard missing")
-    assert(main_tip.fetch('run').include?('origin/main'), "#{job_name}: stale main comparison missing")
     distribution = step(job, "Select #{job_name == 'ios' ? 'iOS' : 'Android'} distribution")
     assert(distribution.fetch('run').include?('GITHUB_EVENT_NAME'), "#{job_name}: manual dispatch is not preview-only")
+    assert(!distribution.fetch('run').include?('refs/heads/main'), "#{job_name}: main must not select the store profile")
+    expected_preview_profile = job_name == 'ios' ? 'profile=ios-simulator' : 'profile=preview'
+    assert(distribution.fetch('run').include?(expected_preview_profile), "#{job_name}: wrong non-tag profile")
+    expected_preview_artifact =
+      job_name == 'ios' ? 'artifact=openlocker-ios-simulator.tar.gz' : 'artifact=openlocker-android.apk'
+    assert(distribution.fetch('run').include?(expected_preview_artifact), "#{job_name}: wrong non-tag artifact")
+    expected_store_artifact = job_name == 'ios' ? 'artifact=openlocker-ios.ipa' : 'artifact=openlocker-android.aab'
+    assert(distribution.fetch('run').include?(expected_store_artifact), "#{job_name}: wrong store artifact")
     assert(distribution.fetch('run').scan(/>> "\$\{GITHUB_OUTPUT\}"/).length == 2, "#{job_name}: outputs must be grouped per branch")
     version = step(job, 'Derive tagged app version')
     assert(version.fetch('if').start_with?("github.event_name == 'push'"), "#{job_name}: tag version must be push-only")
 
     submit_name = job_name == 'ios' ? 'Submit TestFlight candidate' : 'Submit Android store candidate'
     submit = step(job, submit_name)
-    expected_submit_if = "github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/mobile-v'))"
+    expected_submit_if = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')"
     assert(submit.fetch('if') == expected_submit_if, "#{job_name}: submit expression is not push-only")
     assert(submit.fetch('run').include?('pnpm dlx "eas-cli@${EAS_CLI_VERSION}" submit'), "#{job_name}: EAS submit package must be quoted")
     build = step(job, "Build #{job_name == 'ios' ? 'iOS' : 'Android'} (${{ steps.distribution.outputs.channel }})")
     assert(build.fetch('run').include?('pnpm dlx "eas-cli@${EAS_CLI_VERSION}" build'), "#{job_name}: EAS build package must be quoted")
+    assert(
+      build.fetch('run').include?('--output "./build/${{ steps.distribution.outputs.artifact }}"'),
+      "#{job_name}: build output must follow the selected artifact",
+    )
   end
+end
+
+def validate_mobile_profiles
+  eas = JSON.parse(File.read(File.join(ROOT, 'mobile-app', 'eas.json')))
+  profiles = eas.fetch('build')
+  simulator = profiles.fetch('ios-simulator')
+
+  assert(simulator.fetch('extends') == 'preview', 'iOS simulator profile must inherit preview settings')
+  assert(simulator.fetch('ios').fetch('simulator') == true, 'iOS simulator profile must disable device signing')
+  assert(profiles.fetch('store').fetch('extends') == 'production', 'store profile mapping changed unexpectedly')
 end
 
 def validate_release_workflow
@@ -237,6 +278,7 @@ end
 validate_container_workflow('backend-docker.yml', 'backend-v')
 validate_container_workflow('client-docker.yml', 'client-v')
 validate_mobile_workflow
+validate_mobile_profiles
 validate_release_workflow
 validate_git_cliff
 validate_event_matrix

--- a/.github/workflows/mobile-app-build.yml
+++ b/.github/workflows/mobile-app-build.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Upload Android artifact
         uses: actions/upload-artifact@v6
         with:
-          name: openlocker-android-${{ github.ref_name }}
+          name: openlocker-android-${{ github.run_id }}-${{ github.run_attempt }}
           path: mobile-app/build/${{ steps.distribution.outputs.artifact }}
           if-no-files-found: error
           retention-days: 14
@@ -262,7 +262,7 @@ jobs:
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v6
         with:
-          name: openlocker-ios-${{ github.ref_name }}
+          name: openlocker-ios-${{ github.run_id }}-${{ github.run_attempt }}
           path: mobile-app/build/${{ steps.distribution.outputs.artifact }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/mobile-app-build.yml
+++ b/.github/workflows/mobile-app-build.yml
@@ -1,6 +1,12 @@
 name: Mobile App Build
 
 on:
+  pull_request:
+    paths:
+      - 'mobile-app/**'
+      - '.github/git-cliff/mobile.toml'
+      - '.github/workflows/component-release.yml'
+      - '.github/workflows/mobile-app-build.yml'
   push:
     branches:
       - main
@@ -15,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/mobile-v')) && 'mobile-store' || format('mobile-preview-{0}', github.ref) }}
+  group: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v') && 'mobile-store' || format('mobile-preview-{0}', github.ref) }}
   cancel-in-progress: false
 
 env:
@@ -114,20 +120,10 @@ jobs:
             exit 1
           fi
 
-      - name: Verify current main tip for store build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: ${{ github.workspace }}
-        run: |
-          git fetch --no-tags origin main
-          if [[ "${GITHUB_SHA}" != "$(git rev-parse origin/main)" ]]; then
-            echo "::error::Refusing to submit a stale main build."
-            exit 1
-          fi
-
       - name: Select Android distribution
         id: distribution
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && ("${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == refs/tags/mobile-v*) ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/mobile-v* ]]; then
             {
               echo "profile=store"
               echo "artifact=openlocker-android.aab"
@@ -172,7 +168,7 @@ jobs:
           retention-days: 14
 
       - name: Submit Android store candidate
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/mobile-v'))
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
@@ -224,28 +220,20 @@ jobs:
             exit 1
           fi
 
-      - name: Verify current main tip for store build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: ${{ github.workspace }}
-        run: |
-          git fetch --no-tags origin main
-          if [[ "${GITHUB_SHA}" != "$(git rev-parse origin/main)" ]]; then
-            echo "::error::Refusing to submit a stale main build."
-            exit 1
-          fi
-
       - name: Select iOS distribution
         id: distribution
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && ("${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == refs/tags/mobile-v*) ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/mobile-v* ]]; then
             {
               echo "profile=store"
+              echo "artifact=openlocker-ios.ipa"
               echo "channel=production"
             } >> "${GITHUB_OUTPUT}"
           else
             {
-              echo "profile=preview"
-              echo "channel=preview"
+              echo "profile=ios-simulator"
+              echo "artifact=openlocker-ios-simulator.tar.gz"
+              echo "channel=simulator"
             } >> "${GITHUB_OUTPUT}"
           fi
 
@@ -269,18 +257,18 @@ jobs:
             --local --non-interactive \
             --profile "${{ steps.distribution.outputs.profile }}" \
             --platform ios \
-            --output ./build/openlocker-ios.ipa
+            --output "./build/${{ steps.distribution.outputs.artifact }}"
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v6
         with:
           name: openlocker-ios-${{ github.ref_name }}
-          path: mobile-app/build/openlocker-ios.ipa
+          path: mobile-app/build/${{ steps.distribution.outputs.artifact }}
           if-no-files-found: error
           retention-days: 14
 
       - name: Submit TestFlight candidate
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/mobile-v'))
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APP_VARIANT: production
@@ -288,7 +276,7 @@ jobs:
           pnpm dlx "eas-cli@${EAS_CLI_VERSION}" submit \
             --non-interactive \
             --profile production --platform ios \
-            --path ./build/openlocker-ios.ipa
+            --path "./build/${{ steps.distribution.outputs.artifact }}"
 
   release:
     name: Create mobile release

--- a/docs/adr/0032-mobile-internal-test-builds-ci.md
+++ b/docs/adr/0032-mobile-internal-test-builds-ci.md
@@ -120,7 +120,10 @@ Constraints / drivers:
 ## Supersedes / Superseded By
 
 - Supersedes: none
-- Superseded by: none
+- Superseded in part by:
+  [ADR-0055](0055-tag-only-mobile-store-distribution.md) replaces signed
+  `main` builds with unsigned iOS Simulator validation and reserves signed
+  store distribution for `mobile-v*` tags.
 - Extended by: [ADR-0043](0043-monorepo-release-strategy.md) — its decision 7 adds
   `dev` internal builds and `mobile-v*` tagged releases to the distribution
   channels this ADR limits to `main`.

--- a/docs/adr/0043-monorepo-release-strategy.md
+++ b/docs/adr/0043-monorepo-release-strategy.md
@@ -301,6 +301,9 @@ paused.
 ## Supersedes / Superseded By
 
 - Supersedes: none.
+- Superseded in part by:
+  [ADR-0055](0055-tag-only-mobile-store-distribution.md) replaces decision 7's
+  mobile `main` store mapping with tag-only store distribution.
 - Related: mobile internal test-build decisions and website deployment stay
   outside or adjacent to this model; website remains continuous deploy from
   `main`.

--- a/docs/adr/0055-tag-only-mobile-store-distribution.md
+++ b/docs/adr/0055-tag-only-mobile-store-distribution.md
@@ -1,0 +1,104 @@
+# ADR-0055: Tag-only mobile store distribution
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-24
+
+## Context
+
+The mobile release workflow selected signed store builds for pushes to `main`.
+That made the `dev` to `main` synchronization pull request depend on Apple
+Internal Distribution credentials even though no physical iOS test device is
+currently available. Signed iOS device and TestFlight validation is tracked for
+Beta 2 in issue #242.
+
+Backend and locker-client artifacts are independently versioned. Their first
+beta releases must not be blocked by mobile signing work that cannot yet be
+validated on a physical device.
+
+Expo documents that an EAS profile with `ios.simulator: true` produces an iOS
+Simulator build without an Apple Developer account. EAS CLI also supports
+`--non-interactive` for CI. For local builds, EAS packages the simulator
+application directory as a `.tar.gz` artifact when writing the selected output;
+the workflow must not label that archive as an unpacked `.app` directory.
+
+## Decision
+
+1. Pull request, `dev`, `main`, and `workflow_dispatch` mobile runs use the
+   existing Android `preview` profile and a dedicated iOS `ios-simulator`
+   profile with `ios.simulator: true`. The local iOS artifact is retained as a
+   `.tar.gz` archive containing the Simulator `.app`.
+2. Only a pushed `mobile-v*` tag may select the signed `store` profile, submit
+   to TestFlight or the configured Android track, and create a mobile GitHub
+   Release.
+3. A `mobile-v*` tag must still match mobile SemVer and point to the current
+   `main` tip. Tagged releases retain the mobile quality gate, version mapping,
+   and non-canceling global store concurrency.
+4. Manual runs remain preview/simulator-only even when dispatched from a tag.
+5. No `mobile-v*` tag is created until issue #242 has provisioned and validated
+   signing and physical-device distribution for Beta 2. Backend and
+   locker-client beta tags may be created independently before then.
+
+## Alternatives Considered
+
+### Keep signed store builds on `main`
+
+- Pros: exercises store credentials before a mobile tag is created.
+- Cons: blocks ordinary branch synchronization on unavailable Apple
+  credentials and implies physical-device readiness that has not been tested.
+- Why not chosen: store publication must be an explicit mobile release action.
+
+### Skip iOS builds until a physical device is available
+
+- Pros: avoids Apple credentials and macOS build time.
+- Cons: removes native iOS compilation coverage from integration branches.
+- Why not chosen: simulator builds provide useful unsigned native validation.
+
+## Consequences
+
+### Positive
+
+- Branch and manual CI no longer depend on Apple signing or store submission.
+- Backend and locker-client releases can proceed independently.
+- Native iOS compilation remains covered through an installable simulator app.
+
+### Negative
+
+- Simulator success does not validate signing, TestFlight, push notifications,
+  or behavior specific to physical iOS hardware.
+- A mobile release cannot be considered ready until issue #242 is complete.
+
+### Risks
+
+- A future workflow change could accidentally restore store behavior on
+  `main`. The structural validator therefore checks the event/profile matrix
+  and tag-only submit conditions.
+- Apple credential problems may remain undiscovered until Beta 2. Issue #242
+  owns explicit provisioning, expiry, physical-device, and submission evidence.
+
+## Rollout / Migration
+
+Add the simulator profile, update workflow selection and artifacts, and rerun
+the blocked `dev` to `main` checks. Do not run real EAS builds or submissions
+during this migration and do not create a mobile tag.
+
+## Supersedes / Superseded By
+
+- Supersedes: ADR-0043 decision 7 for mobile branch/store mapping and ADR-0032
+  decisions 1, 3, and 5 for `main` iOS distribution
+- Superseded by: none
+
+## References
+
+- Related issues: #50, #242
+- Related ADRs: [ADR-0032](0032-mobile-internal-test-builds-ci.md),
+  [ADR-0043](0043-monorepo-release-strategy.md)
+- Related files: `.github/workflows/mobile-app-build.yml`,
+  `.github/scripts/validate_release_workflows.rb`, `mobile-app/eas.json`
+- Expo documentation:
+  [iOS Simulator builds](https://docs.expo.dev/build-reference/simulators/),
+  [EAS builds on CI](https://docs.expo.dev/build/building-on-ci/)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,7 +23,7 @@ tags follow [ADR-0043](adr/0043-monorepo-release-strategy.md).
 
 ## 1. Hard gates
 
-Do not create release tags or submit store builds until every hard gate is
+Do not create a component's release tag until its applicable hard gates are
 closed and verified.
 
 - [ ] #50 — per-component release workflows and notes are operational with
@@ -32,6 +32,9 @@ closed and verified.
       release-owner acceptance with no unresolved blocker.
 - [ ] #67 — complete the Beta task and record its outcome. It is required Beta
       work even though it is tracked separately from the hard-gate list above.
+- [ ] #242 — before any `mobile-v*` tag, provision iOS signing and validate the
+      signed Beta 2 build on a physical device. This does not block backend or
+      locker-client tags.
 
 The real deployment checks require the versioned images produced by this
 release. External MQTTS acceptance (#233) and the Raspberry Pi/Modbus soak
@@ -66,9 +69,10 @@ work and do not block the first Beta artifacts.
       component release workflow rejects tags on older `main` commits.
 - [ ] Confirm non-`main` and manual workflow runs cannot overwrite `latest` or
       mint a SemVer release.
-- [ ] Confirm the repository `EXPO_TOKEN` secret is available to the mobile
-      workflow and EAS holds valid Android, iOS, and App Store Connect
-      credentials.
+- [ ] Before a `mobile-v*` tag, confirm the repository `EXPO_TOKEN` secret is
+      available and EAS holds valid Android, iOS, and App Store Connect
+      credentials. Branch and manual CI use Android preview and unsigned iOS
+      Simulator builds.
 - [ ] Confirm Actions can write GHCR packages and GitHub Releases through the
       workflow-scoped `GITHUB_TOKEN` permissions.
 - [ ] Create each required component tag using the approved release process.
@@ -79,7 +83,7 @@ work and do not block the first Beta artifacts.
 - [ ] Client multi-architecture image exists under the immutable version tag,
       has the expected digest, and is pullable on the target Pi architecture.
 - [ ] Mobile artifacts identify the intended version/build and originated from
-      the tagged or approved `main` release path.
+      the validated `mobile-v*` release path.
 - [ ] Record immutable tags and image digests. Do not deploy `latest` to the beta
       pilot.
 
@@ -172,10 +176,12 @@ in a controlled deployment and does not block creating those artifacts.
 
 ## 8. Mobile beta distribution
 
+- [ ] Complete #242 in Beta 2 before creating a `mobile-v*` tag; record signing,
+      provisioning, and physical-device evidence.
 - [ ] Verify the candidate against the beta backend on physical iOS and Android
       devices before submission.
-- [ ] Submit the approved `mobile-v*` build to TestFlight and the configured
-      Android Beta/internal testing track from the release path.
+- [ ] Push the approved `mobile-v*` tag to invoke the only workflow path allowed
+      to submit to TestFlight and the configured Android Beta/internal track.
 - [ ] Confirm the Android artifact and track are appropriate for the named pilot;
       an internal APK is not automatically an external beta programme.
 - [ ] Restrict access to the named pilot tester group.

--- a/docs/releases/beta.md
+++ b/docs/releases/beta.md
@@ -183,8 +183,9 @@ in the feature list and change log; collected here so they are hard to miss.
 - Auto-logout on `401` with a session-expired message (`#60`).
 - EN/DE localization with a persisted in-app language switcher; centralized theme and UI
   defaults, dark-mode-aware logo and splash scaling (`#93`, `#98`).
-- Internal test builds from CI: EAS build + TestFlight submission from `main`
-  (`#19`, ADR-0032).
+- Branch CI builds Android preview and unsigned iOS Simulator artifacts; signed
+  TestFlight distribution is reserved for `mobile-v*` after Beta 2 issue #242
+  (`#19`, ADR-0032, ADR-0055).
 - Legacy auth context and hand-written API layer removed (`#85`).
 - react-doctor evaluated for code health, expo-doctor kept in the quality gate (`#64`).
 
@@ -312,7 +313,7 @@ Grouped by component; `feat` / `fix` / `perf` from the Conventional Commit histo
 ### Mobile app
 
 **Features**
-- Internal test build CI from `main`, EAS + TestFlight (`#19`)
+- Android preview and unsigned iOS Simulator CI from `main` (`#19`, ADR-0055)
 - Realtime compartment door state via Reverb (`#45`)
 - Auto-logout on `401` with a session-expired message
 - Content notes and the event-sourced compartment model
@@ -323,7 +324,8 @@ Grouped by component; `feat` / `fix` / `perf` from the Conventional Commit histo
 
 **Fixes**
 - Align the Expo patch version; align `expo-localization` with the SDK
-- Set `ascAppId` and `APP_VARIANT` for non-interactive iOS TestFlight submits (`#19`)
+- Set `ascAppId` and `APP_VARIANT` for tag-only non-interactive iOS TestFlight
+  submits (`#19`)
 - Correct logo and splash-screen scaling, with dark-mode support (`#93`)
 - Prevent an empty-compartments flash on load
 - Guard the reset-password response message
@@ -412,16 +414,17 @@ Beta artifacts.
 
 1. Complete all component checks on `dev`, synchronize the approved candidate to
    `main`, and rerun protected checks.
-2. Create only the required component tags (`backend-v*`, `client-v*`,
-   `mobile-v*`) on the intended `main` commit and verify immutable artifacts and
-   release notes.
+2. Create the required `backend-v*` and `client-v*` tags on the intended `main`
+   commit and verify immutable artifacts and release notes. Defer `mobile-v*`
+   until Beta 2 issue #242 validates signing and a physical iOS device.
 3. Record the immutable tags, image digests, compatibility notes, and the mandatory
    client-first credential rollout order from PR `#227`. Do not deploy `latest`.
 
-Beta 2 then deploys those immutable artifacts for external MQTTS acceptance
-(#233), the Raspberry Pi/Modbus soak (#169), and the remaining controlled pilot
-checks. Those field results determine whether the pilot continues; they are not
-prerequisites for cutting the Beta 1 tags.
+Beta 2 then deploys those immutable backend/client artifacts for external MQTTS
+acceptance (#233), the Raspberry Pi/Modbus soak (#169), and the remaining
+controlled pilot checks. It also completes #242 before creating the first
+`mobile-v*` tag. Those field results determine whether the pilot continues; they
+are not prerequisites for cutting the Beta 1 backend and client tags.
 
 The core feature set is intended to support authenticate → list accessible
 compartments → open → live door-state update. The artifact cut depends on the

--- a/mobile-app/docs/internal-builds.md
+++ b/mobile-app/docs/internal-builds.md
@@ -1,18 +1,17 @@
 # Mobile App — Build and Release CI (Maintainer Guide)
 
 This guide covers the branch and tag channels implemented by
-[ADR-0043](../../docs/adr/0043-monorepo-release-strategy.md). Signing credentials
-remain on EAS; GitHub Actions receives only `EXPO_TOKEN`.
+[ADR-0055](../../docs/adr/0055-tag-only-mobile-store-distribution.md). Signing
+credentials remain on EAS; GitHub Actions receives only `EXPO_TOKEN`.
 
 ## Overview
 
 GitHub Actions uses `eas build --local` on GitHub-hosted runners:
 
 ```
-dev / manual ──▶ preview profile ──▶ internal artifacts only
-main         ──▶ store profile   ──▶ TestFlight + Android internal track
-mobile-v*    ──▶ main ancestry gate + quality
-             ──▶ store profile + submissions + GitHub Release
+PR / dev / main / manual ──▶ Android preview + iOS Simulator artifacts
+mobile-v*                  ──▶ main-tip gate + quality
+                           ──▶ signed store builds + submissions + GitHub Release
 ```
 
 Store processing is asynchronous. The tag workflow creates the GitHub Release
@@ -32,12 +31,11 @@ runtime and diagnostic metadata.
 
 The complete mobile store workflow uses one global `mobile-store` concurrency
 group with `cancel-in-progress: false`. A running tag release therefore finishes
-before a `main` or later tag run can start, so neither platform can be canceled
-halfway through a release. GitHub retains only one pending run per concurrency
-group: a newly queued store run replaces an older pending run before any of its
-jobs start. If that replaces a pending tag run, rerun that original tag-triggered
-workflow from the Actions UI. Reruns from a stale `main` commit still fail before
-building or submitting.
+before a later tag run can start, so neither platform can be canceled halfway
+through a release. Branch and manual simulator/preview builds use ref-specific
+concurrency groups and do not queue behind store releases. GitHub retains only
+one pending run per concurrency group: if a newer tag replaces a pending tag
+run, rerun the original tag-triggered workflow from the Actions UI.
 
 ## Project facts
 
@@ -49,8 +47,9 @@ building or submitting.
 | Bundle ID (iOS + Android) | `de.merona.openlocker` (set via `APP_ID_BASE`)                                            |
 | Apple Team                | `UKC9C5ZQPC` (merona, Company/Organization)                                               |
 | Google Play account       | merona                                                                                    |
-| Internal build profile    | `preview` (`dev` and manual runs; no store submission)                                    |
-| Store build profile       | `store` (`main` and validated `mobile-v*` tags)                                           |
+| Android branch profile    | `preview` (PR, `dev`, `main`, and manual; no store submission)                            |
+| iOS branch profile        | `ios-simulator` (PR, `dev`, `main`, and manual; no Apple signing)                         |
+| Store build profile       | `store` (validated `mobile-v*` tags only)                                                 |
 | Store submit profile      | `production` (TestFlight and Android internal track)                                      |
 
 > ⚠️ `app.config.ts` **throws** for the `production` variant unless `APP_ID_BASE`
@@ -111,14 +110,11 @@ This writes (all **gitignored**, never commit): `credentials.json`,
 
 ## Distribution to testers
 
-- **`dev` and manual runs:** the `preview` profile produces internal artifacts;
-  neither platform is submitted to a store.
-- **`main`:** the `store` profile produces an Android App Bundle and iOS IPA.
-  The workflow submits them using the `production` submit profile to the Android
-  internal track and TestFlight.
-- **`mobile-v*`:** the same store path runs only after the tag commit is proven
-  to be contained in `main` and mobile quality checks pass. Accepted submissions
-  are followed by a component-scoped GitHub Release.
+- **Pull requests, `dev`, `main`, and manual runs:** Android uses `preview`; iOS
+  uses the unsigned `ios-simulator` profile. Neither platform is submitted.
+- **`mobile-v*`:** the signed store path runs only after the tag commit is proven
+  to be the current `main` tip and mobile quality checks pass. Accepted
+  submissions are followed by a component-scoped GitHub Release.
 
 ## Installing a build (for testers)
 
@@ -152,30 +148,36 @@ x86 emulator, build locally with `pnpm android` instead.
    adb install ./apk/openlocker-android.apk
    ```
 
-### iOS (real iPhone only, via TestFlight)
+### iOS Simulator (branch and manual builds)
 
-Apple does not allow sideloading an `.ipa`; iOS testers install through
-TestFlight. The iOS job runs `eas submit`, which uploads the build to TestFlight.
+The iOS job uploads `openlocker-ios-simulator.tar.gz`. EAS Local Build creates
+this archive from its `.app` application directory. Extract it and install the
+contained app on a booted Simulator:
 
-1. In **App Store Connect** → the app → **TestFlight**, add the tester as an
-   **internal tester** (their Apple ID email).
-2. The tester installs the **TestFlight** app from the App Store on their iPhone.
-3. They accept the invite (email / redeem code) → the build appears in TestFlight
-   → tap **Install**.
+```bash
+tar -xzf openlocker-ios-simulator.tar.gz
+xcrun simctl install booted OpenLocker.app
+```
 
-> The iOS Simulator cannot run this `.ipa` (it is a device build). iOS testing
-> requires a real iPhone via TestFlight.
+The exact `.app` name is the directory found in the archive. Simulator success
+does not validate Apple signing, TestFlight, or physical-device behavior.
+
+### iOS physical devices (tagged release only)
+
+Only a validated `mobile-v*` tag builds the signed `.ipa` and submits it to
+TestFlight. Provisioning and physical-device validation are deferred to Beta 2
+in issue #242; do not create a mobile release tag until that issue is complete.
 
 ## Manual rebuild
 
-**Run workflow** (`workflow_dispatch`) is deliberately an internal `preview`
-build, regardless of the selected ref. It never submits to a store or creates a
-versioned release. Build locally with:
+**Run workflow** (`workflow_dispatch`) is deliberately an Android preview and
+iOS Simulator build, regardless of the selected ref. It never submits to a
+store or creates a versioned release. Build locally with:
 
 ```bash
 cd mobile-app
 APP_ID_BASE=de.merona.openlocker eas build --local --profile preview --platform android
-APP_ID_BASE=de.merona.openlocker eas build --local --profile preview --platform ios
+APP_ID_BASE=de.merona.openlocker eas build --local --profile ios-simulator --platform ios
 ```
 
 (Local builds need Java/Android SDK for Android and Xcode for iOS.)
@@ -200,9 +202,9 @@ and the TestFlight submit completes.
 - [x] Android store artifact: `.aab` submitted to the configured internal track.
 - [x] iOS: TestFlight upload step added (`eas submit` in the workflow).
 - [ ] Add `EXPO_TOKEN` secret to the GitHub repo.
-- [ ] Validate via `workflow_dispatch`, then a real push to `main`.
+- [ ] Validate branch/manual Android preview and iOS Simulator artifacts.
 - [x] iOS `eas submit` needs the App Store Connect app id in CI — set
       `submit.production.ios.ascAppId: "6743854342"` in `eas.json` (public, not secret).
 - [x] Android: CI-produced APK installed on a device (issue #19 acceptance, Android side).
-- [ ] iOS: Account Holder signs the App Store Connect agreement, then TestFlight submit succeeds.
-- [ ] iOS: teammate installs via TestFlight (issue #19 acceptance, iOS side).
+- [ ] Beta 2 / #242: renew signing, validate the `mobile-v*` TestFlight submit,
+      and install the result on a physical iOS device.

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -19,6 +19,12 @@
         "APP_VARIANT": "preview"
       }
     },
+    "ios-simulator": {
+      "extends": "preview",
+      "ios": {
+        "simulator": true
+      }
+    },
     "production": {
       "channel": "production",
       "autoIncrement": true,


### PR DESCRIPTION
## Summary
- run Android preview and unsigned iOS Simulator builds for pull requests, `dev`, `main`, and manual dispatches
- reserve signed store builds, submissions, and GitHub Releases for validated `mobile-v*` tag pushes
- document the decision in [ADR-0055](docs/adr/0055-tag-only-mobile-store-distribution.md) and defer physical-device signing validation to #242

## Test plan
- [x] `actionlint` 1.7.12
- [x] Ruby release workflow validator, YAML parsing, and JSON parsing
- [x] EAS CLI 21.8.0 config resolution for `preview`, `ios-simulator`, and `store` profiles
- [x] `cd mobile-app && pnpm check`
- [x] `cd mobile-app && pnpm test:ci`
- [x] changed Markdown local-link validation and `git diff --check`
- [ ] required pull request checks pass, including local Android preview and iOS Simulator builds

Related: #50, #242

Made with [Cursor](https://cursor.com)