### PR TITLE
fix(mobile): refresh terms acceptance without restarting the app (#250)

### DIFF
--- a/docs/adr/0056-account-state-on-its-own-realtime-channel.md
+++ b/docs/adr/0056-account-state-on-its-own-realtime-channel.md
@@ -1,0 +1,120 @@
+# ADR-0056: Account-level realtime state gets its own per-user channel
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-25
+
+## Context
+
+[ADR-0023](0023-mobile-realtime-compartment-status-via-reverb.md) put compartment
+state on a private per-user Reverb channel, `users.{id}.compartment-status`. It is
+the only channel the app subscribes to.
+
+Terms acceptance needed the same treatment. A user's profile carries
+`terms_current_accepted`, the app caches it, and nothing told the app when new
+terms were activated — so the prompt to accept never appeared and every write
+failed with a 403 the app could not explain (#250).
+
+The obvious shortcut was to broadcast that on the existing channel. It is already
+authorised in `routes/channels.php`, the app is already subscribed, and Echo is
+already connected. Adding one more `listen()` would have been a two-line change
+with no new plumbing at all.
+
+## Decision
+
+Account-level state broadcasts on its own private channel, `users.{id}.account`,
+authorised the same way as the compartment channel.
+
+A channel is named after what it carries. `compartment-status` carrying "your
+terms are out of date" makes the name a lie, and a name that has lied once stops
+being read — the next unrelated event goes on whichever channel is nearest, and
+the app ends up filtering a firehose to find what it cares about.
+
+Both channels are served by **one Echo instance**. A hook per channel would open a
+websocket per channel, and this event fires perhaps twice a year.
+
+The payload is a signal, not content: `TermsAcceptanceRequired` carries a version
+number and nothing else. The app invalidates its cached profile and re-reads it,
+so there is exactly one answer to "must I accept" and it comes from the API.
+Broadcasting the terms themselves would put a second copy on the wire, free to
+disagree with the first.
+
+Broadcasts hang off **activation**, not publication. `terms_current_accepted`
+compares a user's acceptance against the *active* version, so activation is the
+moment the cached profile becomes wrong. Today one service call records both, but
+an activate-an-existing-version path would otherwise broadcast nothing.
+
+## Rationale
+
+The realtime path is not the only defence, and should not be. #250 also added a
+403-triggered refresh and extended the existing reconnect/foreground fallback, so
+a user whose socket is down still recovers. This channel is the fast path, not the
+guarantee — which is why a missed event costs latency rather than correctness.
+
+## Alternatives Considered
+
+### Alternative A: Broadcast on `users.{id}.compartment-status`
+
+- Pros: no new channel, no new authorisation, no new subscription; two lines.
+- Cons: the channel name stops describing its contents, and the precedent invites
+  every future event onto it.
+- Why not chosen: the saving is a few lines once; the cost is paid by every reader
+  afterwards.
+
+### Alternative B: A second Echo instance for the account channel
+
+- Pros: clean separation, each hook owning its own connection.
+- Cons: a second websocket per session for an event that fires rarely.
+- Why not chosen: channels are cheap, connections are not.
+
+### Alternative C: Poll the profile instead
+
+- Pros: no broadcast, no channel, no authorisation.
+- Cons: either slow to notice or wasteful; and the fallbacks already cover the
+  cases polling would.
+- Why not chosen: the infrastructure for pushing this already exists.
+
+## Consequences
+
+### Positive
+
+- Channel names keep describing their contents, so where a new event belongs stays
+  an easy question.
+- Account state can grow (verification status, role changes) without touching the
+  compartment channel.
+- One websocket per session, unchanged.
+
+### Negative
+
+- Two channel names to authorise, subscribe and keep in step across two codebases.
+  Nothing fails loudly when they drift — the app simply stops hearing the event —
+  so both names are pinned by tests on each side.
+
+### Risks
+
+- **A missed broadcast is invisible.** No acknowledgement, no retry. Mitigated by
+  design: the 403 refresh and the reconnect/foreground fallback both recover the
+  same state, so this path failing is a delay rather than a defect.
+
+## Rollout / Migration
+
+Additive. Existing clients subscribe to one channel and ignore the other; nothing
+breaks if the app updates after the backend, only the live update is missing until
+it does.
+
+## Supersedes / Superseded By
+
+- Supersedes: none.
+- Related: [ADR-0023](0023-mobile-realtime-compartment-status-via-reverb.md) —
+  established the per-user private channel pattern this follows.
+
+## References
+
+- Related issues: #250
+- Code: `app/Events/TermsAcceptanceRequired.php`,
+  `app/Reactors/TermsNotificationReactor.php`, `routes/channels.php`,
+  `mobile-app/src/features/realtime/useCompartmentStatusRealtime.ts`

--- a/locker-backend/app/Events/TermsAcceptanceRequired.php
+++ b/locker-backend/app/Events/TermsAcceptanceRequired.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Tells connected apps that the terms they are holding are no longer the current
+ * ones, so the profile they cached is stale.
+ *
+ * Carries the version and nothing else. The app re-reads its own profile to learn
+ * what it now needs to do; sending terms content here would put a second copy of
+ * the answer on the wire, free to disagree with the first.
+ */
+class TermsAcceptanceRequired implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @param  list<int>  $recipientUserIds
+     */
+    public function __construct(
+        public readonly array $recipientUserIds,
+        public readonly int $version,
+    ) {}
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return array_map(
+            fn (int $userId) => new PrivateChannel("users.{$userId}.account"),
+            $this->recipientUserIds
+        );
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'terms.acceptance-required';
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function broadcastWith(): array
+    {
+        return ['version' => $this->version];
+    }
+}

--- a/locker-backend/app/Reactors/TermsNotificationReactor.php
+++ b/locker-backend/app/Reactors/TermsNotificationReactor.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Reactors;
 
+use App\Events\TermsAcceptanceRequired;
 use App\Models\TermsDocument;
 use App\Models\User;
 use App\Notifications\Terms\TermsVersionPublishedNotification;
+use App\StorableEvents\TermsVersionActivated;
 use App\StorableEvents\TermsVersionPublished;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
@@ -31,6 +33,27 @@ class TermsNotificationReactor extends Reactor implements ShouldQueue
                         version: $event->version
                     )
                 );
