### PR TITLE
fix(deploy): flatten Coolify compose so it does not use extends

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -172,9 +172,10 @@ Use Coolify v4's documented Git-based Docker Compose application instead:
 2. In **Project → Environment → Add Resource**, select the repository and choose
    the **Docker Compose** build pack. In the resource's **General** settings set
    **Docker Compose Location** to
-   `/locker-backend/docker-compose.prod.coolify.yml`. This single entry file
-   uses Compose `extends` to load every service from `docker-compose.prod.yml`;
-   no UI override is required.
+   `/locker-backend/docker-compose.prod.coolify.yml`. This file is a
+   self-contained copy of the production stack plus Coolify MQTT labels;
+   Coolify does not resolve Compose `extends` or `include`. No UI override
+   is required.
 3. Add the values from `.env.prod.example` under the resource's
    **Environment Variables**. Use real secrets and domains, pin
    `BACKEND_IMAGE_TAG`, and set a deployment-unique

--- a/locker-backend/docker-compose.prod.coolify.yml
+++ b/locker-backend/docker-compose.prod.coolify.yml
@@ -1,43 +1,209 @@
+# Self-contained Coolify adapter. Coolify parses one Compose file and does not
+# resolve `extends` or `include`, so this file inlines the production stack
+# instead of inheriting docker-compose.prod.yml. Keep service definitions
+# aligned with that base file; only MQTT networking/labels differ.
+x-laravel-env-prod: &laravel_env_prod
+  PUID: "1000"
+  PGID: "1000"
+  WWWUSER: "1000"
+  APP_ENV: production
+  QUEUE_CONNECTION: redis
+  BROADCAST_CONNECTION: reverb
+  DB_HOST: db
+  REDIS_HOST: redis
+  MQTT_BROKER_HOST: mqtt
+  REVERB_APP_ID: "${REVERB_APP_ID}"
+  REVERB_APP_KEY: "${REVERB_APP_KEY}"
+  REVERB_APP_SECRET: "${REVERB_APP_SECRET}"
+  # Internal Reverb endpoint for Laravel app/worker containers.
+  REVERB_HOST: reverb
+  REVERB_PORT: 8080
+  REVERB_SCHEME: http
+  REVERB_SERVER_HOST: 0.0.0.0
+  REVERB_SERVER_PORT: 8080
+  # Browser-facing Echo settings.
+  VITE_REVERB_APP_KEY: "${REVERB_APP_KEY}"
+  VITE_REVERB_HOST: "${VITE_REVERB_HOST}"
+  VITE_REVERB_PORT: "${VITE_REVERB_PORT}"
+  VITE_REVERB_SCHEME: https
+  # Keep Laravel app version aligned with the deployed image tag
+  APP_VERSION: "${BACKEND_IMAGE_TAG:-latest}"
+
+x-laravel-service-prod: &laravel_service_prod
+  image: ghcr.io/open-locker/locker-backend:${BACKEND_IMAGE_TAG:-latest}
+  # Compose's project .env is only used for interpolation. Laravel processes
+  # need the same file explicitly loaded into every app/worker container.
+  env_file:
+    - path: ./.env
+      required: true
+  volumes:
+    # Mount storage for persistent file uploads
+    - "locker-storage:/var/www/html/storage/app/public"
+    # Persist logs if needed
+    # - "locker-logs:/var/www/html/storage/logs"
+
+x-app-depends-on-prod: &app_depends_on_prod
+  db:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+
+x-worker-depends-on-prod: &worker_depends_on_prod
+  app:
+    condition: service_healthy
+  db:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+  mqtt:
+    condition: service_started
+
 services:
   app:
-    extends:
-      file: docker-compose.prod.yml
-      service: app
+    <<: *laravel_service_prod
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    # ports:
+    # Expose the app port via reverse proxy
+    # - "${APP_PORT:-80}:8080"
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "true"
+      AUTORUN_LARAVEL_MIGRATION_ISOLATION: "true"
+      LARAVEL_SAIL: 0
+      APP_DEBUG: false
+      # Ensure unique MQTT client ids per container to avoid session kicks
+      MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_app"
+      PHP_OPCACHE_ENABLE: 1
+    depends_on:
+      <<: *app_depends_on_prod
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/up"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   queue-worker:
-    extends:
-      file: docker-compose.prod.yml
-      service: queue-worker
+    <<: *laravel_service_prod
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "false"
+      MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_queue_worker"
+    command: "php artisan queue:work --queue=default --tries=3 --timeout=90"
+    depends_on:
+      <<: *worker_depends_on_prod
+    healthcheck:
+      test: ["CMD", "healthcheck-queue"]
+      start_period: 10s
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   event-worker:
-    extends:
-      file: docker-compose.prod.yml
-      service: event-worker
+    <<: *laravel_service_prod
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "false"
+      MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_event_worker"
+    # Single worker on purpose. DoorDetectionReactor and CommandResponseReactor
+    # both guard against duplicate derived events with a read-then-write, which
+    # is not atomic — a second consumer would let a redelivered event be
+    # recorded twice, and duplicated events are permanent history. Do not scale
+    # this service without making those guards safe first.
+    command: "php artisan queue:work --queue=events --tries=3 --timeout=90"
+    depends_on:
+      <<: *worker_depends_on_prod
+    healthcheck:
+      test: ["CMD-SHELL", "php artisan queue:monitor events || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   mqtt-listener:
-    extends:
-      file: docker-compose.prod.yml
-      service: mqtt-listener
+    <<: *laravel_service_prod
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "false"
+      # mqtt-listener uses both listener + publisher connections
+      MQTT_LISTENER_CLIENT_ID: "laravel_backend_listener_mqtt_listener"
+      MQTT_PUBLISHER_CLIENT_ID: "laravel_backend_publisher_mqtt_listener"
+    command: "php artisan mqtt:listen"
+    depends_on:
+      <<: *worker_depends_on_prod
+    labels:
+      autoheal: "true"
+    healthcheck:
+      test: ["CMD", "php", "artisan", "mqtt:health"]
+      start_period: 15s
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
+  # Restarts any container marked unhealthy + labelled `autoheal: "true"`.
+  # Plain Compose does not act on healthcheck status on its own (ADR-0028).
   autoheal:
-    extends:
-      file: docker-compose.prod.yml
-      service: autoheal
+    image: willfarrell/autoheal:latest
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: "10"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   scheduler:
-    extends:
-      file: docker-compose.prod.yml
-      service: scheduler
+    <<: *laravel_service_prod
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "false"
+    command: "php artisan schedule:work"
+    depends_on:
+      <<: *worker_depends_on_prod
+    healthcheck:
+      test: ["CMD", "healthcheck-schedule"]
+      start_period: 10s
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   reverb:
-    extends:
-      file: docker-compose.prod.yml
-      service: reverb
+    <<: *laravel_service_prod
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    environment:
+      <<: *laravel_env_prod
+      AUTORUN_ENABLED: "false"
+    command: "php artisan reverb:start --host=0.0.0.0 --port=8080"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "healthcheck-reverb"]
+      start_period: 10s
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   mqtt:
-    extends:
-      file: docker-compose.prod.yml
-      service: mqtt
+    image: iegomez/mosquitto-go-auth:2.1.0-mosquitto_2.0.15
+    restart: unless-stopped
+    expose:
+      - "1883"
+    volumes:
+      - "./mosquitto/mosquitto.conf:/etc/mosquitto/mosquitto.conf:ro"
+      - "locker-mqtt-data:/mosquitto/data"
+    environment:
+      TZ: UTC
+    depends_on:
+      app:
+        condition: service_healthy
     networks:
       - default
       - coolify
@@ -52,14 +218,37 @@ services:
       - "traefik.tcp.services.${COOLIFY_MQTT_ROUTER_NAME:-open-locker-mqtt}.loadbalancer.server.port=1883"
 
   redis:
-    extends:
-      file: docker-compose.prod.yml
-      service: redis
+    image: "redis:alpine"
+    volumes:
+      - "locker-redis:/data"
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      retries: 3
+      timeout: 5s
 
   db:
-    extends:
-      file: docker-compose.prod.yml
-      service: db
+    image: "postgres:17"
+    environment:
+      PGPASSWORD: "${DB_PASSWORD}"
+      POSTGRES_DB: "${DB_DATABASE}"
+      POSTGRES_USER: "${DB_USERNAME}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD}"
+    volumes:
+      - "locker-pgsql:/var/lib/postgresql/data"
+    healthcheck:
+      test:
+        - CMD
+        - pg_isready
+        - "-q"
+        - "-d"
+        - "${DB_DATABASE}"
+        - "-U"
+        - "${DB_USERNAME}"
+      retries: 3
+      timeout: 5s
 
 networks:
   coolify:

