### PR TITLE
fix(mobile): show the current name, not the one from login (#245)

### DIFF
--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -29,6 +29,7 @@ import {
   usePutCompartmentsByCompartmentContentNoteMutation,
 } from '@/src/store/generatedApi';
 import { useAppSelector } from '@/src/store/hooks';
+import { useUserName } from '@/src/auth/useUserName';
 import {
   getCompartmentStatusPalette,
   getLockerStatusPalette,
@@ -125,7 +126,7 @@ function getFakeLockerStatus(lockerBankId: string): LockerVisualStatus {
 export default function CompartmentsScreen() {
   const { t } = useTranslation();
   const token = useAppSelector((state) => state.auth.token);
-  const userName = useAppSelector((state) => state.auth.userName);
+  const userName = useUserName();
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const scrollY = React.useRef(new Animated.Value(0)).current;

--- a/mobile-app/app/account.tsx
+++ b/mobile-app/app/account.tsx
@@ -14,7 +14,8 @@ import {
   usePutPasswordMutation,
   usePutProfileMutation,
 } from '@/src/store/generatedApi';
-import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
+import { useAppDispatch } from '@/src/store/hooks';
+import { useUserName } from '@/src/auth/useUserName';
 import { OPEN_LOCKER_DESIGN_TOKENS } from '@/src/theme/tokens';
 import { AppButton, AppTextInput, LanguageToggle } from '@/src/ui';
 
@@ -35,7 +36,7 @@ function getErrorMessage(
 export default function AccountScreen() {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const userName = useAppSelector((state) => state.auth.userName);
+  const userName = useUserName();
   const theme = useTheme();
   const { data: user, refetch } = useGetUserQuery();
   const [updateProfile, updateProfileState] = usePutProfileMutation();

--- a/mobile-app/src/auth/useUserName.test.tsx
+++ b/mobile-app/src/auth/useUserName.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-native';
+import { useUserName } from './useUserName';
+
+const mockUseGetUserQuery = jest.fn();
+const mockUseAppSelector = jest.fn();
+
+jest.mock('@/src/store/generatedApi', () => ({
+  useGetUserQuery: () => mockUseGetUserQuery(),
+}));
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: (selector: unknown) => mockUseAppSelector(selector),
+}));
+
+describe('useUserName', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefers the name the API returns over the one stored at login', () => {
+    // The bug this replaces: the account screen showed the login-time name while
+    // its own input field showed the updated one.
+    mockUseAppSelector.mockReturnValue('Old Name');
+    mockUseGetUserQuery.mockReturnValue({ data: { first_name: 'New', last_name: 'Name' } });
+
+    const { result } = renderHook(() => useUserName());
+
+    expect(result.current).toBe('New Name');
+  });
+
+  it('falls back to the stored name until the query resolves', () => {
+    // On a cold start there is no query result yet. Showing nothing would trade a
+    // stale name for a blank one.
+    mockUseAppSelector.mockReturnValue('Stored Name');
+    mockUseGetUserQuery.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() => useUserName());
+
+    expect(result.current).toBe('Stored Name');
+  });
+
+  it('reports no name rather than an empty string when the user has none', () => {
+    mockUseAppSelector.mockReturnValue('Stored Name');
+    mockUseGetUserQuery.mockReturnValue({ data: { first_name: '', last_name: null } });
+
+    const { result } = renderHook(() => useUserName());
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/mobile-app/src/auth/useUserName.ts
+++ b/mobile-app/src/auth/useUserName.ts
@@ -1,0 +1,26 @@
+import { useGetUserQuery } from '@/src/store/generatedApi';
+import { useAppSelector } from '@/src/store/hooks';
+import { formatUserName } from '@/src/utils/userName';
+
+/**
+ * The signed-in user's display name.
+ *
+ * Read from the API rather than from the auth slice. The slice is written once,
+ * at login, and nothing rewrites it afterwards — so a name changed in the account
+ * screen stayed stale everywhere it was displayed, and survived a restart because
+ * the slice is persisted. Only logging out and back in cleared it.
+ *
+ * The slice is still the fallback, and only that: on a cold start it has a name
+ * to show immediately, where the query has not resolved yet. Trading a stale name
+ * for a blank one would not be an improvement.
+ */
+export function useUserName(): string | null {
+  const persistedName = useAppSelector((state) => state.auth.userName);
+  const { data: user } = useGetUserQuery();
+
+  if (user) {
+    return formatUserName(user.first_name, user.last_name) || null;
+  }
+
+  return persistedName;
+}


### PR DESCRIPTION
Closes #245.

## What was wrong

`auth.userName` is written in exactly one place — `sign-in.tsx` — and nothing rewrites it afterwards. Two screens read it:

- the account screen header ("Signed in as …")
- the home tab greeting

So changing your name in the account screen left both showing the login-time value, while the input field right beneath the header — which reads `useGetUserQuery()` — showed the new one. That side-by-side mismatch is what made it look so odd.

The slice is persisted, which is why the old name survived an app restart, and why only logging out and back in fixed it: login is the only code path that ever sets it.

The home tab had the same staleness; the ticket only mentions the account screen.

## The fix

A `useUserName()` hook backed by the user query, used by both screens. The persisted name stays as the fallback until that query resolves — on a cold start there is no result yet, and showing nothing would trade a stale name for a blank one.

Reading from the API rather than mirroring it into the slice is what stops the two drifting again; the duplication is what caused this.

## Verified

Manually: changed the first name in the app and watched the header update immediately, including after a restart. Plus `pnpm check` (18/18) and 19 tests across 6 suites, including three new cases for the hook — API name wins, fallback before the query resolves, and a user with no name reporting `null` rather than an empty string.