### PR TITLE
fix(ci): resolve the production app id when submitting Android

### DIFF
--- a/.github/workflows/mobile-app-build.yml
+++ b/.github/workflows/mobile-app-build.yml
@@ -171,6 +171,12 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mobile-v')
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          # Submitting evaluates app.config.ts again, and the variant decides the
+          # application id. Without this it falls back to development and looks up
+          # credentials for de.merona.openlocker.dev — an id the store build never
+          # produced. The build itself is unaffected: it runs the store profile,
+          # which inherits this from production.
+          APP_VARIANT: production
         run: |
           pnpm dlx "eas-cli@${EAS_CLI_VERSION}" submit \
             --non-interactive \


### PR DESCRIPTION
The `mobile-v1.0.0-beta.1` run failed at the Android submit. Two separate problems came out of it; this PR fixes the second.

## What this fixes

The Android submit step passed only `EXPO_TOKEN`, so eas-cli re-evaluated `app.config.ts` with no `APP_VARIANT`, fell back to `development`, and looked up Play credentials for **`de.merona.openlocker.dev`** — an application id the store build never produces.

The build itself was fine: it runs `--profile store`, which extends `production` and carries `APP_VARIANT: production`. Submit profiles have no `env` of their own, so it has to come from the workflow step. The **TestFlight step already sets it** — Android was simply the one that didn't.

## What this does not fix

The actual failure in that run:

```
Looking up credentials configuration for de.merona.openlocker.dev...
Google Service Account Keys cannot be set up in --non-interactive mode.
```

No Google Play service account is configured on EAS, so a non-interactive submit cannot authenticate at all. That needs setting up in the Play Console and uploading to EAS — tracked separately. This PR only stops the next attempt failing twice, once authentication works.

## Note on the tag

`mobile-v1.0.0-beta.1` published nothing — no GitHub Release, nothing to the store — so nothing references it. Whether it gets re-pushed at the fixed commit or superseded by `beta.2` is a call for the release owner, not this PR.