--- a/locker-backend/tests/Unit/ProductionCoolifyComposeTest.php
+++ b/locker-backend/tests/Unit/ProductionCoolifyComposeTest.php
@@ -25,33 +25,45 @@ class ProductionCoolifyComposeTest extends TestCase
         $prod = $this->parseCompose('docker-compose.prod.yml');
         $coolify = $this->parseCompose('docker-compose.prod.coolify.yml');
 
-        $prodServices = array_keys($prod['services'] ?? []);
-        $coolifyServices = array_keys($coolify['services'] ?? []);
+        $prodServices = $prod['services'] ?? [];
+        $coolifyServices = $coolify['services'] ?? [];
+        $this->assertIsArray($prodServices);
+        $this->assertIsArray($coolifyServices);
+        $this->assertSame(array_keys($prodServices), array_keys($coolifyServices));
+        $this->assertSame($prod['volumes'] ?? null, $coolify['volumes'] ?? null);
 
-        $this->assertSame($prodServices, $coolifyServices);
-
-        foreach ($coolify['services'] as $name => $service) {
+        foreach ($coolifyServices as $name => $service) {
             $this->assertIsArray($service);
             $this->assertArrayNotHasKey('extends', $service, $name.' must not use Compose extends');
+            $this->assertArrayNotHasKey('include', $service, $name.' must not use Compose include');
         }
 
-        foreach (['app', 'queue-worker', 'event-worker', 'mqtt-listener', 'scheduler', 'reverb'] as $name) {
+        foreach ($prodServices as $name => $service) {
+            if ($name === 'mqtt') {
+                continue;
+            }
+
             $this->assertSame(
-                $prod['services'][$name]['image'] ?? null,
-                $coolify['services'][$name]['image'] ?? null,
-                $name.' image must match the production compose',
+                $service,
+                $coolifyServices[$name],
+                $name.' must match the production compose except for Coolify MQTT wiring',
             );
         }
 
-        $this->assertSame(
-            $prod['services']['mqtt']['image'] ?? null,
-            $coolify['services']['mqtt']['image'] ?? null,
-        );
+        $prodMqtt = $prodServices['mqtt'];
+        $coolifyMqtt = $coolifyServices['mqtt'];
+        $this->assertIsArray($prodMqtt);
+        $this->assertIsArray($coolifyMqtt);
 
-        $mqtt = $coolify['services']['mqtt'];
-        $this->assertContains('coolify', $mqtt['networks'] ?? []);
-        $this->assertContains('default', $mqtt['networks'] ?? []);
-        $this->assertContains('traefik.enable=true', $mqtt['labels'] ?? []);
+        $sharedMqtt = $prodMqtt;
+        unset($sharedMqtt['networks'], $sharedMqtt['labels']);
+        $coolifySharedMqtt = $coolifyMqtt;
+        unset($coolifySharedMqtt['networks'], $coolifySharedMqtt['labels']);
+        $this->assertSame($sharedMqtt, $coolifySharedMqtt);
+
+        $this->assertContains('coolify', $coolifyMqtt['networks'] ?? []);
+        $this->assertContains('default', $coolifyMqtt['networks'] ?? []);
+        $this->assertContains('traefik.enable=true', $coolifyMqtt['labels'] ?? []);
         $this->assertTrue($coolify['networks']['coolify']['external'] ?? false);
     }
 }

--- a/locker-backend/tests/Unit/ProductionCoolifyComposeTest.php
+++ b/locker-backend/tests/Unit/ProductionCoolifyComposeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ProductionCoolifyComposeTest extends TestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseCompose(string $filename): array
+    {
+        $parsed = Yaml::parseFile(dirname(__DIR__, 2).'/'.$filename);
+        $this->assertIsArray($parsed);
+
+        return $parsed;
+    }
+
+    public function test_coolify_compose_is_self_contained_and_aligned_with_prod(): void
+    {
+        $prod = $this->parseCompose('docker-compose.prod.yml');
+        $coolify = $this->parseCompose('docker-compose.prod.coolify.yml');
+
+        $prodServices = array_keys($prod['services'] ?? []);
+        $coolifyServices = array_keys($coolify['services'] ?? []);
+
+        $this->assertSame($prodServices, $coolifyServices);
+
+        foreach ($coolify['services'] as $name => $service) {
+            $this->assertIsArray($service);
+            $this->assertArrayNotHasKey('extends', $service, $name.' must not use Compose extends');
+        }
+
+        foreach (['app', 'queue-worker', 'event-worker', 'mqtt-listener', 'scheduler', 'reverb'] as $name) {
+            $this->assertSame(
+                $prod['services'][$name]['image'] ?? null,
+                $coolify['services'][$name]['image'] ?? null,
+                $name.' image must match the production compose',
+            );
+        }
+
+        $this->assertSame(
+            $prod['services']['mqtt']['image'] ?? null,
+            $coolify['services']['mqtt']['image'] ?? null,
+        );
+
+        $mqtt = $coolify['services']['mqtt'];
+        $this->assertContains('coolify', $mqtt['networks'] ?? []);
+        $this->assertContains('default', $mqtt['networks'] ?? []);
+        $this->assertContains('traefik.enable=true', $mqtt['labels'] ?? []);
+        $this->assertTrue($coolify['networks']['coolify']['external'] ?? false);
+    }
+}