+            });
+    }
+
+    /**
+     * Activation, not publication, is what makes acceptance required: a user's
+     * `terms_current_accepted` compares their acceptance against the *active*
+     * version. Today one service call records both, so the two moments coincide —
+     * but an activate-an-existing-version path would leave apps holding a stale
+     * profile if this hung off publication instead.
+     */
+    public function onTermsVersionActivated(TermsVersionActivated $event): void
+    {
+        User::query()
+            ->select(['id'])
+            ->chunkById(250, function ($users) use ($event): void {
+                // One broadcast per chunk rather than per user: the event maps its
+                // recipients to a channel each, so a chunk is a single dispatch.
+                event(new TermsAcceptanceRequired(
+                    recipientUserIds: array_values($users->pluck('id')->map(fn ($id) => (int) $id)->all()),
+                    version: $event->version,
+                ));
             });
     }
 }

--- a/locker-backend/routes/channels.php
+++ b/locker-backend/routes/channels.php
@@ -9,3 +9,10 @@ Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
 Broadcast::channel('users.{id}.compartment-status', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+// Account-level state the app caches and cannot otherwise learn has changed —
+// terms acceptance today. Kept apart from compartment-status so a channel name
+// keeps meaning what it says.
+Broadcast::channel('users.{id}.account', function ($user, $id) {
+    return (int) $user->id === (int) $id;
+});

--- a/locker-backend/tests/Feature/TermsControllerTest.php
+++ b/locker-backend/tests/Feature/TermsControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Events\TermsAcceptanceRequired;
 use App\Models\Compartment;
 use App\Models\TermsDocument;
 use App\Models\TermsDocumentVersion;
@@ -13,6 +14,7 @@ use App\Notifications\Terms\TermsVersionPublishedNotification;
 use App\Services\TermsService;
 use App\StorableEvents\UserAcceptedTermsVersion;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use LogicException;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
@@ -261,5 +263,50 @@ class TermsControllerTest extends TestCase
             ->count();
 
         $this->assertSame(1, $draftCount);
+    }
+
+    public function test_publishing_a_version_broadcasts_that_acceptance_is_required(): void
+    {
+        // Without this the app keeps serving a cached profile that says the user is
+        // fine, so the prompt to accept never appears and every write fails with a
+        // 403 it cannot explain.
+        Notification::fake();
+        Event::fake([TermsAcceptanceRequired::class]);
+
+        $admin = User::factory()->create();
+        $user = User::factory()->create();
+
+        app(TermsService::class)->publishNewVersion('AGB', '<p>Version 1</p>', $admin);
+
+        Event::assertDispatched(
+            TermsAcceptanceRequired::class,
+            function (TermsAcceptanceRequired $event) use ($admin, $user): bool {
+                $this->assertContains($admin->id, $event->recipientUserIds);
+                $this->assertContains($user->id, $event->recipientUserIds);
+                $this->assertSame(1, $event->version);
+
+                return true;
+            }
+        );
+    }
+
+    public function test_the_broadcast_reaches_each_recipient_on_their_own_account_channel(): void
+    {
+        $first = User::factory()->create();
+        $second = User::factory()->create();
+
+        $event = new TermsAcceptanceRequired([$first->id, $second->id], 3);
+
+        $channels = array_map(
+            fn ($channel) => (string) $channel,
+            $event->broadcastOn()
+        );
+
+        $this->assertSame(
+            ["private-users.{$first->id}.account", "private-users.{$second->id}.account"],
+            $channels
+        );
+        // A signal, not a copy of the terms: the app re-reads its own profile.
+        $this->assertSame(['version' => 3], $event->broadcastWith());
     }
 }

