### PR TITLE
fix(simulator): surface MQTT startup failures

### DIFF
--- a/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
+++ b/locker-client/src/adapters/mqtt/mqtt-transport.adapter.ts
@@ -127,66 +127,89 @@ export class MqttTransportAdapter implements MessageTransportPort {
     this.reconnectExhausted = false;
     this.connectionState = 'connecting';
 
+    const clientOptions = withVerifiedMqttTls(brokerUrl, {
+      keepalive: this.transport.keepalive,
+      clean: this.transport.clean,
+      reconnectPeriod: this.transport.reconnectPeriod,
+      connectTimeout: this.transport.connectTimeout,
+      ...options,
+    });
+
+    const client = mqtt.connect(brokerUrl, clientOptions);
+    this.client = client;
+    if (this.messageHandler) {
+      client.on('message', this.messageHandler);
+    }
+
+    this.registerConnectionLifecycle(client);
+    return this.waitForInitialConnection(client, brokerUrl);
+  }
+
+  private waitForInitialConnection(client: MqttClient, brokerUrl: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const clientOptions = withVerifiedMqttTls(brokerUrl, {
-        keepalive: this.transport.keepalive,
-        clean: this.transport.clean,
-        reconnectPeriod: this.transport.reconnectPeriod,
-        connectTimeout: this.transport.connectTimeout,
-        ...options,
-      });
+      let settled = false;
+      let connectTimeout: NodeJS.Timeout;
+      const settle = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
 
-      this.client = mqtt.connect(brokerUrl, clientOptions);
-      let initialConnectSettled = false;
+        settled = true;
+        clearTimeout(connectTimeout);
+        if (error) {
+          this.connectionState = 'disconnected';
+          logger.error('MQTT connection failed during startup', {
+            brokerUrl,
+            error: error.message,
+          });
+          client.end(true);
+          reject(error);
+          return;
+        }
 
-      if (this.messageHandler) {
-        this.client.on('message', this.messageHandler);
-      }
-
-      this.client.on('connect', () => {
-        this.reconnectAttempts = 0;
         this.connectionState = 'connected';
-        initialConnectSettled = true;
         resolve();
         this.notifyConnected();
+      };
+
+      // mqtt can keep retrying without emitting an error, leaving startup
+      // pending forever. Reject explicitly so the composition root can panic.
+      connectTimeout = setTimeout(() => {
+        settle(new Error(`MQTT connection timed out after ${this.transport.connectTimeout}ms`));
+      }, this.transport.connectTimeout);
+
+      client.on('connect', () => {
+        this.reconnectAttempts = 0;
+        settle();
       });
 
-      this.client.on('error', (error) => {
-        if (!initialConnectSettled) {
-          this.connectionState = 'disconnected';
-          reject(error);
-        }
+      client.on('error', (error) => {
+        settle(error);
       });
+    });
+  }
 
-      this.client.on('reconnect', () => {
-        this.connectionState = 'reconnecting';
-        this.reconnectAttempts++;
-        const max = this.transport.maxReconnectAttempts;
-        if (max > 0 && this.reconnectAttempts >= max) {
-          this.reconnectExhausted = true;
-          this.client?.end(true);
-        }
-      });
+  private registerConnectionLifecycle(client: MqttClient): void {
+    client.on('reconnect', () => {
+      this.connectionState = 'reconnecting';
+      this.reconnectAttempts++;
+      const max = this.transport.maxReconnectAttempts;
+      if (max > 0 && this.reconnectAttempts >= max) {
+        this.reconnectExhausted = true;
+        client.end(true);
+      }
+    });
 
-      this.client.on('close', () => {
-        if (this.intentionalShutdown) {
-          this.connectionState = 'disconnected';
-          return;
-        }
-        if (this.reconnectExhausted) {
-          this.connectionState = 'disconnected';
-          return;
-        }
-        if (this.transport.reconnectPeriod === 0) {
-          this.connectionState = 'disconnected';
-          return;
-        }
-        this.connectionState = 'reconnecting';
-      });
+    client.on('close', () => {
+      if (this.intentionalShutdown || this.reconnectExhausted) {
+        this.connectionState = 'disconnected';
+        return;
+      }
+      this.connectionState = this.transport.reconnectPeriod === 0 ? 'disconnected' : 'reconnecting';
+    });
 
-      this.client.on('offline', () => {
-        this.connectionState = 'reconnecting';
-      });
+    client.on('offline', () => {
+      this.connectionState = 'reconnecting';
     });
   }
 


### PR DESCRIPTION
## Summary

Issue #255 asks the simulator to show setup failures instead of appearing to hang when provisioning or broker configuration is incomplete. Before this change, the first MQTT connection could remain pending indefinitely: the MQTT library might continue attempting to connect without emitting an error that settled the startup promise, so the interactive simulator never reached its fatal startup path.

The simulator now fails startup explicitly when the first MQTT connection reports an error or exceeds the configured connection timeout. It logs the broker URL and error, closes the failed client, and rejects startup so the composition root can stop the simulator with a visible failure.

## Implementation

The connection lifecycle is split into two phases.

During initial startup:

1. The adapter creates the MQTT client and attaches the message handler.
2. It starts a guarded wait for the first `connect` event and starts a timer using `transport.connectTimeout`.
3. A successful `connect` clears the timer, marks the state as `connected`, resolves the startup promise, and notifies connected handlers.
4. An MQTT `error` or an expired timer settles startup as failed once, marks the state `disconnected`, logs the broker URL and error message, force-closes the client, and rejects the promise.
5. The one-time settlement guard prevents a late `connect`, error, or timeout from resolving and rejecting the same startup operation more than once.

After the first connection succeeds, the existing ongoing lifecycle remains active:

- `reconnect` marks the state `reconnecting` and increments the reconnect attempt count. Reaching the configured maximum force-closes the client and marks reconnecting as exhausted.
- `offline` marks the state `reconnecting`.
- `close` marks the state `disconnected` for intentional shutdown, exhausted retries, or a zero reconnect period. Otherwise it leaves the state as `reconnecting` while the MQTT client retries according to its configured reconnect period.
- Connected message handling and connected callbacks remain attached to the client created during startup.

The implementation separates startup failure from later reconnect handling because they have different callers and outcomes. The composition root needs a rejected promise to stop a simulator that never became usable, while an already-running simulator must continue to use the MQTT client's reconnect lifecycle.

## Testing

- The repository's `Checks and tests` workflow passed, covering the locker-client typecheck, formatting check, lint, build, and test suite.
- The `Verify client image` workflow passed.
- The release-tag verification, release quality gate, tagged-image verification, image publication, and release creation jobs were skipped because this pull request does not meet their release conditions.

## Glossary

| Term | Meaning in this PR |
| --- | --- |
| MQTT | The messaging protocol used by the simulator and locker client to communicate with the broker. |
| Broker | The MQTT server identified by the configured broker URL. |
| Initial connection | The simulator's first attempt to establish an MQTT session during startup. |
| Reconnect | A later attempt to restore MQTT after a connection that had already succeeded is lost. |
| Connection timeout | The maximum time allowed for the initial MQTT connection before startup is failed explicitly. |
| Composition root | The application startup code that assembles the simulator and decides whether it can continue running. |

Refs #255