--- a/website/src/content/docs/de/dokumentation/operations.md
+++ b/website/src/content/docs/de/dokumentation/operations.md
@@ -26,10 +26,11 @@ Produktion nicht veröffentlicht.
 
 Für Coolify v4 das Git-basierte **Docker Compose** Build Pack verwenden und
 **Docker Compose Location** auf
-`/locker-backend/docker-compose.prod.coolify.yml` setzen. Die Entry-Datei lädt
-den Basis-Stack per Compose `extends`; Coolifys ähnlich benanntes Custom
-Compose Override konfiguriert die Coolify-Infrastruktur und ist kein
-Anwendungs-Overlay. Der verwaltete Traefik-Proxy muss einen TCP-Entrypoint
+`/locker-backend/docker-compose.prod.coolify.yml` setzen. Die Datei enthält
+den Produktions-Stack inline, weil Coolify Compose `extends` und `include`
+nicht auflöst. Coolifys ähnlich benanntes Custom Compose Override
+konfiguriert die Coolify-Infrastruktur und ist kein Anwendungs-Overlay.
+Der verwaltete Traefik-Proxy muss einen TCP-Entrypoint
 `mqtts` auf Port 8883 veröffentlichen; der Adapter routet
 `HostSNI(MQTT_DOMAIN)` darüber zu Mosquitto-Port 1883. Eine normale
 HTTPS-Domain-Route oder direkte Portfreigabe sichert MQTT nicht ab.

--- a/website/src/content/docs/dokumentation/operations.md
+++ b/website/src/content/docs/dokumentation/operations.md
@@ -24,9 +24,10 @@ plaintext only inside the Docker network and is not published in production.
 
 For Coolify v4, use the Git-based **Docker Compose** build pack and set
 **Docker Compose Location** to
-`/locker-backend/docker-compose.prod.coolify.yml`. The entry file loads the base
-stack with Compose `extends`; Coolify's similarly named custom Compose override
-configures Coolify's own infrastructure and is not an application overlay. The
+`/locker-backend/docker-compose.prod.coolify.yml`. That file inlines the
+production stack because Coolify does not resolve Compose `extends` or
+`include`. Coolify's similarly named custom Compose override configures
+Coolify's own infrastructure and is not an application overlay. The
 managed Traefik proxy must publish a TCP `mqtts` entrypoint on 8883; the adapter
 routes `HostSNI(MQTT_DOMAIN)` through that entrypoint to Mosquitto port 1883. A
 normal HTTPS domain route or direct port mapping does not secure MQTT. Follow


### PR DESCRIPTION
## Summary
- Inline the production backend stack in `docker-compose.prod.coolify.yml` so Coolify no longer depends on Compose `extends`/`include`, which its single-file parser does not resolve.
- Keep the Coolify-only MQTT bits: attach Mosquitto to the external `coolify` network and set Traefik TCP labels for MQTTS on 8883 (internal broker remains 1883).
- Add a unit test that the Coolify file stays aligned with `docker-compose.prod.yml`, and update the Coolify install/ops docs.

## Test plan
- [x] `docker compose -f locker-backend/docker-compose.prod.coolify.yml config` renders without `extends`
- [x] `vendor/bin/phpunit tests/Unit/ProductionCoolifyComposeTest.php`
- [ ] Create a Coolify Docker Compose resource pointed at `/locker-backend/docker-compose.prod.coolify.yml` and confirm all services appear in the deployable compose
- [ ] Confirm Coolify still injects HTTP labels for the app domain and does not need to invent the MQTT TCP router

Refs #233


Made with [Cursor](https://cursor.com)