--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -25,6 +25,7 @@ import { ActivityIndicator, Button, Chip, HelperText, Text, useTheme } from 'rea
 import {
   type GetCompartmentsAccessibleApiResponse,
   useGetCompartmentsAccessibleQuery,
+  useGetUserQuery,
   usePostCompartmentsByCompartmentOpenMutation,
   usePutCompartmentsByCompartmentContentNoteMutation,
 } from '@/src/store/generatedApi';
@@ -127,6 +128,8 @@ export default function CompartmentsScreen() {
   const { t } = useTranslation();
   const token = useAppSelector((state) => state.auth.token);
   const userName = useUserName();
+  const { refetch: refetchUser } = useGetUserQuery();
+  const [isPullRefreshing, setIsPullRefreshing] = React.useState(false);
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const scrollY = React.useRef(new Animated.Value(0)).current;
@@ -137,7 +140,6 @@ export default function CompartmentsScreen() {
     data,
     error,
     isLoading,
-    isFetching,
     refetch: refetchCompartments,
   } = useGetCompartmentsAccessibleQuery(token ? undefined : skipToken);
   const [selectedCompartment, setSelectedCompartment] = React.useState<CompartmentEntry | null>(
@@ -341,9 +343,18 @@ export default function CompartmentsScreen() {
         scrollEventThrottle={16}
         refreshControl={
           <RefreshControl
-            refreshing={isFetching && !isLoading}
+            refreshing={isPullRefreshing}
             onRefresh={() => {
-              void refetchCompartments();
+              // Tied to the gesture rather than to either query's fetching flag:
+              // a realtime event or a 403 also refetches these, and a spinner
+              // nobody pulled looks like a bug.
+              setIsPullRefreshing(true);
+              // Pulling down is the gesture people reach for when something looks
+              // wrong, and stale terms acceptance is one of the things that can be
+              // wrong — the tab layout reads it to decide whether to prompt.
+              void Promise.all([refetchCompartments(), refetchUser()]).finally(() =>
+                setIsPullRefreshing(false),
+              );
             }}
           />
         }

--- a/mobile-app/src/features/realtime/accountChannel.test.ts
+++ b/mobile-app/src/features/realtime/accountChannel.test.ts
@@ -1,0 +1,18 @@
+import { TERMS_ACCEPTANCE_EVENT, accountChannelName } from './useCompartmentStatusRealtime';
+
+describe('account channel contract', () => {
+  // Both halves are string literals in two repositories' worth of code. Nothing
+  // fails loudly when they drift — the app simply stops hearing the event — so
+  // they are pinned here against the backend's channel route and broadcastAs().
+  it('subscribes to the channel the backend authorises', () => {
+    expect(accountChannelName(42)).toBe('users.42.account');
+  });
+
+  it('listens for the name the backend broadcasts as', () => {
+    expect(TERMS_ACCEPTANCE_EVENT).toBe('.terms.acceptance-required');
+  });
+
+  it('keeps the leading dot that stops Echo namespacing the event', () => {
+    expect(TERMS_ACCEPTANCE_EVENT.startsWith('.')).toBe(true);
+  });
+});

--- a/mobile-app/src/features/realtime/useCompartmentStatusRealtime.ts
+++ b/mobile-app/src/features/realtime/useCompartmentStatusRealtime.ts
@@ -15,6 +15,14 @@ import {
 
 const DOOR_STATE_EVENT = '.compartment.door_state.updated';
 const CONTENT_NOTE_EVENT = '.compartment.content_note.updated';
+/** Must match `TermsAcceptanceRequired::broadcastAs()`. The leading dot stops Echo
+ *  prefixing its namespace. */
+export const TERMS_ACCEPTANCE_EVENT = '.terms.acceptance-required';
+
+/** Must match the channel authorised in the backend's routes/channels.php. */
+export function accountChannelName(userId: number | string): string {
+  return `users.${userId}.account`;
+}
 
 /**
  * Subscribes the signed-in user to their private compartment-status channel and
@@ -44,6 +52,9 @@ export function useCompartmentStatusRealtime(): void {
 
     const echo = createEcho(token);
     const channelName = `users.${userId}.compartment-status`;
+    // Account-level state rides the same socket. A second Echo instance would mean
+    // a second websocket per session for one rare event.
+    const accountChannel = accountChannelName(userId);
 
     const handleDoorState = (payload: CompartmentDoorStateUpdatedPayload) => {
       dispatch(
@@ -62,14 +73,26 @@ export function useCompartmentStatusRealtime(): void {
     };
 
     // Independent of the socket: a plain REST refetch to reconcile missed events.
+    // Runs when the socket drops and when the app returns to the foreground.
+    // `Auth` is included because the user's terms acceptance goes stale the same
+    // way compartment state does, and restarting the app was the only thing that
+    // refreshed it.
     const refetchFallback = () => {
-      dispatch(openLockerApi.util.invalidateTags(['Compartment']));
+      dispatch(openLockerApi.util.invalidateTags(['Compartment', 'Auth']));
+    };
+
+    // The payload carries only a version; the profile is re-read rather than
+    // patched, so there is one answer to "must I accept" and it comes from the API.
+    const handleTermsAcceptanceRequired = () => {
+      dispatch(openLockerApi.util.invalidateTags(['Auth']));
     };
 
     echo
       .private(channelName)
       .listen(DOOR_STATE_EVENT, handleDoorState)
       .listen(CONTENT_NOTE_EVENT, handleContentNote);
+
+    echo.private(accountChannel).listen(TERMS_ACCEPTANCE_EVENT, handleTermsAcceptanceRequired);
 
     const connection = (echo.connector as { pusher: { connection: PusherConnection } }).pusher
       .connection;
@@ -87,6 +110,7 @@ export function useCompartmentStatusRealtime(): void {
       connection.unbind('unavailable', refetchFallback);
       connection.unbind('disconnected', refetchFallback);
       echo.leave(channelName);
+      echo.leave(accountChannel);
       echo.disconnect();
     };
   }, [token, userId, dispatch]);

--- a/mobile-app/src/store/baseApi.ts
+++ b/mobile-app/src/store/baseApi.ts
@@ -2,6 +2,7 @@ import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolk
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import { getApiBaseUrl } from '@/src/api/baseUrl';
+import { isTermsNotAcceptedError } from './termsGate';
 import { getCurrentAppLanguage } from '@/src/i18n';
 import { markSessionExpired } from '@/src/store/authSlice';
 import { clearPersistedAuth } from '@/src/store/authStorage';
@@ -74,11 +75,23 @@ const baseQueryWithSessionExpiry: BaseQueryFn<
     }
   }
 
+  // A 403 from the terms gate means the user's cached profile is out of date: new
+  // terms were activated after it was fetched. Without this the app keeps showing
+  // a stale `terms_current_accepted`, so the banner that explains the refusal
+  // never appears and every action fails for no visible reason.
+  if (result.error?.status === 403 && isTermsNotAcceptedError(result.error.data)) {
+    api.dispatch(baseApi.util.invalidateTags(['Auth']));
+  }
+
   return result;
 };
 
 export const baseApi = createApi({
   reducerPath: 'openLockerApi',
   baseQuery: baseQueryWithSessionExpiry,
+  // The generated API adds the rest through `enhanceEndpoints`. `Auth` is declared
+  // here because the base query itself invalidates it, and importing the generated
+  // list from here would be circular.
+  tagTypes: ['Auth'],
   endpoints: () => ({}),
 });

--- a/mobile-app/src/store/termsGate.test.ts
+++ b/mobile-app/src/store/termsGate.test.ts
@@ -1,0 +1,30 @@
+import { isTermsNotAcceptedError } from './termsGate';
+
+describe('isTermsNotAcceptedError', () => {
+  it('recognises the gate by its code', () => {
+    expect(
+      isTermsNotAcceptedError({
+        message: 'You must accept the latest terms before continuing.',
+        code: 'terms_not_accepted',
+        terms_current_version: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores other refusals that happen to be 403', () => {
+    // Access denied to a compartment is also a 403, and must not quietly refetch
+    // the profile as though the terms had changed.
+    expect(isTermsNotAcceptedError({ code: 'forbidden' })).toBe(false);
+    expect(isTermsNotAcceptedError({ message: 'Forbidden' })).toBe(false);
+  });
+
+  it('is not fooled by a message mentioning terms', () => {
+    expect(isTermsNotAcceptedError({ message: 'terms_not_accepted' })).toBe(false);
+  });
+
+  it('handles bodies that are not objects at all', () => {
+    expect(isTermsNotAcceptedError('terms_not_accepted')).toBe(false);
+    expect(isTermsNotAcceptedError(null)).toBe(false);
+    expect(isTermsNotAcceptedError(undefined)).toBe(false);
+  });
+});

--- a/mobile-app/src/store/termsGate.ts
+++ b/mobile-app/src/store/termsGate.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether a refusal came from the terms gate.
+ *
+ * Matched on the code the middleware sends, never on the message: the message is
+ * localised and free to be reworded, and a 403 that merely mentions terms is not
+ * the same thing as the gate refusing.
+ */
+export function isTermsNotAcceptedError(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { code?: unknown }).code === 'terms_not_accepted'
+  );
+}


### PR DESCRIPTION
Closes #250. Reasoning and alternatives: [ADR-0056](docs/adr/0056-account-state-on-its-own-realtime-channel.md).

## What was wrong

`terms_current_accepted` comes from the user profile, which the app caches and nothing refreshed. When an admin activated new terms the app kept believing the old answer: the prompt to accept never appeared, and every write came back 403 with nothing to explain it. Restarting the app or signing out again was the only cure.

## Four layers, cheapest first

The issue asks for a realtime update with pull-to-refresh as the fallback. Both are here, plus a third path that removes the symptom entirely.

1. **The refusal explains itself.** A 403 carrying `code: terms_not_accepted` invalidates the cached profile, so the very request that was refused produces the prompt explaining why. Deterministic, no socket involved. Matched on the code, never the message — the message is localised, and a 403 that merely mentions terms is not the gate refusing.
2. **The existing fallback now covers it.** `refetchFallback` in the realtime hook already ran on socket drop and on returning to the foreground; it invalidates `Auth` alongside `Compartment`. That covers the "restarting helps" complaint using machinery that was already there.
3. **Pull-to-refresh refetches the profile**, not just compartments — the gesture people reach for when something looks wrong.
4. **Reverb makes it live.** `TermsAcceptanceRequired` on a new per-user channel; the app invalidates `Auth` on receipt.

Layers 1–3 are what make a missed broadcast a delay rather than a defect.

## Contract added

| | |
|---|---|
| Channel | `users.{id}.account`, private, authorised like the compartment channel |
| Event | `.terms.acceptance-required` (leading dot: no Echo namespacing) |
| Payload | `{ version: number }` — a signal, not content |

Three decisions worth knowing, all argued in the ADR:

- **Activation, not publication.** Acceptance is compared against the *active* version, so that is the moment a cached profile becomes wrong. One service call records both today, but an activate-an-existing-version path would otherwise broadcast nothing.
- **Its own channel**, not the compartment one. Overloading `compartment-status` would have been two lines with no new plumbing — and would make the channel name stop describing its contents.
- **One Echo instance** for both channels. A hook per channel means a websocket per channel, for an event that fires perhaps twice a year.

## Verified

- Backend: 404 tests, PHPStan clean, Pint clean. Two new tests cover the dispatch and the channel/payload shape.
- Mobile: 26 tests (was 19), 18/18 checks. `termsGate.test.ts` covers the 403 predicate against the real body, a different 403 code, a message-only impostor and non-object bodies; `accountChannel.test.ts` pins the channel and event names against the backend's route and `broadcastAs()` — they are string literals on two sides of a network boundary and drift fails silently.
- **End to end against the running stack**: published a version in the admin panel and watched the prompt appear in the app without touching it.

One thing that cost time and is worth repeating: the first attempt showed nothing because the **event-worker had the old reactor in memory**. Queued reactors need a worker restart on deploy, same as the credential-issuance change in #227.
